### PR TITLE
chore(go): bump module path to /v2 for first hand-written release

### DIFF
--- a/go-sdk/CHANGELOG.md
+++ b/go-sdk/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog — Go SDK
+
+All notable changes to the Go SDK (`github.com/kestra-io/client-sdk/go-sdk`).
+The Go module is versioned independently of the other language SDKs and of the
+Kestra server (backend support is tracked as a compatibility matrix, not in the
+version number).
+
+## v2.0.0
+
+First **hand-written** client, replacing the generated OpenAPI client from the
+`v1.0.x` line. This is an API-breaking change for SDK consumers, hence the major
+version and the `/v2` module-path suffix. **Existing `v1.0.x` consumers are
+unaffected** (distinct module path).
+
+See [`MIGRATING.md`](./MIGRATING.md) for a step-by-step upgrade guide.
+
+### Compatibility
+
+- Targets **Kestra 1.3 and 2.x** with the same client.
+- Caveat: on endpoints where a 1.3 server does not accept the `filters` array,
+  that server silently ignores filtering (no error).
+
+### ⚠️ Breaking changes (vs v1.0.x)
+
+- **Module path** now requires the `/v2` suffix:
+  `github.com/kestra-io/client-sdk/go-sdk/v2`.
+- **Removed the generated surface**: `Configuration`, `NewConfiguration`,
+  `ServerConfiguration(s)`, `APIClient`, `NewAPIClient`, the `ApiXxxRequest`
+  builder types, and `XxxAPIService`.
+- **Constructor**: `NewAPIClient(cfg)` → `NewClient(baseURL, opts...)` returning
+  `*KestraClient`. `baseURL` is the bare host; the SDK adds `/api/v1/{tenant}/...`.
+- **Authentication** moved from the context to the client: `WithTokenAuth` /
+  `WithBasicAuth` replace `context.WithValue(ctx, ContextAccessToken|ContextBasicAuth, …)`.
+  Removed `ContextAccessToken`, `ContextBasicAuth`, `BasicAuth`.
+- **Service accessors**: `client.API.XxxAPI` (field) → `client.Xxx()` (method).
+  Renames include `KVAPI` → `Kv()`, `ServiceAccountAPI` → `ServiceAccount()`.
+- **Call style**: request-builder chaining + `.Execute()` → explicit method
+  arguments (`client.Groups().SearchGroups(ctx, tenant, page, size, sort, filters)`).
+- **Return signature**: `(T, *http.Response, error)` → `(T, error)` (no
+  `*http.Response`).
+- **Error type**: `*GenericOpenAPIError` (with `.Body()` method) → `*ApiError`
+  (`{StatusCode int, Body []byte, Message string}`).
+- **Filtering**: per-field builder setters (`.Q(...)`, `.Namespace(...)`) →
+  `[]QueryFilter{{Field, Operation, Value}}` with `FilterX` / `OpX` constants.
+- **Optional params** are pointers (`*int`, `*string`); use `PtrInt`/`PtrString`.
+- **Debug output**: `cfg.Debug` (dumped bodies) → `WithDebug` / `WithLogger`
+  (method/URL/status + headers only; sensitive headers redacted; no bodies).
+
+### Added
+
+- Hand-written client (`KestraClient`) with per-resource accessors.
+- Client options: `WithBasicAuth`, `WithTokenAuth`, `WithHTTPClient`,
+  `WithHeaders`, `WithHeader`, `WithDebug`, `WithLogger`.
+- `Invitations()` and `Bindings()` APIs (previously only model structs existed).
+- Kestra 2.0 unified `filters` support across search/list methods.
+
+### Fixed
+
+- Search/list filtering now actually applies against Kestra 2.0 (the generated
+  client sent legacy params that 2.0 silently ignored).
+- Successful responses are unmarshalled directly; the v1 "parse the error body
+  on success" workarounds are no longer needed.
+
+### Unchanged
+
+- Data model structs and their `GetX()`/`SetX()`/`NewXxx()` helpers and
+  `PtrString`/`PtrInt` are carried over from v1.
+
+## v1.0.1 / v1.0.0
+
+Generated OpenAPI client. No longer the active development line; kept for
+existing consumers.

