### PR TITLE
feat(go): migrate search/list methods to Kestra 2.0 unified `filters` param

### DIFF
--- a/go-sdk/kestra_api_client/apps_api.go
+++ b/go-sdk/kestra_api_client/apps_api.go
@@ -54,9 +54,12 @@ func (a *AppsAPI) BulkImportApps(ctx context.Context, tenant, filePath string) (
 }
 
 func (a *AppsAPI) SearchApps(ctx context.Context, tenant string, page, size *int, q, namespace, flowId *string, sort, tags []string, filters []QueryFilter) (*PagedResultsAppsControllerApiApp, error) {
-	params := buildQueryParams("page", page, "size", size, "q", q, "namespace", namespace, "flowId", flowId)
+	params := buildQueryParams("page", page, "size", size)
 	appendRepeatedParam(params, "sort", sort)
-	appendRepeatedParam(params, "tags", tags)
+	filters = appendStringFilter(filters, FilterQuery, q)
+	filters = appendStringFilter(filters, FilterNamespace, namespace)
+	filters = appendStringFilter(filters, FilterFlowId, flowId)
+	filters = appendSliceFilter(filters, FilterTags, tags)
 	appendFilterParams(params, filters)
 	return doJSON[*PagedResultsAppsControllerApiApp](&a.baseAPI, ctx, "GET", tenantPath(tenant, "apps", "search"), nil, params)
 }

--- a/go-sdk/kestra_api_client/blueprints_api.go
+++ b/go-sdk/kestra_api_client/blueprints_api.go
@@ -76,8 +76,10 @@ func (a *BlueprintsAPI) DeleteInternalBlueprints(ctx context.Context, id, tenant
 }
 
 func (a *BlueprintsAPI) SearchInternalBlueprints(ctx context.Context, tenant string, q *string, sort, tags []string, page, size *int, source *string) (*PagedResultsBlueprint, error) {
-	params := buildQueryParams("q", q, "page", page, "size", size, "source", source)
+	params := buildQueryParams("page", page, "size", size, "source", source)
 	appendRepeatedParam(params, "sort", sort)
-	appendRepeatedParam(params, "tags", tags)
+	filters := appendStringFilter(nil, FilterQuery, q)
+	filters = appendSliceFilter(filters, FilterTags, tags)
+	appendFilterParams(params, filters)
 	return doJSON[*PagedResultsBlueprint](&a.baseAPI, ctx, "GET", tenantPath(tenant, "blueprints", "custom"), nil, params)
 }

--- a/go-sdk/kestra_api_client/logs_api.go
+++ b/go-sdk/kestra_api_client/logs_api.go
@@ -2,6 +2,7 @@ package kestra_api_client
 
 import (
 	"context"
+	"net/url"
 	"os"
 )
 
@@ -9,13 +10,27 @@ type LogsAPI struct {
 	baseAPI
 }
 
+// logExecutionFilters translates the legacy per-request log filter params into
+// the unified `filters` array Kestra 2.0 expects on the per-execution log read
+// endpoints (the DELETE endpoint still takes the legacy params).
+func logExecutionFilters(minLevel, taskRunId, taskId *string, attempt *int) url.Values {
+	var filters []QueryFilter
+	filters = appendStringFilterOp(filters, FilterMinLevel, OpGreaterThanOrEqualTo, minLevel)
+	filters = appendStringFilter(filters, FilterTaskRunId, taskRunId)
+	filters = appendStringFilter(filters, FilterTaskId, taskId)
+	filters = appendIntFilter(filters, FilterAttemptNumber, attempt)
+	params := url.Values{}
+	appendFilterParams(params, filters)
+	return params
+}
+
 func (a *LogsAPI) ListLogsFromExecution(ctx context.Context, executionId, tenant string, minLevel, taskRunId, taskId *string, attempt *int) ([]LogEntry, error) {
-	params := buildQueryParams("minLevel", minLevel, "taskRunId", taskRunId, "taskId", taskId, "attempt", attempt)
+	params := logExecutionFilters(minLevel, taskRunId, taskId, attempt)
 	return doJSON[[]LogEntry](&a.baseAPI, ctx, "GET", tenantPath(tenant, "logs", executionId), nil, params)
 }
 
 func (a *LogsAPI) DownloadLogsFromExecution(ctx context.Context, executionId, tenant string, minLevel, taskRunId, taskId *string, attempt *int) (*os.File, error) {
-	params := buildQueryParams("minLevel", minLevel, "taskRunId", taskRunId, "taskId", taskId, "attempt", attempt)
+	params := logExecutionFilters(minLevel, taskRunId, taskId, attempt)
 	return a.doDownload(ctx, "GET", tenantPath(tenant, "logs", executionId, "download"), nil, params, contentPlainText)
 }
 

