### PR TITLE
ci: add JavaScript SDK coverage reporting to PRs

### DIFF
--- a/.github/scripts/coverage-comment.mjs
+++ b/.github/scripts/coverage-comment.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Reads a vitest/istanbul coverage-final.json and posts (or updates) a sticky
+ * comment on the pull request listing every uncovered function in openapi/sdk/.
+ *
+ * Usage: node coverage-comment.mjs <path-to-coverage-final.json>
+ *
+ * Required env vars:
+ *   GITHUB_REPOSITORY  – e.g. "owner/repo"
+ *   PR_NUMBER          – pull-request number
+ *   GH_TOKEN           – GitHub token with pull-requests:write
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { execSync } from "child_process";
+
+const MARKER = "<!-- js-sdk-coverage-comment -->";
+
+const coveragePath = process.argv[2] ?? "javascript/coverage/coverage-final.json";
+
+if (!existsSync(coveragePath)) {
+    console.log(`Coverage file not found at ${coveragePath} — skipping comment.`);
+    process.exit(0);
+}
+
+const { GITHUB_REPOSITORY: repo, PR_NUMBER: prNumber } = process.env;
+if (!repo || !prNumber) {
+    console.log("GITHUB_REPOSITORY or PR_NUMBER not set — skipping comment.");
+    process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Parse coverage data
+// ---------------------------------------------------------------------------
+
+const coverage = JSON.parse(readFileSync(coveragePath, "utf8"));
+
+let totalFunctions = 0;
+let coveredFunctions = 0;
+
+/** @type {{ file: string; uncovered: string[] }[]} */
+const uncoveredByFile = [];
+
+for (const [filePath, data] of Object.entries(coverage)) {
+    if (!filePath.includes("openapi/sdk")) continue;
+
+    const uncovered = [];
+
+    for (const [key, count] of Object.entries(data.f)) {
+        totalFunctions++;
+        if (count === 0) {
+            const fn = data.fnMap[key];
+            const name =
+                fn?.name && fn.name !== "(anonymous)"
+                    ? fn.name
+                    : `<anonymous:${fn?.loc?.start?.line ?? "?"}>`;
+            uncovered.push(name);
+        } else {
+            coveredFunctions++;
+        }
+    }
+
+    if (uncovered.length > 0) {
+        // Strip everything up to and including "openapi/sdk/" for a tidy display name.
+        const match = filePath.match(/openapi\/sdk\/(.+)/);
+        const file = match ? match[1] : filePath.split("/").pop();
+        uncoveredByFile.push({ file, uncovered });
+    }
+}
+
+uncoveredByFile.sort((a, b) => a.file.localeCompare(b.file));
+
+const pct =
+    totalFunctions > 0
+        ? ((coveredFunctions / totalFunctions) * 100).toFixed(1)
+        : "100.0";
+
+// ---------------------------------------------------------------------------
+// Build comment body
+// ---------------------------------------------------------------------------
+
+let body;
+
+if (uncoveredByFile.length === 0) {
+    body = `${MARKER}
+### ✅ JavaScript SDK — Function Coverage
+
+All **${totalFunctions}** functions in \`openapi/sdk/\` are covered (**${pct}%**). Nothing to do here!`;
+} else {
+    const rows = uncoveredByFile
+        .map(({ file, uncovered }) => {
+            const fns = uncovered.map((f) => `\`${f}\``).join(", ");
+            return `| \`${file}\` | ${uncovered.length} | ${fns} |`;
+        })
+        .join("\n");
+
+    body = `${MARKER}
+### ⚠️ JavaScript SDK — Uncovered Functions
+
+**${pct}%** of functions covered (${coveredFunctions} / ${totalFunctions}).
+${uncoveredByFile.length} file(s) contain functions with **no test coverage** in \`openapi/sdk/\`:
+
+<details>
+<summary>Show uncovered functions</summary>
+
+| File | # uncovered | Functions |
+|------|:-----------:|-----------|
+${rows}
+
+</details>
+
+> Run \`npm run test --workspace test_javascript_sdk -- --coverage\` locally to reproduce.`;
+}
+
+// ---------------------------------------------------------------------------
+// Post or update sticky PR comment
+// ---------------------------------------------------------------------------
+
+writeFileSync("/tmp/coverage-body.json", JSON.stringify({ body }));
+
+let existingCommentId = null;
+try {
+    const raw = execSync(
+        `gh api "repos/${repo}/issues/${prNumber}/comments?per_page=100"`,
+        { encoding: "utf8" }
+    );
+    const comments = JSON.parse(raw);
+    const existing = comments.find((c) => c.body?.includes(MARKER));
+    if (existing) existingCommentId = existing.id;
+} catch (err) {
+    console.warn("Could not fetch existing comments:", err.message);
+}
+
+try {
+    if (existingCommentId) {
+        execSync(
+            `gh api "repos/${repo}/issues/comments/${existingCommentId}" -X PATCH --input /tmp/coverage-body.json`,
+            { stdio: "inherit" }
+        );
+        console.log(`Updated coverage comment (id ${existingCommentId}).`);
+    } else {
+        execSync(
+            `gh api "repos/${repo}/issues/${prNumber}/comments" --input /tmp/coverage-body.json`,
+            { stdio: "inherit" }
+        );
+        console.log("Posted new coverage comment.");
+    }
+} catch (err) {
+    console.error("Failed to post coverage comment:", err.message);
+    process.exit(1);
+}

--- a/.github/workflows/javascript-sdk.yml
+++ b/.github/workflows/javascript-sdk.yml
@@ -35,6 +35,9 @@ jobs:
   test:
     name: Test Javascript SDK
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     defaults:
       run:
         working-directory: ./javascript
@@ -107,6 +110,14 @@ jobs:
         with:
           name: coverage-report
           path: ./javascript/coverage
+
+      - name: Comment coverage on PR
+        if: always() && github.event_name == 'pull_request' && inputs.skip-test != 'true'
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node .github/scripts/coverage-comment.mjs javascript/coverage/coverage-final.json
 
   publish-release:
     name: Publish Release to Npm

--- a/javascript/test_javascript_sdk/vitest.config.ts
+++ b/javascript/test_javascript_sdk/vitest.config.ts
@@ -34,7 +34,8 @@ export default defineConfig({
             all: true,
             reporter: ["text", "json"],
             thresholds: {
-                functions: 75,
+                perFile: true,
+                functions: 80,
             },
         },
     },

--- a/javascript/test_javascript_sdk/vitest.config.ts
+++ b/javascript/test_javascript_sdk/vitest.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
             // picomatch matches these against absolute file paths using
             // contains:true, and tinyglobby globs from root for all:true.
             include: ["javascript-sdk/src/openapi/sdk/**"],
+            // Include all SDK files even if never imported, so fully-untested
+            // files show up as 0% rather than being invisible.
+            all: true,
+            reporter: ["text", "json"],
             thresholds: {
                 functions: 75,
             },


### PR DESCRIPTION
### What changes are being made and why?

This PR adds automated coverage reporting for the JavaScript SDK to pull requests. The changes include:

1. **New coverage comment script** (`.github/scripts/coverage-comment.mjs`): A Node.js script that parses vitest/istanbul coverage data and posts a sticky comment on PRs showing:
   - Overall function coverage percentage for `openapi/sdk/`
   - A detailed breakdown of uncovered functions by file (when coverage is incomplete)
   - The comment is automatically updated on subsequent test runs

2. **Updated GitHub Actions workflow** (`.github/workflows/javascript-sdk.yml`):
   - Added `pull-requests: write` permission to enable posting comments
   - Added a new step to run the coverage comment script after tests complete
   - Only runs on pull requests (not on other event types)

3. **Enhanced coverage configuration** (`javascript/test_javascript_sdk/vitest.config.ts`):
   - Enabled `all: true` to include all SDK files in coverage reports, even if never imported (so untested files show 0% rather than being invisible)
   - Added JSON reporter for machine-readable coverage data
   - Changed threshold to `perFile: true` for per-file enforcement
   - Increased function coverage threshold from 75% to 80%

This provides developers with immediate, visible feedback on test coverage gaps directly in their PRs, making it easier to identify which functions need test coverage before merging.

---

### How the changes have been QAed?

The workflow step is conditional (`if: always() && github.event_name == 'pull_request'`) and gracefully handles missing coverage files or environment variables by exiting cleanly without failing the build. The script has been designed to work with the existing vitest coverage output format.

https://claude.ai/code/session_01UL7b7kt176tM4xn3zZJNmi