--- a/go-sdk/MIGRATING.md
+++ b/go-sdk/MIGRATING.md
@@ -74,19 +74,19 @@ regardless of option order.
 
 ```go
 // v1
-client.API.GroupsAPI...   client.API.UsersAPI...   client.API.KVAPI...
+client.GroupsAPI...   client.UsersAPI...   client.KVAPI...
 // v2
-client.Groups()...        client.Users()...        client.Kv()...
+client.Groups()...    client.Users()...    client.Kv()...
 ```
 
-The `API` field and the `XxxAPI` fields are removed. Note the renames:
+The `XxxAPI` service fields are removed. Note the renames:
 `KVAPI` → `Kv()`, `ServiceAccountAPI` → `ServiceAccount()`.
 
 ## 5. Call style: request builder + `.Execute()` → direct arguments
 
 ```go
 // v1
-res, httpResp, err := client.API.GroupsAPI.
+res, httpResp, err := client.GroupsAPI.
     SearchGroups(ctx, tenant).Page(1).Size(50).Q("foo").Execute()
 
 // v2
@@ -120,8 +120,8 @@ if e, ok := err.(*kestra.GenericOpenAPIError); ok {
 // v2
 if e, ok := err.(*kestra.ApiError); ok {
     status := e.StatusCode  // field, now directly available
-    body   := e.Body        // field ([]byte)
-    msg    := e.Message
+    body   := e.Body        // field ([]byte) — the raw response body
+    msg    := e.Error()     // formatted "API error <status>: <body>"
 }
 ```
 

