### PR TITLE
fix(java-sdk): fix followDependenciesExecution return type

### DIFF
--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/ExecutionsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/ExecutionsApi.java
@@ -27,12 +27,11 @@ import io.kestra.sdk.internal.BaseApi;
 import io.kestra.sdk.internal.Configuration;
 import io.kestra.sdk.internal.Pair;
 
-import io.kestra.sdk.model.BulkErrorResponse;
 import io.kestra.sdk.model.BulkResponse;
 import io.kestra.sdk.model.ConcurrencyLimit;
 import io.kestra.sdk.model.EventExecution;
-import io.kestra.sdk.model.EventExecutionStatusEvent;
 import io.kestra.sdk.model.Execution;
+import io.kestra.sdk.model.ExecutionStatusEvent;
 import io.kestra.sdk.model.ExecutionControllerExecutionResponse;
 import io.kestra.sdk.model.ExecutionControllerLastExecutionResponse;
 import io.kestra.sdk.model.ExecutionControllerSetLabelsByIdsRequest;
@@ -1021,7 +1020,7 @@ import java.util.StringJoiner;
 
 
 
-  public Flux<Execution> followDependenciesExecution(@javax.annotation.Nonnull String executionId, @javax.annotation.Nonnull String tenant, boolean destinationOnly, boolean expandAll) throws ApiException {
+  public Flux<ExecutionStatusEvent> followDependenciesExecution(@javax.annotation.Nonnull String executionId, @javax.annotation.Nonnull String tenant, boolean destinationOnly, boolean expandAll) throws ApiException {
     return Flux.create(sink -> {
       org.apache.hc.client5.http.impl.classic.CloseableHttpResponse response = null;
       BufferedReader reader = null;
@@ -1041,7 +1040,7 @@ import java.util.StringJoiner;
               dataBuffer.setLength(0);
 
               try {
-                Execution ev = apiClient.getObjectMapper().readValue(data, Execution.class);
+                ExecutionStatusEvent ev = apiClient.getObjectMapper().readValue(data, ExecutionStatusEvent.class);
                 sink.next(ev);
               } catch (Exception e) {
                 sink.error(new ApiException(e));
@@ -1061,7 +1060,7 @@ import java.util.StringJoiner;
         if (dataBuffer.length() > 0) {
           String data = dataBuffer.toString();
           try {
-            Execution ev = apiClient.getObjectMapper().readValue(data, Execution.class);
+            ExecutionStatusEvent ev = apiClient.getObjectMapper().readValue(data, ExecutionStatusEvent.class);
             sink.next(ev);
           } catch (Exception e) {
             sink.error(new ApiException(e));
@@ -1131,7 +1130,7 @@ import java.util.StringJoiner;
   }
 
 
-  public Flux<Execution> followExecution(@javax.annotation.Nonnull String executionId, @javax.annotation.Nonnull String tenant) throws ApiException {
+  public Flux<EventExecution> followExecution(@javax.annotation.Nonnull String executionId, @javax.annotation.Nonnull String tenant) throws ApiException {
     return Flux.create(sink -> {
       org.apache.hc.client5.http.impl.classic.CloseableHttpResponse response = null;
       BufferedReader reader = null;
@@ -1151,7 +1150,7 @@ import java.util.StringJoiner;
               dataBuffer.setLength(0);
 
               try {
-                Execution ev = apiClient.getObjectMapper().readValue(data, Execution.class);
+                EventExecution ev = apiClient.getObjectMapper().readValue(data, EventExecution.class);
                 sink.next(ev);
               } catch (Exception e) {
                 sink.error(new ApiException(e));
@@ -1171,7 +1170,7 @@ import java.util.StringJoiner;
         if (dataBuffer.length() > 0) {
           String data = dataBuffer.toString();
           try {
-            Execution ev = apiClient.getObjectMapper().readValue(data, Execution.class);
+            EventExecution ev = apiClient.getObjectMapper().readValue(data, EventExecution.class);
             sink.next(ev);
           } catch (Exception e) {
             sink.error(new ApiException(e));

--- a/java/template/libraries/apache-httpclient/api.mustache
+++ b/java/template/libraries/apache-httpclient/api.mustache
@@ -385,7 +385,7 @@ public class {{classname}} extends BaseApi {
               dataBuffer.setLength(0);
 
               try {
-                Execution ev = apiClient.getObjectMapper().readValue(data, Execution.class);
+                ExecutionStatusEvent ev = apiClient.getObjectMapper().readValue(data, ExecutionStatusEvent.class);
                 sink.next(ev);
               } catch (Exception e) {
                 sink.error(new ApiException(e));
@@ -405,7 +405,7 @@ public class {{classname}} extends BaseApi {
         if (dataBuffer.length() > 0) {
           String data = dataBuffer.toString();
           try {
-            Execution ev = apiClient.getObjectMapper().readValue(data, Execution.class);
+            ExecutionStatusEvent ev = apiClient.getObjectMapper().readValue(data, ExecutionStatusEvent.class);
             sink.next(ev);
           } catch (Exception e) {
             sink.error(new ApiException(e));


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---
The `/api/v1/{tenant}/executions/{executionId}/follow-dependencies` API routes returns a stream of [`ExecutionStatusEvent`](https://github.com/kestra-io/kestra/blob/a4ca3498f3a54d330cf05053b97d50154c7d7b8f/webserver/src/main/java/io/kestra/webserver/controllers/api/ExecutionController.java#L2428) yet the client code deserialize the event stream as a stream of `Execution` which ends up in a stream of empty objects when calling `KestraClient().builder().executions().followDependenciesExecution(executionId, MAIN_TENANT, false, true)` (because property names don't match)


### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---
Before:
```java
KestraClient().builder().executions().followDependenciesExecution(executionId, MAIN_TENANT, false, true).toStream().toList()
```
return a list of empty `Execution` objects (null properties every everywhere

After:
```java
KestraClient().builder().executions().followDependenciesExecution(executionId, MAIN_TENANT, false, true).toStream().toList()
```
**should** return a list of valid `ExecutionStatusEvent` (I wasn't able to test properly as I wasn't able to setup unit test properly)