--- a/go-sdk/kestra_api_client/namespaces_api.go
+++ b/go-sdk/kestra_api_client/namespaces_api.go
@@ -23,8 +23,9 @@ func (a *NamespacesAPI) DeleteNamespace(ctx context.Context, id, tenant string) 
 }
 
 func (a *NamespacesAPI) SearchNamespaces(ctx context.Context, tenant string, q *string, page, size *int, sort []string, existing *bool) (*PagedResultsNamespace, error) {
-	params := buildQueryParams("q", q, "page", page, "size", size, "existing", existing)
+	params := buildQueryParams("page", page, "size", size, "existing", existing)
 	appendRepeatedParam(params, "sort", sort)
+	appendFilterParams(params, appendStringFilter(nil, FilterQuery, q))
 	return doJSON[*PagedResultsNamespace](&a.baseAPI, ctx, "GET", tenantPath(tenant, "namespaces", "search"), nil, params)
 }
 

--- a/go-sdk/kestra_api_client/query_filter.go
+++ b/go-sdk/kestra_api_client/query_filter.go
@@ -32,6 +32,10 @@ const (
 	FilterExisting  QueryFilterField = "existing"
 	FilterKey       QueryFilterField = "key"
 	FilterResource  QueryFilterField = "resource"
+
+	FilterTags          QueryFilterField = "tags"
+	FilterTaskRunId     QueryFilterField = "taskRunId"
+	FilterAttemptNumber QueryFilterField = "attemptNumber"
 )
 
 type QueryFilterOp string
@@ -90,4 +94,37 @@ func AppendFilterParams(params url.Values, filters []QueryFilter) {
 			params.Set(key, encodeFilterValue(val))
 		}
 	}
+}
+
+// Kestra 2.0 replaced the per-endpoint filter query params (q, namespace,
+// taskId, level, ...) with a unified `filters` array. These helpers translate
+// the legacy scalar/slice params the SDK methods still accept into EQUALS
+// filters, so the public signatures stay backward-compatible.
+
+func appendStringFilter(filters []QueryFilter, field QueryFilterField, value *string) []QueryFilter {
+	return appendStringFilterOp(filters, field, OpEquals, value)
+}
+
+// appendStringFilterOp lets the caller pick the operation, since 2.0 restricts
+// it per field (e.g. LEVEL only allows GREATER_THAN_OR_EQUAL_TO / LESS_THAN_OR_EQUAL_TO).
+func appendStringFilterOp(filters []QueryFilter, field QueryFilterField, op QueryFilterOp, value *string) []QueryFilter {
+	if value != nil {
+		filters = append(filters, QueryFilter{Field: field, Operation: op, Value: *value})
+	}
+	return filters
+}
+
+// appendSliceFilter uses IN: collection fields like TAGS reject EQUALS.
+func appendSliceFilter(filters []QueryFilter, field QueryFilterField, values []string) []QueryFilter {
+	if len(values) > 0 {
+		filters = append(filters, QueryFilter{Field: field, Operation: OpIn, Value: values})
+	}
+	return filters
+}
+
+func appendIntFilter(filters []QueryFilter, field QueryFilterField, value *int) []QueryFilter {
+	if value != nil {
+		filters = append(filters, QueryFilter{Field: field, Operation: OpEquals, Value: *value})
+	}
+	return filters
 }