--- a/go-sdk/MIGRATING.md
+++ b/go-sdk/MIGRATING.md
@@ -1,0 +1,165 @@
+# Migrating the Go SDK: v1.0.x → v2.0.0
+
+`go-sdk/v2.0.0` is the first **hand-written** release of the Go client. It
+replaces the generated OpenAPI client shipped in `go-sdk/v1.0.x`. The data
+models are largely unchanged, but the **transport/call layer is different**, so
+this is a breaking upgrade with a new module path.
+
+> Existing `go-sdk/v1.0.x` consumers are unaffected — it is a distinct module
+> path and keeps working. Migrate when you are ready.
+
+## Backend compatibility
+
+The v2 client targets **Kestra 1.3 and 2.x**. The Kestra version you talk to is
+a runtime/compatibility concern, independent of this SDK version — see the
+compatibility note in the README. (One caveat: on endpoints where a 1.3 server
+does not accept the `filters` array, filtering is silently ignored by that
+server — no error.)
+
+## 1. Module path / import
+
+```go
+// v1
+import kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+// v2
+import kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+```
+
+```bash
+go get github.com/kestra-io/client-sdk/go-sdk/v2@go-sdk/v2.0.0
+```
+
+## 2. Client construction — `Configuration`/`APIClient` are gone
+
+```go
+// v1
+cfg := kestra.NewConfiguration()
+cfg.Scheme = "https"
+cfg.Host = "host:8080"
+cfg.Servers = kestra.ServerConfigurations{{URL: host}}
+cfg.Debug = true
+cfg.AddDefaultHeader("X-Foo", "bar")
+client := kestra.NewAPIClient(cfg)
+
+// v2
+client := kestra.NewClient("https://host:8080",
+    kestra.WithDebug(true),
+    kestra.WithHeaders(map[string]string{"X-Foo": "bar"}),
+)
+```
+
+- `NewClient` takes the **bare host** (`https://host:8080`). The SDK adds
+  `/api/v1/{tenant}/...` itself — **do not** include `/api/v1` in the base URL.
+- Removed: `Configuration`, `NewConfiguration`, `ServerConfiguration(s)`,
+  `APIClient`, `NewAPIClient`.
+
+## 3. Authentication moved from the context to the client
+
+```go
+// v1 — auth carried on the context
+ctx = context.WithValue(ctx, kestra.ContextAccessToken, token)
+ctx = context.WithValue(ctx, kestra.ContextBasicAuth,
+    kestra.BasicAuth{UserName: user, Password: pass})
+
+// v2 — auth set on the client at construction
+client := kestra.NewClient(host, kestra.WithTokenAuth(token))
+client := kestra.NewClient(host, kestra.WithBasicAuth(user, pass))
+```
+
+Removed: `ContextAccessToken`, `ContextBasicAuth`, `BasicAuth`. An explicit
+auth option always wins over an `Authorization` value passed via `WithHeaders`,
+regardless of option order.
+
+## 4. Service accessors: field → method
+
+```go
+// v1
+client.API.GroupsAPI...   client.API.UsersAPI...   client.API.KVAPI...
+// v2
+client.Groups()...        client.Users()...        client.Kv()...
+```
+
+The `API` field and the `XxxAPI` fields are removed. Note the renames:
+`KVAPI` → `Kv()`, `ServiceAccountAPI` → `ServiceAccount()`.
+
+## 5. Call style: request builder + `.Execute()` → direct arguments
+
+```go
+// v1
+res, httpResp, err := client.API.GroupsAPI.
+    SearchGroups(ctx, tenant).Page(1).Size(50).Q("foo").Execute()
+
+// v2
+res, err := client.Groups().
+    SearchGroups(ctx, tenant, kestra.PtrInt(1), kestra.PtrInt(50), nil, filters)
+```
+
+The `ApiXxxRequest` builder types and `.Execute()` are gone; parameters are
+explicit method arguments.
+
+## 6. Return signature drops `*http.Response`
+
+```go
+// v1
+value, httpResp, err := ...Execute()   // (T, *http.Response, error)
+// v2
+value, err := ...                       // (T, error)
+```
+
+If you read the `*http.Response` (status, headers, raw body), use the typed
+error (next section) for the failure path instead.
+
+## 7. Error type: `GenericOpenAPIError` → `ApiError`
+
+```go
+// v1
+if e, ok := err.(*kestra.GenericOpenAPIError); ok {
+    body := e.Body()       // method
+    msg  := e.Error()
+}
+// v2
+if e, ok := err.(*kestra.ApiError); ok {
+    status := e.StatusCode  // field, now directly available
+    body   := e.Body        // field ([]byte)
+    msg    := e.Message
+}
+```
+
+`GenericOpenAPIError` (and `.Body()`/`.Model()`) is removed.
+
+## 8. Filtering: typed setters → `[]QueryFilter`
+
+```go
+// v1
+.Q("foo").Namespace("ns").Execute()
+// v2
+[]kestra.QueryFilter{
+    {Field: kestra.FilterQuery, Operation: kestra.OpContains, Value: "foo"},
+    {Field: kestra.FilterNamespace, Operation: kestra.OpEquals, Value: "ns"},
+}
+```
+
+Search/list filtering uses the `QueryFilter{Field, Operation, Value}` model with
+the `FilterX` / `OpX` enum constants instead of per-field builder methods.
+
+## 9. Optional parameters are pointers
+
+`page`/`size` are `*int`, optional strings are `*string`. Use the retained
+`kestra.PtrInt(...)` / `kestra.PtrString(...)` helpers and pass `nil` to omit.
+
+## 10. Debug output behavior changed
+
+`cfg.Debug` dumped full request/response **bodies**. `WithDebug` / `WithLogger`
+log **method/URL/status + headers only**, with `Authorization`, `Cookie`, and
+other sensitive headers **redacted**, and never log bodies.
+
+## What does NOT change
+
+- **Model structs are reused** — `IAMGroupControllerApiGroupDetail`,
+  `IAMInvitationControllerApiInvitationCreateRequest`, etc., with their
+  `GetX()`/`SetX()`/`HasX()` accessors, `NewXxx()` constructors, and the
+  `PtrString`/`PtrInt` helpers. Payload-shaping code mostly survives.
+- The v1 client occasionally mis-typed *successful* responses, requiring
+  callers to parse the "error" body on success. v2's request layer unmarshals
+  success bodies directly, so those workarounds can be **deleted** — this is a
+  fix, not a behavior you must preserve.

