### PR TITLE
fix(go): possible context leak in SSE follow methods (go vet)

### DIFF
--- a/go-sdk/kestra_api_client/api_executions.go
+++ b/go-sdk/kestra_api_client/api_executions.go
@@ -1612,6 +1612,7 @@ func (a *ExecutionsAPIService) FollowDependenciesExecutionsExecute(r ApiFollowDe
 	ctx, cancel := context.WithCancel(r.ctx)
 	req, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
+		cancel()
 		return executionEvents, err
 	}
 
@@ -1747,6 +1748,7 @@ func (a *ExecutionsAPIService) FollowExecutionExecute(r ApiFollowExecutionReques
 	ctx, cancel := context.WithCancel(r.ctx)
 	req, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
+		cancel()
 		return executionEvents, err
 	}
 


### PR DESCRIPTION
## Summary
`go vet` reported possible context leaks in `go-sdk/kestra_api_client/api_executions.go`:

```
api_executions.go:1612:2: the cancel function is not used on all paths (possible context leak)
api_executions.go:1615:3: this return statement may be reached without using the cancel var defined on line 1612
api_executions.go:1747:2: the cancel function is not used on all paths (possible context leak)
api_executions.go:1750:3: this return statement may be reached without using the cancel var defined on line 1747
```

In `FollowDependenciesExecutionsExecute` and `FollowExecutionExecute`, the `cancel` function from `context.WithCancel` was not called when `prepareRequest` failed, leaking the context on the early-return error path.

## Changes
- Call `cancel()` before the early return when `prepareRequest` fails (both SSE follow methods).

## Verification
- `go vet ./kestra_api_client/` — clean
- `go build ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)