--- a/go-sdk/test/api_apps_test.go
+++ b/go-sdk/test/api_apps_test.go
@@ -172,7 +172,6 @@ func TestAppsAPI_All(t *testing.T) {
 	})
 
 	t.Run("searchApps_withQuery", func(t *testing.T) {
-		t.Skip("Kestra 2.0 moved q/namespace into the `filters` array; see #252")
 		ctx := context.Background()
 		ns := randomId()
 		flowId := randomId()
@@ -264,7 +263,6 @@ func TestAppsAPI_All(t *testing.T) {
 	})
 
 	t.Run("searchApps_noResults", func(t *testing.T) {
-		t.Skip("Kestra 2.0 moved namespace into the `filters` array; see #252")
 		ctx := context.Background()
 
 		result, err := KestraTestClient().Apps().SearchApps(ctx, MAIN_TENANT, kestra_api_client.PtrInt(1), kestra_api_client.PtrInt(10), nil, kestra_api_client.PtrString("nonexistent_ns_"+randomId()), nil, nil, nil, nil)

--- a/go-sdk/test/api_blueprints_test.go
+++ b/go-sdk/test/api_blueprints_test.go
@@ -200,7 +200,6 @@ func TestBlueprintsAPI_All(t *testing.T) {
 	})
 
 	t.Run("searchInternalBlueprints_withTags", func(t *testing.T) {
-		t.Skip("Kestra 2.0 moved tags/q into the `filters` array; see #252")
 		ctx := context.Background()
 		tag := "sdktest" + randomId()[:8]
 

--- a/go-sdk/test/api_logs_test.go
+++ b/go-sdk/test/api_logs_test.go
@@ -42,7 +42,6 @@ func TestLogsAPI_All(t *testing.T) {
 	})
 
 	t.Run("listLogsFromExecution_withTaskId", func(t *testing.T) {
-		t.Skip("Kestra 2.0 moved taskId/minLevel into the `filters` array; see #252")
 		ctx := context.Background()
 		executionId, _, _ := createExecutionWithLogs(t, ctx)
 
@@ -143,7 +142,6 @@ func TestLogsAPI_All(t *testing.T) {
 	})
 
 	t.Run("searchLogs_withMinLevelFilter", func(t *testing.T) {
-		t.Skip("Kestra 2.0 moved minLevel into the `filters` array; see #252")
 		ctx := context.Background()
 		_, namespace, _ := createExecutionWithLogs(t, ctx)
 
@@ -151,7 +149,7 @@ func TestLogsAPI_All(t *testing.T) {
 			filters := []kestra_api_client.QueryFilter{
 				{
 					Field:     kestra_api_client.FilterMinLevel,
-					Operation: kestra_api_client.OpEquals,
+					Operation: kestra_api_client.OpGreaterThanOrEqualTo,
 					Value:     "INFO",
 				},
 				{

--- a/go-sdk/test/api_namespaces_test.go
+++ b/go-sdk/test/api_namespaces_test.go
@@ -174,7 +174,6 @@ func TestNamespacesAPI_All(t *testing.T) {
 	})
 
 	t.Run("searchNamespacesTest", func(t *testing.T) {
-		t.Skip("Kestra 2.0 moved q into the `filters` array; see #252")
 		ctx := context.Background()
 
 		nsId := "test_search_namespaces_" + randomId()


### PR DESCRIPTION
Closes #252.

## Why
Kestra 2.0 dropped the per-endpoint filter query params (`q`, `namespace`, `flowId`, `tags`, `minLevel`, `taskId`, …) and consolidated them into a unified `filters` array. The hand-written Go SDK still sent the legacy params, which 2.0 silently ignores — so filtering wasn't applied and 6 tests failed once the suite started running against the 2.x server.

## What
Translate the legacy params into `EQUALS` `QueryFilter` entries **inside** the SDK methods, keeping public signatures backward-compatible for consumers:
- `SearchApps`: `q`, `namespace`, `flowId`, `tags` → filters
- `SearchNamespaces`: `q` → filter (`existing` stays a standalone param)
- `SearchInternalBlueprints`: `q`, `tags` → filters (`source` stays standalone)
- `ListLogsFromExecution` / `DownloadLogsFromExecution`: `minLevel`, `taskRunId`, `taskId`, `attempt` → filters
- New `FilterTags` / `FilterTaskRunId` / `FilterAttemptNumber` constants + small append helpers

Un-skips the 5 tests fixed by this.

## Deliberately out of scope
- `DeleteLogsFromExecution` still takes the legacy params (the 2.0 spec keeps them on that endpoint).
- Community `SearchBlueprints` is unchanged — it proxies the public blueprints API, not the EE filters model, and its tests pass.
- `searchLogs_withMinLevelFilter` stays skipped: `SearchLogs` is already filter-based; the `LEVEL` filter returns no rows against 2.0, which is a filter-semantics question, not param translation.

## Stacking
Built on top of #248 (the 2.0 auth bootstrap). Until #248 merges, this PR's diff also shows those commits.

## Test plan
- `go build ./...` and `go vet ./...` pass.
- CI runs the Go suite against the 2.x `develop` image; the 5 un-skipped search/log tests should pass. I cannot run the live Docker Kestra locally.