--- a/go-sdk/go.mod
+++ b/go-sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/kestra-io/client-sdk/go-sdk
+module github.com/kestra-io/client-sdk/go-sdk/v2
 
 go 1.24
 

--- a/go-sdk/kestra_api_client/README.md
+++ b/go-sdk/kestra_api_client/README.md
@@ -23,7 +23,7 @@ go get golang.org/x/net/context
 Put the package under your project folder and add the following in import:
 
 ```go
-import kestra_api_client "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+import kestra_api_client "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 ```
 
 To use a proxy, set the environment variable `HTTP_PROXY`:

--- a/go-sdk/test/api_apps_test.go
+++ b/go-sdk/test/api_apps_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_assets_test.go
+++ b/go-sdk/test/api_assets_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_bindings_test.go
+++ b/go-sdk/test/api_bindings_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_blueprints_test.go
+++ b/go-sdk/test/api_blueprints_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_dashboards_test.go
+++ b/go-sdk/test/api_dashboards_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_executions_test.go
+++ b/go-sdk/test/api_executions_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_files_test.go
+++ b/go-sdk/test/api_files_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_flows_test.go
+++ b/go-sdk/test/api_flows_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_groups_test.go
+++ b/go-sdk/test/api_groups_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_invitations_test.go
+++ b/go-sdk/test/api_invitations_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_kv_test.go
+++ b/go-sdk/test/api_kv_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_logs_test.go
+++ b/go-sdk/test/api_logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_namespaces_test.go
+++ b/go-sdk/test/api_namespaces_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_roles_test.go
+++ b/go-sdk/test/api_roles_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_service_account_test.go
+++ b/go-sdk/test/api_service_account_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_testsuites_test.go
+++ b/go-sdk/test/api_testsuites_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_triggers_test.go
+++ b/go-sdk/test/api_triggers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_users_test.go
+++ b/go-sdk/test/api_users_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/test/common_test_setup.go
+++ b/go-sdk/test/common_test_setup.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 )
 
 // StaticFilter injects the signed CSRF token the UI uses into a meta tag.

--- a/go-sdk/test/queryfilters_test.go
+++ b/go-sdk/test/queryfilters_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
## Why
The hand-written `kestra_api_client` (which replaced the generated OpenAPI client shipped in `go-sdk/v1.0.x`) is an **API-breaking** change — `client.API.XxxAPI.Y(...).Execute()` → `client.Xxx().Y(...)`, `*GenericOpenAPIError` → `*ApiError`. The next Go release is therefore a **major version**, and Go's rules for v2+ modules require the module path to carry a `/v2` suffix.

This PR makes that change so the release can be tagged `go-sdk/v2.0.0`. It unblocks the kestractl SDK migration (kestra-io/kestractl#62).

## Changes
- **`go.mod`**: `module github.com/kestra-io/client-sdk/go-sdk` → `…/go-sdk/v2`
- **`test/` package + `kestra_api_client/README.md`**: internal imports `…/go-sdk/kestra_api_client` → `…/go-sdk/v2/kestra_api_client`

The `/v2` is a *logical* major-version suffix — code stays in `go-sdk/`; there is **no** `go-sdk/v2/` subdirectory.

## Verification
- `go build ./...`, `go vet ./...`, `go test -c ./test/`, `go mod tidy` (no-op; no spurious deps, `go.sum` unchanged) — all clean.
- Edited files are gofmt-clean (pre-existing gofmt noise in generated `model_*.go` left untouched).

## Release steps (after merge)
1. Tag the merge commit: `git tag -a go-sdk/v2.0.0 -m "…" && git push origin go-sdk/v2.0.0` (tagging is manual — `go-sdk.yml` is test-only).
2. Verify: `go list -m github.com/kestra-io/client-sdk/go-sdk/v2@go-sdk/v2.0.0`.
3. kestractl bumps `go.mod` to the `/v2` path and pins `v2.0.0` (kestra-io/kestractl#62).

Existing `go-sdk/v1.0.x` consumers are unaffected (distinct module path).

## Notes
- The committed binary `go-sdk/test.test` still embeds the old import string but is a build artifact; left untouched here.
