### PR TITLE
chore(issue form): Change the incorrect area label from 'plugin' to 'backend'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,4 +22,4 @@ body:
       required: false
 labels:
   - bug
-  - area/plugin
+  - area/backend


### PR DESCRIPTION
Change the incorrect area label from 'plugin' to 'backend'