### PR TITLE
fix: use npm trusted publishing OIDC correctly in javascript-sdk.yml

### DIFF
--- a/.github/workflows/javascript-sdk.yml
+++ b/.github/workflows/javascript-sdk.yml
@@ -115,6 +115,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Get OIDC Token
+        env:
+          AUDIENCE: "npm:registry.npmjs.org"
+        run: |
+          TOKEN_JSON=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$AUDIENCE")
+          ID_TOKEN=$(echo "$TOKEN_JSON" | jq -r .value)
+          echo "$TOKEN_JSON"
+          echo "NODE_AUTH_TOKEN=$ID_TOKEN" >> "$GITHUB_ENV"
+          echo "$ID_TOKEN" | awk -F. '{print $2}' | base64 -d 2>/dev/null | jq -r
+
       - uses: actions/setup-node@v6
         with:
           node-version: "22.18"

--- a/.github/workflows/javascript-sdk.yml
+++ b/.github/workflows/javascript-sdk.yml
@@ -143,7 +143,7 @@ jobs:
 
             # list all versions and filter those that start with the current version prefix (e.g., 1.2.)
             # `|| true` so an empty grep does not abort the step under `bash -e`
-            VERSIONS=$(npm view @kestra-io/kestra-sdk versions --json | jq -r '.[]' | grep "^${VERSION_PREFIX}\." || true)
+            VERSIONS=$(npm view @kestra-io/kestra-sdk versions --json 2>/dev/null | jq -r '.[]' 2>/dev/null | grep "^${VERSION_PREFIX}\." || true)
 
             echo "Existing versions with prefix $VERSION_PREFIX: $VERSIONS"
 
@@ -214,4 +214,4 @@ jobs:
       - name: Publish to npm with latest tag
         if: steps.check.outputs.skip != 'true' && github.ref != 'refs/heads/main'
         working-directory: ./javascript/javascript-sdk
-        run: npm publish --access public --force
+        run: npm publish --access public

--- a/.github/workflows/javascript-sdk.yml
+++ b/.github/workflows/javascript-sdk.yml
@@ -9,8 +9,6 @@ on:
         type: string
         default: "develop"
     secrets:
-      NPM_TOKEN:
-        required: true
       GCP_SERVICE_ACCOUNT:
         required: true
       KESTRA_EE_UNIT_TEST_LICENSE_FILE:
@@ -28,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:
@@ -107,6 +104,9 @@ jobs:
     name: Publish to Npm
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      id-token: write
     if: |
       !cancelled() && (
         github.ref == 'refs/heads/main' ||
@@ -114,16 +114,6 @@ jobs:
       )
     steps:
       - uses: actions/checkout@v6
-
-      - name: Get OIDC Token
-        env:
-          AUDIENCE: "npm:registry.npmjs.org"
-        run: |
-          TOKEN_JSON=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$AUDIENCE")
-          ID_TOKEN=$(echo "$TOKEN_JSON" | jq -r .value)
-          echo "$TOKEN_JSON"
-          echo "NODE_AUTH_TOKEN=$ID_TOKEN" >> "$GITHUB_ENV"
-          echo "$ID_TOKEN" | awk -F. '{print $2}' | base64 -d 2>/dev/null | jq -r
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,9 @@ jobs:
   javascript:
     if: "needs.file-changes.outputs.javascript == 'true'"
     needs: [ file-changes, compute-version ]
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/javascript-sdk.yml
     with:
       kestra_version: ${{ needs.compute-version.outputs.kestra_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,6 @@ jobs:
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       KESTRA_EE_UNIT_TEST_LICENSE_FILE: ${{ secrets.KESTRA_EE_UNIT_TEST_LICENSE_FILE }}
       KESTRA_EE_UNIT_TEST_LICENSE_LEGACY_FILE: ${{ secrets.KESTRA_EE_UNIT_TEST_LICENSE_LEGACY_FILE }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   python:
     if: "needs.file-changes.outputs.python == 'true'"


### PR DESCRIPTION
Two bugs prevented trusted publishing from working when called via workflow_call from main.yml:

1. The manual "Get OIDC Token" step set NODE_AUTH_TOKEN to a raw OIDC JWT, which npm treated as a classic bearer token instead of triggering its internal OIDC exchange. Removed the step entirely so npm performs the exchange itself at publish time.

2. `id-token: write` was declared at the top-level workflow scope. When triggered via workflow_call, top-level permissions in the called workflow are not reliably inherited by child jobs. Moved the permission to the publish job directly.

Also removed the now-unused NPM_TOKEN secret from both workflows.
