### PR TITLE
feat(go): add WithHeaders/WithHeader and WithDebug/WithLogger client options

### DIFF
--- a/go-sdk/kestra_api_client/base_api.go
+++ b/go-sdk/kestra_api_client/base_api.go
@@ -122,6 +122,9 @@ func (b *baseAPI) doRequest(ctx context.Context, method, path string, body io.Re
 	for k, v := range b.client.headers {
 		req.Header.Set(k, v)
 	}
+	if b.client.authHeader != "" {
+		req.Header.Set("Authorization", b.client.authHeader)
+	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
@@ -129,10 +132,14 @@ func (b *baseAPI) doRequest(ctx context.Context, method, path string, body io.Re
 		req.Header.Set("Accept", accept)
 	}
 
+	b.client.logRequest(req)
+
 	resp, err := b.client.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
+
+	b.client.logResponse(resp)
 
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
@@ -465,12 +472,19 @@ func (b *baseAPI) openSSEStream(ctx context.Context, path string, params url.Val
 	for k, v := range b.client.headers {
 		req.Header.Set(k, v)
 	}
+	if b.client.authHeader != "" {
+		req.Header.Set("Authorization", b.client.authHeader)
+	}
 	req.Header.Set("Accept", "text/event-stream")
+
+	b.client.logRequest(req)
 
 	resp, err := b.client.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
+
+	b.client.logResponse(resp)
 
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()

--- a/go-sdk/kestra_api_client/client.go
+++ b/go-sdk/kestra_api_client/client.go
@@ -2,6 +2,7 @@ package kestra_api_client
 
 import (
 	"encoding/base64"
+	"io"
 	"net/http"
 )
 
@@ -9,6 +10,13 @@ type KestraClient struct {
 	baseURL    string
 	httpClient *http.Client
 	headers    map[string]string
+	// authHeader holds the Authorization value set by WithBasicAuth/WithTokenAuth.
+	// It is applied after the default headers on every request, so an explicit
+	// auth option always takes precedence over an Authorization entry supplied
+	// through WithHeaders/WithHeader, regardless of option ordering.
+	authHeader string
+	debug      bool
+	logger     io.Writer
 }
 
 type ClientOption func(*KestraClient)
@@ -28,19 +36,62 @@ func NewClient(baseURL string, opts ...ClientOption) *KestraClient {
 func WithBasicAuth(username, password string) ClientOption {
 	return func(c *KestraClient) {
 		encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
-		c.headers["Authorization"] = "Basic " + encoded
+		c.authHeader = "Basic " + encoded
 	}
 }
 
 func WithTokenAuth(token string) ClientOption {
 	return func(c *KestraClient) {
-		c.headers["Authorization"] = "Bearer " + token
+		c.authHeader = "Bearer " + token
 	}
 }
 
 func WithHTTPClient(hc *http.Client) ClientOption {
 	return func(c *KestraClient) {
 		c.httpClient = hc
+	}
+}
+
+// WithHeaders merges the given headers into the client's default headers, which
+// are applied to every request. Existing entries with the same key are
+// overwritten.
+//
+// Precedence: an Authorization entry supplied here is overridden on the wire by
+// an explicit WithBasicAuth/WithTokenAuth option (whenever one is set),
+// independent of the order in which the options are passed to NewClient.
+func WithHeaders(headers map[string]string) ClientOption {
+	return func(c *KestraClient) {
+		for k, v := range headers {
+			c.headers[k] = v
+		}
+	}
+}
+
+// WithHeader sets a single default header, applied to every request. See
+// WithHeaders for the Authorization precedence rule.
+func WithHeader(key, value string) ClientOption {
+	return func(c *KestraClient) {
+		c.headers[key] = value
+	}
+}
+
+// WithDebug toggles HTTP request/response logging to os.Stderr. Logged output
+// covers the method, URL, status and headers; sensitive headers (Authorization,
+// Proxy-Authorization, Cookie, Set-Cookie) are redacted. Request and response
+// bodies are not logged. Use WithLogger to send the output elsewhere.
+func WithDebug(enabled bool) ClientOption {
+	return func(c *KestraClient) {
+		c.debug = enabled
+	}
+}
+
+// WithLogger directs debug output to w and enables debug logging. It is the
+// preferred option when you need to capture or redirect diagnostics (e.g. in
+// tests). See WithDebug for what is logged and which headers are redacted.
+func WithLogger(w io.Writer) ClientOption {
+	return func(c *KestraClient) {
+		c.logger = w
+		c.debug = true
 	}
 }
 

--- a/go-sdk/kestra_api_client/client_test.go
+++ b/go-sdk/kestra_api_client/client_test.go
@@ -1,0 +1,138 @@
+package kestra_api_client
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// captureRequest spins up a test server that records the headers of the
+// incoming request and returns the configured client baseURL plus a pointer to
+// the captured headers.
+func captureRequest(t *testing.T, opts ...ClientOption) (*KestraClient, *http.Header) {
+	t.Helper()
+	var captured http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(srv.URL, opts...)
+	return client, &captured
+}
+
+func TestWithHeaders_MergesIntoEveryRequest(t *testing.T) {
+	client, captured := captureRequest(t,
+		WithHeaders(map[string]string{
+			"X-Proxy":  "gateway",
+			"X-Tenant": "acme",
+		}),
+		WithHeader("X-Single", "one"),
+	)
+
+	if _, err := client.Misc().baseAPI.doText(context.Background(), "GET", "/", nil); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if got := captured.Get("X-Proxy"); got != "gateway" {
+		t.Errorf("X-Proxy = %q, want %q", got, "gateway")
+	}
+	if got := captured.Get("X-Tenant"); got != "acme" {
+		t.Errorf("X-Tenant = %q, want %q", got, "acme")
+	}
+	if got := captured.Get("X-Single"); got != "one" {
+		t.Errorf("X-Single = %q, want %q", got, "one")
+	}
+}
+
+func TestWithTokenAuth_OverridesUserAuthorizationHeader(t *testing.T) {
+	// Option order intentionally puts WithHeaders last to prove that the
+	// explicit auth option wins regardless of ordering.
+	client, captured := captureRequest(t,
+		WithTokenAuth("real-token"),
+		WithHeaders(map[string]string{"Authorization": "Bearer user-supplied"}),
+	)
+
+	if _, err := client.Misc().baseAPI.doText(context.Background(), "GET", "/", nil); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if got := captured.Get("Authorization"); got != "Bearer real-token" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer real-token")
+	}
+}
+
+func TestWithBasicAuth_OverridesUserAuthorizationHeader(t *testing.T) {
+	client, captured := captureRequest(t,
+		WithHeaders(map[string]string{"Authorization": "Bearer user-supplied"}),
+		WithBasicAuth("user", "pass"),
+	)
+
+	if _, err := client.Misc().baseAPI.doText(context.Background(), "GET", "/", nil); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	if got := captured.Get("Authorization"); got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestWithLogger_RedactsSensitiveHeaders(t *testing.T) {
+	var buf bytes.Buffer
+	client, _ := captureRequest(t,
+		WithTokenAuth("super-secret-token"),
+		WithHeader("Cookie", "session=topsecret"),
+		WithHeader("X-Proxy", "gateway"),
+		WithLogger(&buf),
+	)
+
+	if _, err := client.Misc().baseAPI.doText(context.Background(), "GET", "/", nil); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	out := buf.String()
+
+	// Diagnostics are present.
+	if !strings.Contains(out, "> GET ") {
+		t.Errorf("debug output missing request line:\n%s", out)
+	}
+	if !strings.Contains(out, "< 200") {
+		t.Errorf("debug output missing response status:\n%s", out)
+	}
+	// Non-sensitive header value is shown.
+	if !strings.Contains(out, "X-Proxy: gateway") {
+		t.Errorf("debug output missing non-sensitive header:\n%s", out)
+	}
+	// Sensitive values are redacted and never leak.
+	if strings.Contains(out, "super-secret-token") {
+		t.Errorf("Authorization token leaked into debug output:\n%s", out)
+	}
+	if strings.Contains(out, "topsecret") {
+		t.Errorf("Cookie value leaked into debug output:\n%s", out)
+	}
+	if !strings.Contains(out, "Authorization: "+redactedValue) {
+		t.Errorf("Authorization header not redacted:\n%s", out)
+	}
+	if !strings.Contains(out, "Cookie: "+redactedValue) {
+		t.Errorf("Cookie header not redacted:\n%s", out)
+	}
+}
+
+func TestWithoutDebug_ProducesNoOutput(t *testing.T) {
+	var buf bytes.Buffer
+	client, _ := captureRequest(t, WithTokenAuth("token"))
+	client.logger = &buf // debug stays false, so nothing should be written
+
+	if _, err := client.Misc().baseAPI.doText(context.Background(), "GET", "/", nil); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no debug output when debug disabled, got:\n%s", buf.String())
+	}
+}

--- a/go-sdk/kestra_api_client/debug.go
+++ b/go-sdk/kestra_api_client/debug.go
@@ -1,0 +1,66 @@
+package kestra_api_client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+)
+
+// redactedValue replaces the value of a sensitive header in debug output.
+const redactedValue = "REDACTED"
+
+// sensitiveHeaders are header names (lower-cased) whose values are masked in
+// debug output so credentials never leak into logs.
+var sensitiveHeaders = map[string]bool{
+	"authorization":       true,
+	"proxy-authorization": true,
+	"cookie":              true,
+	"set-cookie":          true,
+}
+
+// logWriter returns the destination for debug output, defaulting to os.Stderr
+// when no logger was configured via WithLogger.
+func (c *KestraClient) logWriter() io.Writer {
+	if c.logger != nil {
+		return c.logger
+	}
+	return os.Stderr
+}
+
+func (c *KestraClient) logRequest(req *http.Request) {
+	if !c.debug {
+		return
+	}
+	w := c.logWriter()
+	fmt.Fprintf(w, "> %s %s\n", req.Method, req.URL.String())
+	writeHeaders(w, ">", req.Header)
+}
+
+func (c *KestraClient) logResponse(resp *http.Response) {
+	if !c.debug {
+		return
+	}
+	w := c.logWriter()
+	fmt.Fprintf(w, "< %s\n", resp.Status)
+	writeHeaders(w, "<", resp.Header)
+}
+
+// writeHeaders prints headers in sorted order (for deterministic output),
+// redacting the values of sensitive headers.
+func writeHeaders(w io.Writer, prefix string, h http.Header) {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		value := strings.Join(h[k], ", ")
+		if sensitiveHeaders[strings.ToLower(k)] {
+			value = redactedValue
+		}
+		fmt.Fprintf(w, "%s %s: %s\n", prefix, k, value)
+	}
+}


### PR DESCRIPTION
Closes #255.

## Why
kestractl is migrating from the generated OpenAPI Go client to the hand-written `kestra_api_client` (kestractl#62). Two capabilities it relies on had no equivalent in the hand-written `NewClient`: custom default headers (`--header`) and HTTP debug logging (`--verbose`). This adds them.

## Changes

**`WithHeaders` / `WithHeader` — custom default headers**
```go
func WithHeaders(headers map[string]string) ClientOption // merges into c.headers
func WithHeader(key, value string) ClientOption           // single-header convenience
```
Applied to every request via the existing `doRequest` plumbing.

**`WithDebug` / `WithLogger` — request/response logging**
```go
func WithDebug(enabled bool) ClientOption  // logs to os.Stderr
func WithLogger(w io.Writer) ClientOption  // custom sink, also enables debug
```
Emits curl-style `> METHOD URL` / `< STATUS` plus sorted headers. **Sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`) are redacted** to `REDACTED`. Bodies are not logged (avoids buffering multipart uploads and leaking body-borne secrets).

**Auth precedence — defined & deterministic**
`WithBasicAuth`/`WithTokenAuth` now set a dedicated `authHeader` field applied *after* the default headers in `doRequest`. An explicit auth option therefore **always wins** over an `Authorization` entry supplied via `WithHeaders`, regardless of option order. Documented in the option doc comments.

## Tests
New in-package, hermetic `httptest`-based tests (no Docker): header merge, both auth-precedence directions, debug redaction (asserts raw token/cookie never appear), and the debug-off no-output case.

## Acceptance criteria
- [x] `WithHeaders`/`WithHeader` merge into default headers, applied to every request
- [x] Precedence between user `Authorization` and `WithTokenAuth`/`WithBasicAuth` defined & documented
- [x] `WithDebug`/`WithLogger` emit request/response diagnostics
- [x] Debug output redacts `Authorization` and sensitive headers
- [x] Unit tests for header merge + redaction
- [x] `go build ./...`, `go vet ./...`, `gofmt`, `go test -c ./...` clean; new tests pass under `-race`

## Release coordination
Item #4 in the issue's merge order — overlaps `client.go` with #253/#248/#254, so a rebase may be needed depending on merge sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)