### PR TITLE
test(python): bootstrap Kestra 2.0 auth via API token

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -77,14 +77,16 @@ jobs:
           sh run-tests.sh $KESTRA_VERSION
 
       # The CI Kestra container dies with a Java heap OutOfMemoryError mid-run
-      # (regression on the 2.0 develop image); upload the heap dump written via
-      # -XX:+HeapDumpOnOutOfMemoryError so the leak can be analyzed with MAT.
-      - name: Upload Kestra heap dump
+      # (regression on the 2.0 develop image). Rather than a multi-GB heap dump,
+      # the JVM logs a class histogram around each full GC; the last one before the
+      # terminal OOM shows the accumulating classes. Upload the full Kestra log so
+      # that histogram can be inspected (a few KB of text, not a multi-GB .hprof).
+      - name: Upload Kestra logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: kestra-heap-dump
-          path: python/python-sdk/heap-dump/*.hprof
+          name: kestra-logs
+          path: python/python-sdk/kestra-logs/*.log
           if-no-files-found: ignore
           retention-days: 5
 

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -77,16 +77,16 @@ jobs:
           sh run-tests.sh $KESTRA_VERSION
 
       # The CI Kestra container dies with a Java heap OutOfMemoryError mid-run
-      # (regression on the 2.0 develop image). Rather than a multi-GB heap dump,
-      # the JVM logs a class histogram around each full GC; the last one before the
-      # terminal OOM shows the accumulating classes. Upload the full Kestra log so
-      # that histogram can be inspected (a few KB of text, not a multi-GB .hprof).
+      # (regression on the 2.0 develop image). Instead of a multi-GB heap dump,
+      # upload small text diagnostics: the unified GC log (heap occupancy + Full GC
+      # events) and per-class histogram snapshots polled from the host, the last of
+      # which (before the OOM) shows the accumulating classes.
       - name: Upload Kestra logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: kestra-logs
-          path: python/python-sdk/kestra-logs/*.log
+          path: python/python-sdk/kestra-logs/
           if-no-files-found: ignore
           retention-days: 5
 

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -76,6 +76,18 @@ jobs:
           echo "${{ steps.license.outputs.license }}" | base64 -d > ../../test-utils/docker-setup/application-secrets.yml
           sh run-tests.sh $KESTRA_VERSION
 
+      # The CI Kestra container dies with a Java heap OutOfMemoryError mid-run
+      # (regression on the 2.0 develop image); upload the heap dump written via
+      # -XX:+HeapDumpOnOutOfMemoryError so the leak can be analyzed with MAT.
+      - name: Upload Kestra heap dump
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kestra-heap-dump
+          path: python/python-sdk/heap-dump/*.hprof
+          if-no-files-found: ignore
+          retention-days: 5
+
   publish:
     name: Publish to Pip
     runs-on: ubuntu-latest

--- a/python/python-sdk/.gitignore
+++ b/python/python-sdk/.gitignore
@@ -64,3 +64,4 @@ target/
 
 # Ipython Notebook
 .ipynb_checkpoints
+heap-dump/

--- a/python/python-sdk/.gitignore
+++ b/python/python-sdk/.gitignore
@@ -64,4 +64,4 @@ target/
 
 # Ipython Notebook
 .ipynb_checkpoints
-heap-dump/
+kestra-logs/

--- a/python/python-sdk/application-postgres.yml
+++ b/python/python-sdk/application-postgres.yml
@@ -11,3 +11,9 @@ kestra:
     type: postgres
   queue:
     type: postgres
+  ai:
+    # Disable AI features: KestraDocsContextTool spawns a langchain4j MCP client
+    # towards https://api.kestra.io/v1/mcp which the CI container cannot reach,
+    # leaving a reconnect loop (mcp-server-health-checker) suspected of leaking
+    # heap until the JVM dies with OutOfMemoryError mid test run.
+    enabled: false

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -33,14 +33,16 @@ services:
       - ../../test-utils/docker-setup/application.yml:/app/confs/application.yml:ro
       - ../../test-utils/docker-setup/application-secrets.yml:/app/secrets/application-secrets.yml:ro
       - ./application-postgres.yml:/app/confs/application-postgres.yml:ro
+      - ./kestra-logs:/kestra-logs
     environment:
       MICRONAUT_CONFIG_FILES: /app/confs/application.yml,/app/confs/application-postgres.yml,/app/secrets/application-secrets.yml
       # The container OOMs mid-suite (regression on the 2.0 develop image). A full
       # heap dump is multi-GB and unusable on a laptop, and dropping the heap low
-      # enough to shrink it (1g) stops the OOM from triggering at all. Instead, log
-      # a class histogram around each full GC: the last histogram before the
-      # terminal OOM shows which classes are accumulating, in a few KB of text that
-      # CI captures in the container logs. Keep 4g so the OOM still reproduces.
-      JAVA_OPTS: "-Xms512m -Xmx4g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -XX:+PrintClassHistogramBeforeFullGC -XX:+PrintClassHistogramAfterFullGC"
+      # enough to shrink it (1g) stops the OOM from triggering at all. Instead,
+      # write unified GC logs to the bind mount: small text that shows heap
+      # occupancy after every GC and each Full GC, so the leak's shape and onset
+      # are visible. run-tests.sh additionally polls a per-class histogram from the
+      # host. Keep 4g so the OOM still reproduces.
+      JAVA_OPTS: "-Xms512m -Xmx4g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -Xlog:gc*:file=/kestra-logs/gc.log:time,uptime,level,tags"
     ports:
       - "9902:8080"

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -35,5 +35,6 @@ services:
       - ./application-postgres.yml:/app/confs/application-postgres.yml:ro
     environment:
       MICRONAUT_CONFIG_FILES: /app/confs/application.yml,/app/confs/application-postgres.yml,/app/secrets/application-secrets.yml
+      JAVA_OPTS: "-Xms512m -Xmx8g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError"
     ports:
       - "9902:8080"

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -33,8 +33,12 @@ services:
       - ../../test-utils/docker-setup/application.yml:/app/confs/application.yml:ro
       - ../../test-utils/docker-setup/application-secrets.yml:/app/secrets/application-secrets.yml:ro
       - ./application-postgres.yml:/app/confs/application-postgres.yml:ro
+      - ./heap-dump:/heap-dump
     environment:
       MICRONAUT_CONFIG_FILES: /app/confs/application.yml,/app/confs/application-postgres.yml,/app/secrets/application-secrets.yml
-      JAVA_OPTS: "-Xms512m -Xmx8g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError"
+      # 4g is known to OOM mid-suite (8g only delays it, see run 26883549146); keep
+      # it small so the heap dump stays uploadable as a CI artifact. The dump is
+      # written to the bind mount before ExitOnOutOfMemoryError terminates the JVM.
+      JAVA_OPTS: "-Xms512m -Xmx4g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/heap-dump/kestra.hprof"
     ports:
       - "9902:8080"

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -36,9 +36,11 @@ services:
       - ./heap-dump:/heap-dump
     environment:
       MICRONAUT_CONFIG_FILES: /app/confs/application.yml,/app/confs/application-postgres.yml,/app/secrets/application-secrets.yml
-      # 4g is known to OOM mid-suite (8g only delays it, see run 26883549146); keep
-      # it small so the heap dump stays uploadable as a CI artifact. The dump is
-      # written to the bind mount before ExitOnOutOfMemoryError terminates the JVM.
-      JAVA_OPTS: "-Xms512m -Xmx4g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/heap-dump/kestra.hprof"
+      # The container OOMs mid-suite regardless of heap size (8g/4g only delay it,
+      # see run 26883549146), so cap the heap at 1g: it still reproduces the OOM
+      # but keeps the .hprof small enough to download and open in MAT without
+      # overwhelming a laptop. The dump is written to the bind mount before
+      # ExitOnOutOfMemoryError terminates the JVM.
+      JAVA_OPTS: "-Xms512m -Xmx1g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/heap-dump/kestra.hprof"
     ports:
       - "9902:8080"

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -33,14 +33,14 @@ services:
       - ../../test-utils/docker-setup/application.yml:/app/confs/application.yml:ro
       - ../../test-utils/docker-setup/application-secrets.yml:/app/secrets/application-secrets.yml:ro
       - ./application-postgres.yml:/app/confs/application-postgres.yml:ro
-      - ./heap-dump:/heap-dump
     environment:
       MICRONAUT_CONFIG_FILES: /app/confs/application.yml,/app/confs/application-postgres.yml,/app/secrets/application-secrets.yml
-      # The container OOMs mid-suite regardless of heap size (8g/4g only delay it,
-      # see run 26883549146), so cap the heap at 1g: it still reproduces the OOM
-      # but keeps the .hprof small enough to download and open in MAT without
-      # overwhelming a laptop. The dump is written to the bind mount before
-      # ExitOnOutOfMemoryError terminates the JVM.
-      JAVA_OPTS: "-Xms512m -Xmx1g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/heap-dump/kestra.hprof"
+      # The container OOMs mid-suite (regression on the 2.0 develop image). A full
+      # heap dump is multi-GB and unusable on a laptop, and dropping the heap low
+      # enough to shrink it (1g) stops the OOM from triggering at all. Instead, log
+      # a class histogram around each full GC: the last histogram before the
+      # terminal OOM shows which classes are accumulating, in a few KB of text that
+      # CI captures in the container logs. Keep 4g so the OOM still reproduces.
+      JAVA_OPTS: "-Xms512m -Xmx4g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -XX:+PrintClassHistogramBeforeFullGC -XX:+PrintClassHistogramAfterFullGC"
     ports:
       - "9902:8080"

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -38,11 +38,14 @@ services:
       MICRONAUT_CONFIG_FILES: /app/confs/application.yml,/app/confs/application-postgres.yml,/app/secrets/application-secrets.yml
       # The container OOMs mid-suite (regression on the 2.0 develop image). A full
       # heap dump is multi-GB and unusable on a laptop, and dropping the heap low
-      # enough to shrink it (1g) stops the OOM from triggering at all. Instead,
-      # write unified GC logs to the bind mount: small text that shows heap
-      # occupancy after every GC and each Full GC, so the leak's shape and onset
-      # are visible. run-tests.sh additionally polls a per-class histogram from the
-      # host. Keep 4g so the OOM still reproduces.
-      JAVA_OPTS: "-Xms512m -Xmx4g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -Xlog:gc*:file=/kestra-logs/gc.log:time,uptime,level,tags"
+      # enough to shrink it (1g) stops the OOM from triggering at all. Instead:
+      #  - -Xlog:gc* writes a small GC log to the bind mount; it already shows the
+      #    leak shape (old gen pins full, Full GCs reclaim ~0, then OOM).
+      #  - -XX:+PrintClassHistogram makes the JVM print a per-class histogram to
+      #    stdout on SIGQUIT (the image is a JRE with no jcmd/jmap); run-tests.sh
+      #    sends SIGQUIT periodically and the histograms land in the captured logs,
+      #    naming the classes that fill the old gen.
+      # Keep 4g so the OOM still reproduces.
+      JAVA_OPTS: "-Xms512m -Xmx4g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -XX:+PrintClassHistogram -Xlog:gc*:file=/kestra-logs/gc.log:time,uptime,level,tags"
     ports:
       - "9902:8080"

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -15,11 +15,10 @@ services:
 
   kestra:
     container_name: python-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop-no-plugins"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION:-develop}-no-plugins"
     pull_policy: always
     user: "root"
     command: server standalone
-    mem_limit: 6g
     depends_on:
       postgres:
         condition: service_healthy
@@ -36,6 +35,5 @@ services:
       - ./application-postgres.yml:/app/confs/application-postgres.yml:ro
     environment:
       MICRONAUT_CONFIG_FILES: /app/confs/application.yml,/app/confs/application-postgres.yml,/app/secrets/application-secrets.yml
-      JAVA_OPTS: "-Xms512m -Xmx4g -XX:MaxMetaspaceSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+ExitOnOutOfMemoryError"
     ports:
       - "9902:8080"

--- a/python/python-sdk/run-tests.sh
+++ b/python/python-sdk/run-tests.sh
@@ -43,22 +43,17 @@ for KESTRA_VERSION in $versions; do
      exit 1;
   }
 
-  # Background poller for a per-class heap histogram. The JVM has no flag to print
-  # one on OOM (PrintClassHistogram*FullGC was removed in modern JDKs), so snapshot
-  # it from the host every 20s and keep the last few; the snapshot just before the
-  # OOM shows which classes are accumulating. jcmd/jmap are JDK tools that may be
-  # absent on a JRE image, so try both and record which (or that neither) worked.
+  # Background poller for a per-class heap histogram. The image is a JRE with no
+  # jcmd/jmap, and the PrintClassHistogram*FullGC flags were removed in modern
+  # JDKs; but -XX:+PrintClassHistogram (set in JAVA_OPTS) makes the JVM dump a
+  # class histogram to stdout on SIGQUIT. Send one every 15s while the container
+  # runs: the histograms accumulate in the container stdout (captured into
+  # kestra.log below), and the last one before the OOM names the classes filling
+  # the old gen. SIGQUIT only requests the dump - it does not kill the JVM.
   (
     while [ "$(docker inspect -f '{{.State.Running}}' python-sdk-test-kestra 2>/dev/null)" = "true" ]; do
-      snap="kestra-logs/histo-$(date +%H%M%S).txt"
-      if ! docker exec python-sdk-test-kestra sh -c 'command -v jcmd >/dev/null 2>&1 && exec jcmd 1 GC.class_histogram' > "$snap" 2>/dev/null; then
-        if ! docker exec python-sdk-test-kestra sh -c 'command -v jmap >/dev/null 2>&1 && exec jmap -histo:live 1' > "$snap" 2>/dev/null; then
-          echo "jcmd/jmap unavailable in image (or JVM is not PID 1)" > "$snap"
-        fi
-      fi
-      # keep only the 3 most recent snapshots
-      ls -1t kestra-logs/histo-*.txt 2>/dev/null | tail -n +4 | xargs -r rm -f
-      sleep 20
+      docker kill --signal=QUIT python-sdk-test-kestra >/dev/null 2>&1 || true
+      sleep 15
     done
   ) &
   histo_poller_pid=$!

--- a/python/python-sdk/run-tests.sh
+++ b/python/python-sdk/run-tests.sh
@@ -32,6 +32,9 @@ for KESTRA_VERSION in $versions; do
   export KESTRA_VERSION=$KESTRA_VERSION
 
   echo "start Kestra container"
+  # pre-create the heap-dump bind mount so the JVM can write its OOM dump there
+  mkdir -p heap-dump
+  rm -f heap-dump/*.hprof
   log_and_run docker compose -f docker-compose-ci.yml down
 
   log_and_run docker compose -f docker-compose-ci.yml up -d --wait || {
@@ -56,6 +59,10 @@ for KESTRA_VERSION in $versions; do
       --format 'OOMKilled={{.State.OOMKilled}} ExitCode={{.State.ExitCode}} Status={{.State.Status}}' || true
     echo "----- kestra logs (last 300 lines) -----"
     docker compose -f docker-compose-ci.yml logs --no-color --tail 300 kestra || true
+    echo "----- heap dump (written on OutOfMemoryError) -----"
+    # written as root inside the container; make it readable for artifact upload
+    sudo chmod -R a+r heap-dump 2>/dev/null || chmod -R a+r heap-dump 2>/dev/null || true
+    ls -lh heap-dump/ || true
   fi
 
   echo "stop Kestra container"

--- a/python/python-sdk/run-tests.sh
+++ b/python/python-sdk/run-tests.sh
@@ -32,6 +32,9 @@ for KESTRA_VERSION in $versions; do
   export KESTRA_VERSION=$KESTRA_VERSION
 
   echo "start Kestra container"
+  # the JVM writes its GC log here (bind mount); also where we collect histograms
+  mkdir -p kestra-logs
+  rm -f kestra-logs/*
   log_and_run docker compose -f docker-compose-ci.yml down
 
   log_and_run docker compose -f docker-compose-ci.yml up -d --wait || {
@@ -40,11 +43,34 @@ for KESTRA_VERSION in $versions; do
      exit 1;
   }
 
+  # Background poller for a per-class heap histogram. The JVM has no flag to print
+  # one on OOM (PrintClassHistogram*FullGC was removed in modern JDKs), so snapshot
+  # it from the host every 20s and keep the last few; the snapshot just before the
+  # OOM shows which classes are accumulating. jcmd/jmap are JDK tools that may be
+  # absent on a JRE image, so try both and record which (or that neither) worked.
+  (
+    while [ "$(docker inspect -f '{{.State.Running}}' python-sdk-test-kestra 2>/dev/null)" = "true" ]; do
+      snap="kestra-logs/histo-$(date +%H%M%S).txt"
+      if ! docker exec python-sdk-test-kestra sh -c 'command -v jcmd >/dev/null 2>&1 && exec jcmd 1 GC.class_histogram' > "$snap" 2>/dev/null; then
+        if ! docker exec python-sdk-test-kestra sh -c 'command -v jmap >/dev/null 2>&1 && exec jmap -histo:live 1' > "$snap" 2>/dev/null; then
+          echo "jcmd/jmap unavailable in image (or JVM is not PID 1)" > "$snap"
+        fi
+      fi
+      # keep only the 3 most recent snapshots
+      ls -1t kestra-logs/histo-*.txt 2>/dev/null | tail -n +4 | xargs -r rm -f
+      sleep 20
+    done
+  ) &
+  histo_poller_pid=$!
+
   echo "start tests"
   set +e
   python3 -m pytest -v --timeout=10
   test_rc=$?
   set -e
+
+  kill "$histo_poller_pid" 2>/dev/null || true
+  wait "$histo_poller_pid" 2>/dev/null || true
 
   if [ "$test_rc" -ne 0 ]; then
     echo "tests failed (rc=$test_rc) - dumping Kestra diagnostics before teardown"
@@ -54,13 +80,14 @@ for KESTRA_VERSION in $versions; do
     echo "----- postgres container state -----"
     docker inspect python-sdk-test-postgres \
       --format 'OOMKilled={{.State.OOMKilled}} ExitCode={{.State.ExitCode}} Status={{.State.Status}}' || true
-    # Capture the FULL kestra logs to a file for upload: the OOM class histograms
-    # (-XX:+PrintClassHistogram{Before,After}FullGC) run to thousands of lines and
-    # would be cut off by a tail. Print only the tail to the console for a quick look.
-    mkdir -p kestra-logs
+    # Capture the FULL kestra stdout to a file for upload; print only the tail to
+    # the console. The GC log and histogram snapshots already sit in kestra-logs/.
     docker compose -f docker-compose-ci.yml logs --no-color --no-log-prefix kestra > kestra-logs/kestra.log 2>&1 || true
-    echo "----- kestra logs (last 300 lines; full log uploaded as artifact) -----"
+    echo "----- kestra logs (last 300 lines; full logs + GC log + histograms uploaded as artifact) -----"
     tail -n 300 kestra-logs/kestra.log || true
+    # gc.log is written by root inside the container; make everything readable for upload
+    sudo chmod -R a+r kestra-logs 2>/dev/null || chmod -R a+r kestra-logs 2>/dev/null || true
+    ls -lh kestra-logs/ || true
   fi
 
   echo "stop Kestra container"

--- a/python/python-sdk/run-tests.sh
+++ b/python/python-sdk/run-tests.sh
@@ -32,9 +32,6 @@ for KESTRA_VERSION in $versions; do
   export KESTRA_VERSION=$KESTRA_VERSION
 
   echo "start Kestra container"
-  # pre-create the heap-dump bind mount so the JVM can write its OOM dump there
-  mkdir -p heap-dump
-  rm -f heap-dump/*.hprof
   log_and_run docker compose -f docker-compose-ci.yml down
 
   log_and_run docker compose -f docker-compose-ci.yml up -d --wait || {
@@ -57,12 +54,13 @@ for KESTRA_VERSION in $versions; do
     echo "----- postgres container state -----"
     docker inspect python-sdk-test-postgres \
       --format 'OOMKilled={{.State.OOMKilled}} ExitCode={{.State.ExitCode}} Status={{.State.Status}}' || true
-    echo "----- kestra logs (last 300 lines) -----"
-    docker compose -f docker-compose-ci.yml logs --no-color --tail 300 kestra || true
-    echo "----- heap dump (written on OutOfMemoryError) -----"
-    # written as root inside the container; make it readable for artifact upload
-    sudo chmod -R a+r heap-dump 2>/dev/null || chmod -R a+r heap-dump 2>/dev/null || true
-    ls -lh heap-dump/ || true
+    # Capture the FULL kestra logs to a file for upload: the OOM class histograms
+    # (-XX:+PrintClassHistogram{Before,After}FullGC) run to thousands of lines and
+    # would be cut off by a tail. Print only the tail to the console for a quick look.
+    mkdir -p kestra-logs
+    docker compose -f docker-compose-ci.yml logs --no-color --no-log-prefix kestra > kestra-logs/kestra.log 2>&1 || true
+    echo "----- kestra logs (last 300 lines; full log uploaded as artifact) -----"
+    tail -n 300 kestra-logs/kestra.log || true
   fi
 
   echo "stop Kestra container"

--- a/python/python-sdk/testApis/conftest.py
+++ b/python/python-sdk/testApis/conftest.py
@@ -1,18 +1,89 @@
 import os
+import re
 import sys
 
 import pytest
+import requests
 
-from kestrapy import Configuration, KestraClient
+from kestrapy import KestraClient
 
 # Make test_helpers importable from test files
 sys.path.insert(0, os.path.dirname(__file__))
 
+HOST = "http://localhost:9902"
+ADMIN_USERNAME = "root@root.com"
+ADMIN_PASSWORD = "Root!1234"
+MAIN_TENANT = "main"
+
+_CSRF_META_RE = re.compile(r'<meta name="csrf-token" content="([^"]+)">')
+
+
+def _setup_super_admin():
+    """Create the first super-admin and the main tenant.
+
+    Kestra 2.0 dropped the config-based super-admin bootstrap; the first
+    user is created through POST /api/v1/setup instead. A 405 means a user
+    already exists, which the CI container never hits since it starts from
+    an empty database on every run.
+    """
+    resp = requests.post(
+        f"{HOST}/api/v1/setup",
+        json={
+            "username": ADMIN_USERNAME,
+            "password": ADMIN_PASSWORD,
+            "tenant": {"id": MAIN_TENANT, "name": MAIN_TENANT},
+        },
+        timeout=30,
+    )
+    if resp.status_code not in (200, 405):
+        raise RuntimeError(f"setup failed: {resp.status_code} {resp.text[:2048]}")
+
+
+def _mint_api_token(username, password):
+    """Authenticate as the given user and return a freshly minted API token.
+
+    Kestra 2.0 dropped per-request HTTP Basic auth, so all on one cookie jar:
+      1. login -> JWT cookie;
+      2. load the UI so StaticFilter sets the csrfToken cookie (a static GET
+         emits no JWT Set-Cookie, so the session is untouched);
+      3. create the token — the JWT cookie authenticates, and the
+         X-CSRF-TOKEN header equals the server-set csrfToken cookie
+         (double-submit check).
+    """
+    session = requests.Session()
+
+    resp = session.post(
+        f"{HOST}/login",
+        json={"username": username, "password": password},
+        timeout=30,
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(f"login({username}) failed: {resp.status_code} {resp.text[:2048]}")
+
+    resp = session.get(f"{HOST}/ui/", timeout=30)
+    match = _CSRF_META_RE.search(resp.text)
+    if match is None:
+        raise RuntimeError(
+            f"no csrf token from /ui/ (status {resp.status_code}, html={'<html' in resp.text})"
+        )
+    csrf = match.group(1)
+
+    resp = session.post(
+        f"{HOST}/api/v1/me/api-tokens",
+        json={"name": "ci-token", "maxAge": "P1D"},
+        headers={"X-CSRF-TOKEN": csrf},
+        timeout=30,
+    )
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(f"create api token failed: {resp.status_code} {resp.text[:2048]}")
+    full_token = resp.json().get("fullToken")
+    if not full_token:
+        raise RuntimeError("api token response had no fullToken")
+    return full_token
+
 
 @pytest.fixture(scope="session")
 def client():
-    configuration = Configuration()
-    configuration.host = "http://localhost:9902"
-    configuration.username = "root@root.com"
-    configuration.password = "Root!1234"
-    return KestraClient(configuration)
+    _setup_super_admin()
+    token = _mint_api_token(ADMIN_USERNAME, ADMIN_PASSWORD)
+    return KestraClient(host=HOST, token=token)

--- a/python/python-sdk/testApis/conftest.py
+++ b/python/python-sdk/testApis/conftest.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 from test_helpers import (  # noqa: E402  (needs the sys.path insert above)
     TENANT,
     create_flow,
+    drain_registered_namespaces,
     log_flow_yaml,
     ns_filter,
     random_id,
@@ -109,22 +110,43 @@ def client():
 # ========================================================================
 
 
+def _purge_namespaces(client, namespaces):
+    """Best-effort deletion of everything a test namespace accumulated."""
+    for ns in namespaces:
+        for call in (
+            lambda: client.executions.delete_executions_by_query(TENANT, [ns_filter(ns)]),
+            lambda: client.flows.delete_flows_by_query(TENANT, [ns_filter(ns)]),
+            lambda: client.namespaces.delete_namespace(ns, TENANT),
+        ):
+            try:
+                call()
+            except Exception:
+                pass  # already deleted by the test itself, or non-empty — fine
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _namespace_gc(client):
+    """Purge namespaces minted via random_namespace() after each module.
+
+    Keeps live server-side namespace cardinality bounded to one module's
+    worth instead of accumulating ~300 namespaces over the run.
+    """
+    yield
+    _purge_namespaces(client, drain_registered_namespaces())
+
+
 @pytest.fixture(scope="session")
 def shared_flow(client):
     """(namespace, flow_id) of one log flow shared by the whole session.
 
     Tests may create additional executions of it, or additional flows inside
     its namespace, as long as they don't assert namespace-wide counts.
+    Deliberately NOT registered with the module GC — purged at session end.
     """
     ns, flow_id = random_id(), random_id()
     create_flow(client, log_flow_yaml(flow_id, ns))
     yield ns, flow_id
-    try:
-        client.executions.delete_executions_by_query(TENANT, [ns_filter(ns)])
-        client.flows.delete_flows_by_query(TENANT, [ns_filter(ns)])
-        client.namespaces.delete_namespace(ns, TENANT)
-    except Exception:
-        pass  # best-effort cleanup; the CI container is discarded anyway
+    _purge_namespaces(client, [ns])
 
 
 @pytest.fixture(scope="session")

--- a/python/python-sdk/testApis/conftest.py
+++ b/python/python-sdk/testApis/conftest.py
@@ -10,6 +10,15 @@ from kestrapy import KestraClient
 # Make test_helpers importable from test files
 sys.path.insert(0, os.path.dirname(__file__))
 
+from test_helpers import (  # noqa: E402  (needs the sys.path insert above)
+    TENANT,
+    create_flow,
+    log_flow_yaml,
+    ns_filter,
+    random_id,
+    wait_for_execution,
+)
+
 HOST = "http://localhost:9902"
 ADMIN_USERNAME = "root@root.com"
 ADMIN_PASSWORD = "Root!1234"
@@ -87,3 +96,54 @@ def client():
     _setup_super_admin()
     token = _mint_api_token(ADMIN_USERNAME, ADMIN_PASSWORD)
     return KestraClient(host=HOST, token=token)
+
+
+# ========================================================================
+# Shared server-side state
+#
+# Each random namespace/flow/execution a test creates is state the Kestra
+# container keeps until the end of the run, and the accumulated load is the
+# prime suspect for the JVM heap OOM that kills CI mid-suite. Tests that only
+# need *some* existing flow or execution share the ones below instead of
+# minting their own (~2 namespaces per test before).
+# ========================================================================
+
+
+@pytest.fixture(scope="session")
+def shared_flow(client):
+    """(namespace, flow_id) of one log flow shared by the whole session.
+
+    Tests may create additional executions of it, or additional flows inside
+    its namespace, as long as they don't assert namespace-wide counts.
+    """
+    ns, flow_id = random_id(), random_id()
+    create_flow(client, log_flow_yaml(flow_id, ns))
+    yield ns, flow_id
+    try:
+        client.executions.delete_executions_by_query(TENANT, [ns_filter(ns)])
+        client.flows.delete_flows_by_query(TENANT, [ns_filter(ns)])
+        client.namespaces.delete_namespace(ns, TENANT)
+    except Exception:
+        pass  # best-effort cleanup; the CI container is discarded anyway
+
+
+@pytest.fixture(scope="session")
+def succeeded_execution(client, shared_flow):
+    """(execution_id, ns, flow_id) of one SUCCESS run of the shared flow.
+
+    STRICTLY for read-only consumers: never delete it, change its state or
+    labels, or delete its logs — use fresh_execution for that.
+    """
+    ns, flow_id = shared_flow
+    resp = client.executions.create_execution(TENANT, ns, flow_id)
+    wait_for_execution(client, resp.id)
+    return resp.id, ns, flow_id
+
+
+@pytest.fixture
+def fresh_execution(client, shared_flow):
+    """A private SUCCESS run of the shared flow, safe to mutate or delete."""
+    ns, flow_id = shared_flow
+    resp = client.executions.create_execution(TENANT, ns, flow_id)
+    wait_for_execution(client, resp.id)
+    return resp.id, ns, flow_id

--- a/python/python-sdk/testApis/test_apps_api.py
+++ b/python/python-sdk/testApis/test_apps_api.py
@@ -9,6 +9,7 @@ from kestrapy import (
 from test_helpers import (
     TENANT,
     random_id,
+    random_namespace,
     log_flow_yaml,
     create_flow,
     ns_filter,
@@ -45,7 +46,7 @@ layout:
 
 def _create_app_with_flow(client):
     """Helper: create a flow and an app pointing to it. Returns (app, ns, flow_id)."""
-    ns = random_id()
+    ns = random_namespace()
     flow_id = random_id()
     create_flow(client, log_flow_yaml(flow_id, ns))
     app = client.apps.create_app(TENANT, _app_yaml(random_id(), ns, flow_id))
@@ -59,7 +60,7 @@ def _create_app_with_flow(client):
 
 class TestCRUD:
     def test_create_app_basic(self, client):
-        ns = random_id()
+        ns = random_namespace()
         flow_id = random_id()
         create_flow(client, log_flow_yaml(flow_id, ns))
 
@@ -75,7 +76,7 @@ class TestCRUD:
         assert result.uid == created.uid
 
     def test_update_app_basic(self, client):
-        ns = random_id()
+        ns = random_namespace()
         flow_id = random_id()
         app_id = random_id()
         create_flow(client, log_flow_yaml(flow_id, ns))
@@ -148,7 +149,7 @@ class TestSearch:
         assert any(app.uid == created.uid for app in result.results)
 
     def test_search_apps_with_flow_id(self, client):
-        ns = random_id()
+        ns = random_namespace()
         flow_id = random_id()
         create_flow(client, log_flow_yaml(flow_id, ns))
         created = client.apps.create_app(TENANT, _app_yaml(random_id(), ns, flow_id))
@@ -159,7 +160,7 @@ class TestSearch:
         assert any(app.uid == created.uid for app in result.results)
 
     def test_search_apps_with_query(self, client):
-        ns = random_id()
+        ns = random_namespace()
         flow_id = random_id()
         create_flow(client, log_flow_yaml(flow_id, ns))
 
@@ -174,7 +175,7 @@ class TestSearch:
             assert app_id1 in app.name
 
     def test_search_apps_with_sort(self, client):
-        ns = random_id()
+        ns = random_namespace()
         flow_id = random_id()
         create_flow(client, log_flow_yaml(flow_id, ns))
 
@@ -207,8 +208,8 @@ class TestSearch:
                     assert tag in app.tags
 
     def test_search_apps_with_filters(self, client):
-        ns1 = random_id()
-        ns2 = random_id()
+        ns1 = random_namespace()
+        ns2 = random_namespace()
         flow_id1 = random_id()
         flow_id2 = random_id()
         create_flow(client, log_flow_yaml(flow_id1, ns1))
@@ -223,7 +224,7 @@ class TestSearch:
             assert app.namespace == ns1
 
     def test_search_apps_from_catalog_with_filters(self, client):
-        ns = random_id()
+        ns = random_namespace()
         flow_id = random_id()
         create_flow(client, log_flow_yaml(flow_id, ns))
         client.apps.create_app(TENANT, _app_yaml(random_id(), ns, flow_id))

--- a/python/python-sdk/testApis/test_executions_api.py
+++ b/python/python-sdk/testApis/test_executions_api.py
@@ -13,14 +13,13 @@ from kestrapy import (
 from test_helpers import (
     TENANT,
     random_id,
-    log_flow_yaml,
     log_flow_yaml_with_labels,
     create_flow,
-    create_log_flow,
     ns_filter,
     flow_id_filter,
     state_filter,
     labels_filter,
+    wait_for_execution,
 )
 
 
@@ -31,24 +30,6 @@ from test_helpers import (
 
 def _execute_flow(client, ns, flow_id):
     return client.executions.create_execution(TENANT, ns, flow_id)
-
-
-def _execute_and_wait(client, ns, flow_id, timeout=30):
-    from kestrapy.exceptions import NotFoundException
-    resp = _execute_flow(client, ns, flow_id)
-    execution_id = resp.id
-    start = time.time()
-    while time.time() - start < timeout:
-        try:
-            exc = client.executions.execution(execution_id, TENANT)
-        except NotFoundException:
-            time.sleep(0.5)
-            continue
-        state = exc.state.current if hasattr(exc.state, "current") else None
-        if state in (StateType.SUCCESS, StateType.FAILED, StateType.WARNING, StateType.CANCELLED):
-            return execution_id
-        time.sleep(0.5)
-    raise TimeoutError(f"Execution {execution_id} did not complete within {timeout}s")
 
 
 def _failing_flow_yaml(flow_id, ns):
@@ -104,38 +85,63 @@ def _wait_for_state(client, execution_id, target_states, timeout=30):
 
 
 # ========================================================================
+# Module fixtures — special-purpose flows, all living in the shared
+# namespace so the module adds no namespace cardinality on the server.
+# ========================================================================
+
+
+@pytest.fixture(scope="module")
+def sleep_flow(client, shared_flow):
+    """(ns, flow_id) of a 10s-sleep flow, for kill/pause tests."""
+    ns, _ = shared_flow
+    flow_id = random_id()
+    create_flow(client, _sleep_flow_yaml(flow_id, ns))
+    return ns, flow_id
+
+
+@pytest.fixture(scope="module")
+def failing_flow(client, shared_flow):
+    """(ns, flow_id) of an always-failing flow, for restart tests."""
+    ns, _ = shared_flow
+    flow_id = random_id()
+    create_flow(client, _failing_flow_yaml(flow_id, ns))
+    return ns, flow_id
+
+
+@pytest.fixture(scope="module")
+def webhook_flow(client, shared_flow):
+    """(ns, flow_id, key) of a webhook-triggered flow."""
+    ns, _ = shared_flow
+    flow_id = random_id()
+    key = random_id()
+    create_flow(client, _webhook_flow_yaml(flow_id, ns, key))
+    time.sleep(0.5)
+    return ns, flow_id, key
+
+
+# ========================================================================
 # Create & Get
 # ========================================================================
 
 
 class TestCreateAndGet:
-    def test_create_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_create_execution_basic(self, client, shared_flow):
+        ns, flow_id = shared_flow
 
         result = _execute_flow(client, ns, flow_id)
         assert result is not None
         assert result.id is not None and result.id != ""
 
-    def test_execution_get_by_id(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_execution_get_by_id(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
-        created = _execute_flow(client, ns, flow_id)
-        time.sleep(0.5)
-
-        result = client.executions.execution(created.id, TENANT)
+        result = client.executions.execution(execution_id, TENANT)
         assert result is not None
-        assert result.id == created.id
+        assert result.id == execution_id
 
-    def test_execution_wait_for_completion(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_execution_wait_for_completion(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
-        execution_id = _execute_and_wait(client, ns, flow_id)
         result = client.executions.execution(execution_id, TENANT)
         assert result.state.current == StateType.SUCCESS
 
@@ -156,21 +162,15 @@ class TestSearchExecutions:
         assert result is not None
         assert len(result.get("results", [])) <= 2
 
-    def test_search_executions_by_flow_id_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        _execute_and_wait(client, ns, flow_id)
+    def test_search_executions_by_flow_id_basic(self, client, succeeded_execution):
+        _, ns, flow_id = succeeded_execution
 
         result = client.executions.search_executions_by_flow_id(TENANT, ns, flow_id, 1, 10)
         assert result is not None
         assert len(result.get("results", [])) > 0
 
-    def test_search_executions_with_namespace_filter(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        _execute_and_wait(client, ns, flow_id)
+    def test_search_executions_with_namespace_filter(self, client, succeeded_execution):
+        _, ns, _ = succeeded_execution
 
         # Poll until search returns results
         deadline = time.time() + 30
@@ -186,11 +186,8 @@ class TestSearchExecutions:
         for exc in results:
             assert exc["namespace"] == ns
 
-    def test_search_executions_with_flow_id_filter(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        _execute_and_wait(client, ns, flow_id)
+    def test_search_executions_with_flow_id_filter(self, client, succeeded_execution):
+        _, _, flow_id = succeeded_execution
 
         deadline = time.time() + 30
         results = []
@@ -205,11 +202,8 @@ class TestSearchExecutions:
         for exc in results:
             assert exc["flowId"] == flow_id
 
-    def test_search_executions_with_state_filter(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        _execute_and_wait(client, ns, flow_id)
+    def test_search_executions_with_state_filter(self, client, succeeded_execution):
+        _, ns, _ = succeeded_execution
 
         deadline = time.time() + 30
         results = []
@@ -224,25 +218,16 @@ class TestSearchExecutions:
         for exc in results:
             assert exc["state"]["current"] == "SUCCESS"
 
-    def test_search_executions_with_labels(self, client):
-        ns = random_id()
+    def test_search_executions_with_labels(self, client, shared_flow):
+        ns, _ = shared_flow
         flow_id = random_id()
         create_flow(client, log_flow_yaml_with_labels(flow_id, ns, {"team": "sdk", "env": "test"}))
-        client.executions.create_execution(TENANT, ns, flow_id, labels=["team:sdk", "env:test"])
-
-        # Wait for execution to terminate
-        deadline = time.time() + 30
-        while time.time() < deadline:
-            resp = client.executions.search_executions(TENANT, 1, 10, None, [ns_filter(ns)])
-            results = resp.get("results", [])
-            if results:
-                state = results[0].get("state", {}).get("current")
-                if state in ("SUCCESS", "FAILED", "WARNING", "CANCELLED"):
-                    break
-            time.sleep(0.5)
+        resp = client.executions.create_execution(TENANT, ns, flow_id, labels=["team:sdk", "env:test"])
+        wait_for_execution(client, resp.id)
 
         # Search with label filter
         deadline = time.time() + 30
+        results = []
         while time.time() < deadline:
             resp = client.executions.search_executions(TENANT, 1, 10, None, [labels_filter({"team": "sdk"}), ns_filter(ns)])
             results = resp.get("results", [])
@@ -252,11 +237,8 @@ class TestSearchExecutions:
 
         assert len(results) > 0
 
-    def test_search_executions_multiple_filters(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        _execute_and_wait(client, ns, flow_id)
+    def test_search_executions_multiple_filters(self, client, succeeded_execution):
+        _, ns, flow_id = succeeded_execution
 
         deadline = time.time() + 30
         results = []
@@ -280,13 +262,11 @@ class TestSearchExecutions:
         assert result.get("total", 0) == 0
         assert len(result.get("results", [])) == 0
 
-    def test_search_executions_with_sort(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        _execute_and_wait(client, ns, flow_id)
-        time.sleep(0.5)
-        _execute_and_wait(client, ns, flow_id)
+    def test_search_executions_with_sort(self, client, succeeded_execution):
+        _, ns, flow_id = succeeded_execution
+        # The shared execution is the first; add a second so ordering is testable.
+        resp = client.executions.create_execution(TENANT, ns, flow_id)
+        wait_for_execution(client, resp.id)
 
         deadline = time.time() + 30
         results = []
@@ -308,30 +288,22 @@ class TestSearchExecutions:
 
 
 class TestGraphAndFlow:
-    def test_execution_flow_graph_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_execution_flow_graph_basic(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         result = client.executions.execution_flow_graph(execution_id, TENANT)
         assert result is not None
         assert len(result.nodes) > 0
 
-    def test_flow_from_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_flow_from_execution_basic(self, client, succeeded_execution):
+        _, ns, flow_id = succeeded_execution
 
         result = client.executions.flow_from_execution(TENANT, ns, flow_id)
         assert result is not None
         assert result.id == flow_id
 
-    def test_flow_from_execution_by_id_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_flow_from_execution_by_id_basic(self, client, succeeded_execution):
+        execution_id, _, flow_id = succeeded_execution
 
         result = client.executions.flow_from_execution_by_id(execution_id, TENANT)
         assert result is not None
@@ -344,20 +316,14 @@ class TestGraphAndFlow:
 
 
 class TestDeleteExecution:
-    def test_delete_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_delete_execution_basic(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         # Should not raise
         client.executions.delete_execution(execution_id, TENANT)
 
-    def test_delete_executions_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_delete_executions_by_ids_basic(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         result = client.executions.delete_executions_by_ids(TENANT, [execution_id])
         assert result is not None
@@ -369,10 +335,8 @@ class TestDeleteExecution:
 
 
 class TestKillExecution:
-    def test_kill_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, _sleep_flow_yaml(flow_id, ns))
+    def test_kill_execution_basic(self, client, sleep_flow):
+        ns, flow_id = sleep_flow
 
         resp = _execute_flow(client, ns, flow_id)
         execution_id = resp.id
@@ -386,10 +350,8 @@ class TestKillExecution:
 
         _wait_for_state(client, execution_id, [StateType.KILLED, StateType.CANCELLED])
 
-    def test_kill_executions_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, _sleep_flow_yaml(flow_id, ns))
+    def test_kill_executions_by_ids_basic(self, client, sleep_flow):
+        ns, flow_id = sleep_flow
 
         resp1 = _execute_flow(client, ns, flow_id)
         resp2 = _execute_flow(client, ns, flow_id)
@@ -407,21 +369,15 @@ class TestKillExecution:
 
 
 class TestLabels:
-    def test_set_labels_on_terminated_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_set_labels_on_terminated_execution_basic(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         label = Label(key="env", value="test")
         result = client.executions.set_labels_on_terminated_execution(execution_id, TENANT, [label])
         assert result is not None
 
-    def test_set_labels_on_terminated_executions_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_set_labels_on_terminated_executions_by_ids_basic(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         label = Label(key="team", value="platform")
         request = ExecutionControllerSetLabelsByIdsRequest(
@@ -439,11 +395,8 @@ class TestLabels:
 
 
 class TestEvalExpression:
-    def test_eval_expression_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_eval_expression_basic(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         result = client.executions.eval_expression(execution_id, TENANT, "{{ execution.id }}")
         assert result is not None
@@ -456,31 +409,22 @@ class TestEvalExpression:
 
 
 class TestReplay:
-    def test_replay_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_replay_execution_basic(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         result = client.executions.replay_execution(execution_id, TENANT)
         assert result is not None
         assert result.id != execution_id
 
-    def test_replay_execution_with_inputs_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_replay_execution_with_inputs_basic(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         result = client.executions.replay_execution_with_inputs(execution_id, TENANT)
         assert result is not None
         assert result.id is not None and result.id != ""
 
-    def test_replay_executions_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_replay_executions_by_ids_basic(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         # Should not raise
         client.executions.replay_executions_by_ids(TENANT, [execution_id])
@@ -496,11 +440,8 @@ class TestReplay:
 
 
 class TestLatestExecutions:
-    def test_latest_executions_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        _execute_and_wait(client, ns, flow_id)
+    def test_latest_executions_basic(self, client, succeeded_execution):
+        _, ns, flow_id = succeeded_execution
 
         flow_filter = ExecutionRepositoryInterfaceFlowFilter(namespace=ns, id=flow_id)
         result = client.executions.latest_executions(TENANT, [flow_filter])
@@ -515,10 +456,8 @@ class TestLatestExecutions:
 
 
 class TestRestart:
-    def test_restart_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, _failing_flow_yaml(flow_id, ns))
+    def test_restart_execution_basic(self, client, failing_flow):
+        ns, flow_id = failing_flow
 
         resp = _execute_flow(client, ns, flow_id)
         execution_id = resp.id
@@ -529,10 +468,8 @@ class TestRestart:
         assert result is not None
         assert result.id is not None and result.id != ""
 
-    def test_restart_executions_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, _failing_flow_yaml(flow_id, ns))
+    def test_restart_executions_by_ids_basic(self, client, failing_flow):
+        ns, flow_id = failing_flow
 
         resp = _execute_flow(client, ns, flow_id)
         _wait_for_state(client, resp.id, [StateType.FAILED])
@@ -551,21 +488,15 @@ class TestRestart:
 
 
 class TestUpdateExecutionStatus:
-    def test_update_execution_status_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_update_execution_status_basic(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         result = client.executions.update_execution_status(execution_id, StateType.WARNING, TENANT)
         assert result is not None
         assert result.id == execution_id
 
-    def test_update_executions_status_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_update_executions_status_by_ids_basic(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         # Should not raise
         client.executions.update_executions_status_by_ids(TENANT, StateType.WARNING, [execution_id])
@@ -581,12 +512,8 @@ class TestUpdateExecutionStatus:
 
 
 class TestWebhooks:
-    def test_trigger_execution_by_get_webhook_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        key = random_id()
-        create_flow(client, _webhook_flow_yaml(flow_id, ns, key))
-        time.sleep(0.5)
+    def test_trigger_execution_by_get_webhook_basic(self, client, webhook_flow):
+        ns, flow_id, key = webhook_flow
 
         result = client.executions.trigger_execution_by_get_webhook(TENANT, ns, flow_id, key)
         assert result is not None
@@ -594,17 +521,13 @@ class TestWebhooks:
         assert result.flow_id == flow_id
         assert result.namespace == ns
 
-    def test_trigger_execution_by_get_webhook_with_path_routes(self, client):
+    def test_trigger_execution_by_get_webhook_with_path_routes(self, client, webhook_flow):
         # The webhook trigger in our test fixture doesn't declare a `path`
         # config, so the path-suffixed URL doesn't match any registered
         # trigger and the server replies 404. That 404 (rather than a
         # connection error or unknown-route 405) confirms the SDK reached
         # the path-with-suffix controller correctly.
-        ns = random_id()
-        flow_id = random_id()
-        key = random_id()
-        create_flow(client, _webhook_flow_yaml(flow_id, ns, key))
-        time.sleep(0.5)
+        ns, flow_id, key = webhook_flow
 
         try:
             result = client.executions.trigger_execution_by_get_webhook_with_path(
@@ -615,12 +538,8 @@ class TestWebhooks:
         except ApiException as e:
             assert e.status == 404
 
-    def test_trigger_execution_by_post_webhook_with_path_routes(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        key = random_id()
-        create_flow(client, _webhook_flow_yaml(flow_id, ns, key))
-        time.sleep(0.5)
+    def test_trigger_execution_by_post_webhook_with_path_routes(self, client, webhook_flow):
+        ns, flow_id, key = webhook_flow
 
         try:
             result = client.executions.trigger_execution_by_post_webhook_with_path(
@@ -630,12 +549,8 @@ class TestWebhooks:
         except ApiException as e:
             assert e.status == 404
 
-    def test_trigger_execution_by_put_webhook_with_path_routes(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        key = random_id()
-        create_flow(client, _webhook_flow_yaml(flow_id, ns, key))
-        time.sleep(0.5)
+    def test_trigger_execution_by_put_webhook_with_path_routes(self, client, webhook_flow):
+        ns, flow_id, key = webhook_flow
 
         try:
             result = client.executions.trigger_execution_by_put_webhook_with_path(
@@ -652,15 +567,12 @@ class TestWebhooks:
 
 
 class TestFiles:
-    def test_download_file_from_execution_invalid_uri_raises(self, client):
+    def test_download_file_from_execution_invalid_uri_raises(self, client, succeeded_execution):
         # The hello-world flow doesn't produce files, so we exercise the SDK
         # wiring by passing a clearly invalid internal storage URI. The
         # server should reject it with a 4xx, confirming path + params
         # are routed correctly.
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+        execution_id, _, _ = succeeded_execution
 
         with pytest.raises(ApiException) as exc_info:
             client.executions.download_file_from_execution(
@@ -668,11 +580,8 @@ class TestFiles:
             )
         assert exc_info.value.status in (400, 404, 422, 500)
 
-    def test_file_metadatas_from_execution_invalid_uri_raises(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_file_metadatas_from_execution_invalid_uri_raises(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         with pytest.raises(ApiException) as exc_info:
             client.executions.file_metadatas_from_execution(
@@ -687,30 +596,24 @@ class TestFiles:
 
 
 class TestCreateExecutionOptions:
-    def test_create_execution_with_labels(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_create_execution_with_labels(self, client, shared_flow):
+        ns, flow_id = shared_flow
 
         resp = client.executions.create_execution(
             TENANT, ns, flow_id, labels=["env:test", "tier:gold"],
         )
         assert resp is not None
 
-    def test_create_execution_with_revision(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_create_execution_with_revision(self, client, shared_flow):
+        ns, flow_id = shared_flow
 
         resp = client.executions.create_execution(
             TENANT, ns, flow_id, revision=1,
         )
         assert resp is not None
 
-    def test_create_execution_with_schedule_date(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_create_execution_with_schedule_date(self, client, shared_flow):
+        ns, flow_id = shared_flow
 
         # Schedule a few seconds in the future — server stores the
         # scheduledDate without executing immediately.
@@ -727,11 +630,8 @@ class TestCreateExecutionOptions:
 
 
 class TestDeleteExecutionFlags:
-    def test_delete_execution_with_all_purge_flags(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_delete_execution_with_all_purge_flags(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         # Should not raise
         client.executions.delete_execution(
@@ -739,11 +639,8 @@ class TestDeleteExecutionFlags:
             delete_logs=True, delete_metrics=True, delete_storage=True,
         )
 
-    def test_delete_executions_by_ids_with_include_non_terminated(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_delete_executions_by_ids_with_include_non_terminated(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         result = client.executions.delete_executions_by_ids(
             TENANT, ids=[execution_id],
@@ -754,10 +651,8 @@ class TestDeleteExecutionFlags:
 
 
 class TestKillCascade:
-    def test_kill_execution_with_cascade_flag(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, _sleep_flow_yaml(flow_id, ns))
+    def test_kill_execution_with_cascade_flag(self, client, sleep_flow):
+        ns, flow_id = sleep_flow
         resp = _execute_flow(client, ns, flow_id)
         execution_id = resp.id
         _wait_for_state(client, execution_id, [StateType.RUNNING])
@@ -770,10 +665,8 @@ class TestKillCascade:
 
 
 class TestRestartRevision:
-    def test_restart_execution_with_revision(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, _failing_flow_yaml(flow_id, ns))
+    def test_restart_execution_with_revision(self, client, failing_flow):
+        ns, flow_id = failing_flow
         resp = _execute_flow(client, ns, flow_id)
         execution_id = resp.id
         _wait_for_state(client, execution_id, [StateType.FAILED])
@@ -786,10 +679,8 @@ class TestRestartRevision:
 
 
 class TestFollowDependenciesFlags:
-    def test_follow_dependencies_execution_with_destination_only(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_follow_dependencies_execution_with_destination_only(self, client, shared_flow):
+        ns, flow_id = shared_flow
         resp = _execute_flow(client, ns, flow_id)
 
         events = []
@@ -843,11 +734,8 @@ class TestNotFound:
 
 
 class TestUpdateTaskRunState:
-    def test_update_task_run_state_unknown_taskrun(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_update_task_run_state_unknown_taskrun(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         # An unknown taskRunId on a completed execution should not change
         # state; the server returns 409 ("if the task run state cannot be
@@ -890,10 +778,8 @@ class TestDeleteByQuery:
 
 
 class TestPauseResume:
-    def test_pause_execution_not_paused(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, _sleep_flow_yaml(flow_id, ns))
+    def test_pause_execution_not_paused(self, client, sleep_flow):
+        ns, flow_id = sleep_flow
 
         resp = _execute_flow(client, ns, flow_id)
         execution_id = resp.id
@@ -931,10 +817,8 @@ class TestPauseResume:
 
 
 class TestRestartBulk:
-    def test_restart_executions_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, _failing_flow_yaml(flow_id, ns))
+    def test_restart_executions_by_ids_basic(self, client, failing_flow):
+        ns, flow_id = failing_flow
 
         resp = _execute_flow(client, ns, flow_id)
         execution_id = resp.id
@@ -954,21 +838,15 @@ class TestRestartBulk:
 
 
 class TestReplayBulk:
-    def test_replay_execution_with_inputs_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_replay_execution_with_inputs_basic(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         result = client.executions.replay_execution_with_inputs(execution_id, TENANT)
         assert result is not None
         assert result.id is not None and result.id != ""
 
-    def test_replay_executions_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_replay_executions_by_ids_basic(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         # Should not raise
         client.executions.replay_executions_by_ids(TENANT, [execution_id])
@@ -984,11 +862,8 @@ class TestReplayBulk:
 
 
 class TestForceRun:
-    def test_force_run_execution_not_queued(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_force_run_execution_not_queued(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         # Force-run on a terminated execution should fail (409)
         with pytest.raises(Exception):
@@ -1009,11 +884,8 @@ class TestForceRun:
 
 
 class TestUnqueue:
-    def test_unqueue_execution_not_queued(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_unqueue_execution_not_queued(self, client, succeeded_execution):
+        execution_id, _, _ = succeeded_execution
 
         with pytest.raises(Exception):
             client.executions.unqueue_execution(execution_id, TENANT)
@@ -1045,11 +917,8 @@ class TestLabelsByQuery:
 
 
 class TestChangeStatusBulk:
-    def test_update_executions_status_by_ids_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
-        execution_id = _execute_and_wait(client, ns, flow_id)
+    def test_update_executions_status_by_ids_basic(self, client, fresh_execution):
+        execution_id, _, _ = fresh_execution
 
         # Should not raise
         client.executions.update_executions_status_by_ids(TENANT, StateType.WARNING, [execution_id])
@@ -1065,10 +934,8 @@ class TestChangeStatusBulk:
 
 
 class TestStreaming:
-    def test_follow_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_follow_execution_basic(self, client, shared_flow):
+        ns, flow_id = shared_flow
 
         resp = _execute_flow(client, ns, flow_id)
 
@@ -1091,10 +958,8 @@ class TestStreaming:
         last = events[-1]
         assert last.state is not None
 
-    def test_follow_dependencies_execution_basic(self, client):
-        ns = random_id()
-        flow_id = random_id()
-        create_flow(client, log_flow_yaml(flow_id, ns))
+    def test_follow_dependencies_execution_basic(self, client, shared_flow):
+        ns, flow_id = shared_flow
 
         resp = _execute_flow(client, ns, flow_id)
 

--- a/python/python-sdk/testApis/test_executions_api.py
+++ b/python/python-sdk/testApis/test_executions_api.py
@@ -939,12 +939,16 @@ class TestStreaming:
 
         resp = _execute_flow(client, ns, flow_id)
 
-        events = []
+        # Only the last frame is asserted on — keep a counter instead of
+        # accumulating every SSE frame.
+        event_count = 0
+        last = None
         deadline = time.time() + 15
         stream = client.executions.follow_execution(resp.id, TENANT)
         try:
             for event in stream:
-                events.append(event)
+                event_count += 1
+                last = event
                 if time.time() > deadline:
                     break
                 if hasattr(event, "state") and event.state is not None:
@@ -954,8 +958,7 @@ class TestStreaming:
         finally:
             stream.close()
 
-        assert len(events) > 0
-        last = events[-1]
+        assert event_count > 0
         assert last.state is not None
 
     def test_follow_dependencies_execution_basic(self, client, shared_flow):

--- a/python/python-sdk/testApis/test_files_api.py
+++ b/python/python-sdk/testApis/test_files_api.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from kestrapy.exceptions import ApiException
-from test_helpers import TENANT, random_id, log_flow_yaml, create_flow
+from test_helpers import TENANT, random_id, random_namespace, log_flow_yaml, create_flow
 
 
 # ========================================================================
@@ -24,7 +24,7 @@ def make_temp_file(name, content):
 # ========================================================================
 
 def test_create_namespace_directory_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     # Should not raise
@@ -32,7 +32,7 @@ def test_create_namespace_directory_basic(client):
 
 
 def test_list_namespace_directory_files_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     tmp = make_temp_file("hello", "world")
@@ -48,7 +48,7 @@ def test_list_namespace_directory_files_basic(client):
 
 
 def test_list_namespace_directory_files_empty(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     files = client.files.list_namespace_directory_files(ns, TENANT)
@@ -60,7 +60,7 @@ def test_list_namespace_directory_files_empty(client):
 # ========================================================================
 
 def test_create_and_get_namespace_file(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     tmp = make_temp_file("myfile", "content here")
@@ -76,7 +76,7 @@ def test_create_and_get_namespace_file(client):
 
 
 def test_file_metadatas_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     tmp = make_temp_file("meta", "some data")
@@ -91,7 +91,7 @@ def test_file_metadatas_basic(client):
 
 
 def test_file_revisions_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     tmp = make_temp_file("rev", "version 1")
@@ -110,7 +110,7 @@ def test_file_revisions_basic(client):
 # ========================================================================
 
 def test_move_file_directory_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     tmp = make_temp_file("move", "data")
@@ -125,7 +125,7 @@ def test_move_file_directory_basic(client):
 
 
 def test_delete_file_directory_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     tmp = make_temp_file("del", "data")
@@ -144,7 +144,7 @@ def test_delete_file_directory_basic(client):
 # ========================================================================
 
 def test_search_namespace_files_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     tmp = make_temp_file("search", "data")
@@ -160,7 +160,7 @@ def test_search_namespace_files_basic(client):
 
 
 def test_export_namespace_files_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     tmp = make_temp_file("export", "data")

--- a/python/python-sdk/testApis/test_flows_api.py
+++ b/python/python-sdk/testApis/test_flows_api.py
@@ -17,6 +17,7 @@ from kestrapy import (
 from test_helpers import (
     TENANT,
     random_id,
+    random_namespace,
     log_flow_yaml,
     log_flow_yaml_with_description,
     log_flow_yaml_with_labels,
@@ -94,7 +95,7 @@ class TestGetFlow:
 
     def test_with_specific_revision(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         v1 = create_flow(client, log_flow_yaml_with_description(fid, ns, "version-one"))
         assert v1.revision == 1
 
@@ -128,7 +129,7 @@ class TestGetFlow:
 
     def test_revision_and_allow_deleted(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml_with_description(fid, ns, "v1"))
         client.flows.update_flow(ns, fid, TENANT, log_flow_yaml_with_description(fid, ns, "v2"))
         client.flows.delete_flow(ns, fid, TENANT)
@@ -156,7 +157,7 @@ class TestGetFlow:
 class TestUpdateFlow:
     def test_change_description(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         created = create_flow(client, log_flow_yaml_with_description(fid, ns, "original"))
 
         updated = client.flows.update_flow(
@@ -168,7 +169,7 @@ class TestUpdateFlow:
 
     def test_add_task(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         created = create_flow(client, log_flow_yaml(fid, ns))
         assert len(created.tasks) == 1
 
@@ -211,7 +212,7 @@ class TestDeleteFlowsByIds:
         assert resp.count == 1
 
     def test_multiple(self, client):
-        ns = random_id()
+        ns = random_namespace()
         f1 = create_flow(client, log_flow_yaml(random_id(), ns))
         f2 = create_flow(client, log_flow_yaml(random_id(), ns))
         f3 = create_flow(client, log_flow_yaml(random_id(), ns))
@@ -234,7 +235,7 @@ class TestDeleteFlowsByIds:
 
 class TestDeleteFlowsByQuery:
     def test_namespace_filter(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
         create_flow(client, log_flow_yaml(random_id(), ns))
 
@@ -242,7 +243,7 @@ class TestDeleteFlowsByQuery:
         assert resp.count == 2
 
     def test_flow_id_filter(self, client):
-        ns = random_id()
+        ns = random_namespace()
         target = create_flow(client, log_flow_yaml(random_id(), ns))
         create_flow(client, log_flow_yaml(random_id(), ns))
 
@@ -301,7 +302,7 @@ class TestDisableEnableByIds:
 
 class TestDisableEnableByQuery:
     def test_disable_namespace_filter(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
         create_flow(client, log_flow_yaml(random_id(), ns))
 
@@ -309,7 +310,7 @@ class TestDisableEnableByQuery:
         assert resp.count == 2
 
     def test_enable_after_disable(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
 
         filters = [ns_filter(ns)]
@@ -327,7 +328,7 @@ class TestDisableEnableByQuery:
 class TestBulkUpdateFlows:
     def test_update_description(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml_with_description(fid, ns, "before"))
 
         result = client.flows.bulk_update_flows(
@@ -336,7 +337,7 @@ class TestBulkUpdateFlows:
         assert result is not None and len(result) > 0
 
     def test_delete_true_removes_stale_flows(self, client):
-        ns = random_id()
+        ns = random_namespace()
         id1 = random_id()
         id2 = random_id()
         create_flow(client, log_flow_yaml(id1, ns))
@@ -353,7 +354,7 @@ class TestBulkUpdateFlows:
         assert remaining[0].id == id1
 
     def test_delete_false_keeps_stale_flows(self, client):
-        ns = random_id()
+        ns = random_namespace()
         id1 = random_id()
         id2 = random_id()
         create_flow(client, log_flow_yaml(id1, ns))
@@ -369,7 +370,7 @@ class TestBulkUpdateFlows:
         assert len(remaining) == 2
 
     def test_with_namespace_and_allow_child(self, client):
-        ns = random_id()
+        ns = random_namespace()
         fid = random_id()
         create_flow(client, log_flow_yaml(fid, ns))
 
@@ -388,7 +389,7 @@ class TestBulkUpdateFlows:
 class TestListFlowRevisions:
     def test_multiple_revisions(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml_with_description(fid, ns, "v1"))
         client.flows.update_flow(ns, fid, TENANT, log_flow_yaml_with_description(fid, ns, "v2"))
         client.flows.update_flow(ns, fid, TENANT, log_flow_yaml_with_description(fid, ns, "v3"))
@@ -402,7 +403,7 @@ class TestListFlowRevisions:
 
     def test_allow_delete_true(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(fid, ns))
         client.flows.delete_flow(ns, fid, TENANT)
         time.sleep(0.2)
@@ -413,7 +414,7 @@ class TestListFlowRevisions:
 
     def test_allow_delete_false_excludes_deleted(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(fid, ns))
         client.flows.delete_flow(ns, fid, TENANT)
         time.sleep(0.2)
@@ -431,7 +432,7 @@ class TestListFlowRevisions:
 class TestDeleteRevisions:
     def test_single(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml_with_description(fid, ns, "v1"))
         client.flows.update_flow(ns, fid, TENANT, log_flow_yaml_with_description(fid, ns, "v2"))
         client.flows.update_flow(ns, fid, TENANT, log_flow_yaml_with_description(fid, ns, "v3"))
@@ -446,7 +447,7 @@ class TestDeleteRevisions:
 
     def test_multiple(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml_with_description(fid, ns, "v1"))
         client.flows.update_flow(ns, fid, TENANT, log_flow_yaml_with_description(fid, ns, "v2"))
         client.flows.update_flow(ns, fid, TENANT, log_flow_yaml_with_description(fid, ns, "v3"))
@@ -465,7 +466,7 @@ class TestDeleteRevisions:
 
 class TestSearchFlows:
     def test_by_namespace(self, client):
-        ns = random_id()
+        ns = random_namespace()
         f = create_flow(client, log_flow_yaml(random_id(), ns))
 
         result = client.flows.search_flows(TENANT, page=1, size=10, filters=[ns_filter(ns)])
@@ -483,7 +484,7 @@ class TestSearchFlows:
         assert result.results[0].namespace == f.namespace
 
     def test_by_query(self, client):
-        ns = random_id()
+        ns = random_namespace()
         fid = random_id()
         create_flow(client, log_flow_yaml(fid, ns))
 
@@ -493,7 +494,7 @@ class TestSearchFlows:
         assert result.total == 1
 
     def test_multiple_filters(self, client):
-        ns = random_id()
+        ns = random_namespace()
         f = create_flow(client, log_flow_yaml(random_id(), ns))
 
         result = client.flows.search_flows(
@@ -502,7 +503,7 @@ class TestSearchFlows:
         assert result.total == 1
 
     def test_pagination(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
         create_flow(client, log_flow_yaml(random_id(), ns))
         create_flow(client, log_flow_yaml(random_id(), ns))
@@ -517,7 +518,7 @@ class TestSearchFlows:
         assert len(page2.results) == 1
 
     def test_sort_asc(self, client):
-        ns = random_id()
+        ns = random_namespace()
         id1 = "aaa" + random_id()
         id2 = "zzz" + random_id()
         create_flow(client, log_flow_yaml(id2, ns))
@@ -531,7 +532,7 @@ class TestSearchFlows:
         assert result.results[1].id == id2
 
     def test_sort_desc(self, client):
-        ns = random_id()
+        ns = random_namespace()
         id1 = "aaa" + random_id()
         id2 = "zzz" + random_id()
         create_flow(client, log_flow_yaml(id2, ns))
@@ -552,7 +553,7 @@ class TestSearchFlows:
         assert len(result.results) == 0
 
     def test_with_labels(self, client):
-        ns = random_id()
+        ns = random_namespace()
         fid = random_id()
         create_flow(client, log_flow_yaml_with_labels(fid, ns, {"team": "sdk", "env": "test"}))
 
@@ -563,7 +564,7 @@ class TestSearchFlows:
         assert result.results[0].id == fid
 
     def test_with_labels_no_match(self, client):
-        ns = random_id()
+        ns = random_namespace()
         fid = random_id()
         create_flow(client, log_flow_yaml_with_labels(fid, ns, {"team": "sdk"}))
 
@@ -588,7 +589,7 @@ class TestSearchFlowsBySourceCode:
         assert any(r.model is not None and r.model.id == f.id for r in result.results)
 
     def test_with_namespace(self, client):
-        ns = random_id()
+        ns = random_namespace()
         f = create_flow(client, log_flow_yaml(random_id(), ns))
 
         result = client.flows.search_flows_by_source_code(
@@ -597,7 +598,7 @@ class TestSearchFlowsBySourceCode:
         assert result.total >= 1
 
     def test_with_query_and_namespace(self, client):
-        ns = random_id()
+        ns = random_namespace()
         id1 = random_id()
         id2 = random_id()
         create_flow(client, log_flow_yaml_with_description(id1, ns, "Hello World unique marker"))
@@ -611,7 +612,7 @@ class TestSearchFlowsBySourceCode:
             assert r.model is not None
 
     def test_with_sort(self, client):
-        ns = random_id()
+        ns = random_namespace()
         id1 = "aaa" + random_id()
         id2 = "zzz" + random_id()
         create_flow(client, log_flow_yaml(id1, ns))
@@ -628,7 +629,7 @@ class TestSearchFlowsBySourceCode:
         assert idx2 > idx1
 
     def test_by_description(self, client):
-        ns = random_id()
+        ns = random_namespace()
         unique_desc = "unique_" + random_id()
         create_flow(client, log_flow_yaml_with_description(random_id(), ns, unique_desc))
 
@@ -643,7 +644,7 @@ class TestSearchFlowsBySourceCode:
 
 class TestListFlowsByNamespace:
     def test_single(self, client):
-        ns = random_id()
+        ns = random_namespace()
         f = create_flow(client, log_flow_yaml(random_id(), ns))
 
         result = client.flows.list_flows_by_namespace(ns, TENANT)
@@ -652,7 +653,7 @@ class TestListFlowsByNamespace:
         assert result[0].id == f.id
 
     def test_multiple(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
         create_flow(client, log_flow_yaml(random_id(), ns))
         create_flow(client, log_flow_yaml(random_id(), ns))
@@ -672,7 +673,7 @@ class TestListFlowsByNamespace:
 
 class TestListDistinctNamespaces:
     def test_contains_created(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
 
         namespaces = client.flows.list_distinct_namespaces(TENANT)
@@ -695,14 +696,14 @@ class TestListDistinctNamespaces:
 
 class TestUpdateFlowsInNamespace:
     def test_basic(self, client):
-        ns = random_id()
+        ns = random_namespace()
         fid = random_id()
 
         result = client.flows.update_flows_in_namespace(ns, TENANT, log_flow_yaml(fid, ns), delete=False, override=False)
         assert result is not None and len(result) > 0
 
     def test_delete_true(self, client):
-        ns = random_id()
+        ns = random_namespace()
         id1 = random_id()
         id2 = random_id()
         create_flow(client, log_flow_yaml(id1, ns))
@@ -716,7 +717,7 @@ class TestUpdateFlowsInNamespace:
         assert remaining[0].id == id1
 
     def test_delete_false(self, client):
-        ns = random_id()
+        ns = random_namespace()
         id1 = random_id()
         id2 = random_id()
         create_flow(client, log_flow_yaml(id1, ns))
@@ -729,7 +730,7 @@ class TestUpdateFlowsInNamespace:
         assert len(remaining) == 2
 
     def test_override_true(self, client):
-        target_ns = random_id()
+        target_ns = random_namespace()
         fid = random_id()
 
         result = client.flows.update_flows_in_namespace(
@@ -756,7 +757,7 @@ class TestExportImport:
         assert zip_bytes is not None and len(zip_bytes) > 10
 
     def test_export_by_ids_multiple(self, client):
-        ns = random_id()
+        ns = random_namespace()
         f1 = create_flow(client, log_flow_yaml(random_id(), ns))
         f2 = create_flow(client, log_flow_yaml(random_id(), ns))
 
@@ -773,7 +774,7 @@ class TestExportImport:
         assert len(double_zip) > len(single_zip)
 
     def test_export_by_query_namespace_filter(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
 
         zip_bytes = client.flows.export_flows_by_query(TENANT, [ns_filter(ns)])
@@ -782,7 +783,7 @@ class TestExportImport:
     def test_import_yaml_file(self, client):
         id1 = random_id()
         id2 = random_id()
-        ns = random_id()
+        ns = random_namespace()
         yaml = log_flow_yaml(id1, ns) + "\n---\n" + log_flow_yaml(id2, ns)
 
         result = client.flows.import_flows(TENANT, fail_on_error=False, file_content=yaml.encode("utf-8"))
@@ -793,7 +794,7 @@ class TestExportImport:
         assert len(flows) >= 2
 
     def test_import_export_then_reimport(self, client):
-        ns = random_id()
+        ns = random_namespace()
         f = create_flow(client, log_flow_yaml(random_id(), ns))
 
         zip_bytes = client.flows.export_flows_by_ids(
@@ -828,7 +829,7 @@ class TestFlowGraph:
 
     def test_with_revision(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(fid, ns))
         client.flows.update_flow(ns, fid, TENANT, two_task_flow_yaml(fid, ns))
 
@@ -850,7 +851,7 @@ class TestFlowGraph:
 
     def test_from_source(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         yaml = log_flow_yaml(fid, ns)
 
         graph = client.flows.generate_flow_graph_from_source(TENANT, yaml)
@@ -872,7 +873,7 @@ class TestFlowGraph:
 
     def test_from_source_with_subflows(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         yaml = log_flow_yaml(fid, ns)
 
         graph = client.flows.generate_flow_graph_from_source(
@@ -908,7 +909,7 @@ class TestFlowDependencies:
         assert deps.nodes is not None
 
     def test_from_namespace(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
 
         deps = client.flows.flow_dependencies_from_namespace(ns, TENANT)
@@ -917,7 +918,7 @@ class TestFlowDependencies:
         assert deps.nodes is not None
 
     def test_from_namespace_destination_only(self, client):
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(random_id(), ns))
 
         deps = client.flows.flow_dependencies_from_namespace(ns, TENANT, destination_only=True)
@@ -942,7 +943,7 @@ class TestTaskFromFlow:
 
     def test_with_revision(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(fid, ns))
 
         task = client.flows.task_from_flow(ns, fid, "hello", TENANT, revision=1)
@@ -957,7 +958,7 @@ class TestTaskFromFlow:
 
     def test_revision_with_different_tasks(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, log_flow_yaml(fid, ns))
         client.flows.update_flow(ns, fid, TENANT, two_task_flow_yaml(fid, ns))
 
@@ -972,7 +973,7 @@ class TestTaskFromFlow:
 
     def test_specific_task_in_two_task_flow(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, two_task_flow_yaml(fid, ns))
 
         task1 = client.flows.task_from_flow(ns, fid, "hello", TENANT)
@@ -998,7 +999,7 @@ class TestConcurrency:
     @pytest.mark.skip(reason="Concurrency limit PUT returns 404 on this kestra-ee image")
     def test_update_concurrency_limit_set(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, concurrency_flow_yaml(fid, ns, 1))
 
         limit = ConcurrencyLimit(tenant_id=TENANT, namespace=ns, flow_id=fid, running=5)
@@ -1012,7 +1013,7 @@ class TestConcurrency:
     @pytest.mark.skip(reason="Concurrency limit PUT returns 404 on this kestra-ee image")
     def test_update_concurrency_limit_update(self, client):
         fid = random_id()
-        ns = random_id()
+        ns = random_namespace()
         create_flow(client, concurrency_flow_yaml(fid, ns, 3))
 
         limit = ConcurrencyLimit(tenant_id=TENANT, namespace=ns, flow_id=fid, running=10)
@@ -1158,7 +1159,7 @@ class TestErrorPaths:
                "passes in isolation. Re-enable once suite has per-test cleanup or Kestra is investigated."
     )
     def test_update_flow_unknown_id_raises(self, client):
-        ns = random_id()
+        ns = random_namespace()
         flow_id = random_id()
         yaml_body = log_flow_yaml(flow_id, ns)
         with pytest.raises(ApiException) as exc_info:
@@ -1169,7 +1170,7 @@ class TestErrorPaths:
 
     @pytest.mark.timeout(60)
     def test_create_flow_duplicate_conflicts(self, client):
-        ns = random_id()
+        ns = random_namespace()
         flow_id = random_id()
         yaml_body = log_flow_yaml(flow_id, ns)
         client.flows.create_flow(TENANT, yaml_body)

--- a/python/python-sdk/testApis/test_helpers.py
+++ b/python/python-sdk/testApis/test_helpers.py
@@ -23,6 +23,31 @@ def random_id():
     return uuid.uuid4().hex
 
 
+# Namespaces materialize per-namespace state server-side (EE/RBAC) that
+# lives until deleted and feeds the CI container's heap. Namespaces minted
+# through random_namespace() are registered here and bulk-purged after each
+# test module by the autouse _namespace_gc fixture in conftest.py, bounding
+# live namespace cardinality to one module's worth.
+_REGISTERED_NAMESPACES = set()
+
+
+def random_namespace():
+    """Random namespace id, purged automatically after the current module."""
+    return register_namespace(random_id())
+
+
+def register_namespace(ns):
+    """Register an externally-built namespace id (e.g. dotted children) for purge."""
+    _REGISTERED_NAMESPACES.add(ns)
+    return ns
+
+
+def drain_registered_namespaces():
+    namespaces = list(_REGISTERED_NAMESPACES)
+    _REGISTERED_NAMESPACES.clear()
+    return namespaces
+
+
 # ========================================================================
 # Flow YAML templates
 # ========================================================================
@@ -120,7 +145,7 @@ def create_flow(client, yaml_body):
 
 
 def create_log_flow(client):
-    return create_flow(client, log_flow_yaml(random_id(), random_id()))
+    return create_flow(client, log_flow_yaml(random_id(), random_namespace()))
 
 
 # ========================================================================
@@ -135,7 +160,7 @@ def read_file(relative_path):
 
 def simple_flow_fixture():
     fid = random_id()
-    ns = random_id()
+    ns = random_namespace()
     body = read_file("flows/simple_flow.yml") \
         .replace("simple_flow_id_to_replace_by_random_id", fid) \
         .replace("simple_flow_namespace_to_replace_by_random_id", ns)
@@ -145,7 +170,7 @@ def simple_flow_fixture():
 def complete_flow_body():
     return read_file("flows/flow_complete.yml") \
         .replace("flow_complete", random_id()) \
-        .replace("tests", random_id())
+        .replace("tests", random_namespace())
 
 
 # ========================================================================

--- a/python/python-sdk/testApis/test_helpers.py
+++ b/python/python-sdk/testApis/test_helpers.py
@@ -213,11 +213,7 @@ def wait_for_execution(client, execution_id, timeout=30, interval=0.5):
     raise TimeoutError(f"Execution {execution_id} did not reach SUCCESS within {timeout}s")
 
 
-def create_execution_with_logs(client):
-    """Create a flow, execute it, wait for SUCCESS. Returns (execution_id, namespace, flow_id)."""
-    ns = random_id()
-    flow_id = random_id()
-    create_flow(client, log_flow_yaml(flow_id, ns))
-    exec_resp = client.executions.create_execution(TENANT, ns, flow_id)
-    wait_for_execution(client, exec_resp.id)
-    return exec_resp.id, ns, flow_id
+# NOTE: tests that only need "an execution with logs" should use the shared
+# `succeeded_execution` fixture from conftest.py instead of creating their
+# own namespace+flow+execution — accumulated server-side state is what OOMs
+# the CI Kestra container.

--- a/python/python-sdk/testApis/test_kv_api.py
+++ b/python/python-sdk/testApis/test_kv_api.py
@@ -3,7 +3,7 @@ import pytest
 from kestrapy import KVControllerApiDeleteBulkRequest
 from kestrapy.exceptions import ApiException
 from test_helpers import (
-    TENANT, random_id, log_flow_yaml, create_flow, ns_filter,
+    TENANT, random_id, random_namespace, register_namespace, log_flow_yaml, create_flow, ns_filter,
 )
 
 
@@ -12,7 +12,7 @@ from test_helpers import (
 # ========================================================================
 
 def test_set_and_get_key_value_string(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "mykey", TENANT, '"hello world"')
@@ -24,7 +24,7 @@ def test_set_and_get_key_value_string(client):
 
 
 def test_set_and_get_key_value_number(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "count", TENANT, "42")
@@ -35,7 +35,7 @@ def test_set_and_get_key_value_number(client):
 
 
 def test_set_and_get_key_value_json_object(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "obj", TENANT, '{"foo":"bar"}')
@@ -47,7 +47,7 @@ def test_set_and_get_key_value_json_object(client):
 
 
 def test_set_and_get_key_value_json_array(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "arr", TENANT, "[1,2,3]")
@@ -59,7 +59,7 @@ def test_set_and_get_key_value_json_array(client):
 
 
 def test_set_key_value_overwrite(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "key1", TENANT, '"first"')
@@ -80,7 +80,7 @@ def test_key_value_not_found(client):
 # ========================================================================
 
 def test_delete_key_value_existing(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "todelete", TENANT, '"value"')
@@ -89,7 +89,7 @@ def test_delete_key_value_existing(client):
 
 
 def test_delete_key_value_nonexistent(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     result = client.kv.delete_key_value(ns, "nonexistent", TENANT)
@@ -97,7 +97,7 @@ def test_delete_key_value_nonexistent(client):
 
 
 def test_delete_key_values_bulk(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "k1", TENANT, '"v1"')
@@ -124,7 +124,7 @@ def test_list_all_keys_with_pagination(client):
 
 
 def test_list_all_keys_with_namespace_filter(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "filtered_key", TENANT, '"filtered_value"')
@@ -136,7 +136,7 @@ def test_list_all_keys_with_namespace_filter(client):
 
 
 def test_list_all_keys_with_sort(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.kv.set_key_value(ns, "zzz_key", TENANT, '"val1"')
@@ -155,8 +155,8 @@ def test_list_all_keys_no_results(client):
 
 
 def test_list_keys_with_inheritance_basic(client):
-    parent_ns = random_id()
-    child_ns = parent_ns + "." + random_id()
+    parent_ns = random_namespace()
+    child_ns = register_namespace(parent_ns + "." + random_id())
     create_flow(client, log_flow_yaml(random_id(), parent_ns))
     create_flow(client, log_flow_yaml(random_id(), child_ns))
 
@@ -168,7 +168,7 @@ def test_list_keys_with_inheritance_basic(client):
 
 
 def test_list_keys_with_inheritance_empty_namespace(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     keys = client.kv.list_keys_with_inheritance(ns, TENANT)

--- a/python/python-sdk/testApis/test_logs_api.py
+++ b/python/python-sdk/testApis/test_logs_api.py
@@ -291,16 +291,20 @@ def test_follow_logs_from_execution_basic(client, succeeded_execution):
     execution_id, ns, flow_id = succeeded_execution
 
     # The server interleaves empty {} keepalive frames with real log
-    # events; collect a handful and assert on the real ones.
-    events = []
+    # events; collect a handful and assert on the real ones. Close the
+    # stream explicitly — an abandoned SSE generator keeps a server-side
+    # emitter thread and queue consumer alive until client-side GC.
     real_events = []
     deadline = time.time() + 8
-    for event in client.logs.follow_logs_from_execution(execution_id, TENANT):
-        events.append(event)
-        if event.execution_id is not None:
-            real_events.append(event)
-        if time.time() > deadline or len(real_events) >= 1:
-            break
+    stream = client.logs.follow_logs_from_execution(execution_id, TENANT)
+    try:
+        for event in stream:
+            if event.execution_id is not None:
+                real_events.append(event)
+            if time.time() > deadline or len(real_events) >= 1:
+                break
+    finally:
+        stream.close()
 
     assert len(real_events) > 0
     assert real_events[0].execution_id == execution_id
@@ -314,11 +318,15 @@ def test_follow_logs_from_execution_with_min_level(client, succeeded_execution):
     # the parameter and verify the events that come through respect it.
     events = []
     deadline = time.time() + 8
-    for event in client.logs.follow_logs_from_execution(execution_id, TENANT, min_level="INFO"):
-        if event.execution_id is not None:
-            events.append(event)
-        if time.time() > deadline or len(events) >= 1:
-            break
+    stream = client.logs.follow_logs_from_execution(execution_id, TENANT, min_level="INFO")
+    try:
+        for event in stream:
+            if event.execution_id is not None:
+                events.append(event)
+            if time.time() > deadline or len(events) >= 1:
+                break
+    finally:
+        stream.close()
 
     assert len(events) > 0
     for e in events:

--- a/python/python-sdk/testApis/test_logs_api.py
+++ b/python/python-sdk/testApis/test_logs_api.py
@@ -1,7 +1,5 @@
 import time
 
-import pytest
-
 from kestrapy.exceptions import ApiException
 from test_helpers import (
     TENANT,
@@ -12,17 +10,22 @@ from test_helpers import (
     flow_id_filter,
     execution_id_filter,
     min_level_filter,
-    create_execution_with_logs,
     wait_for_execution,
 )
+
+# The shared flow is a Log task, so `succeeded_execution` doubles as "an
+# execution with logs" — read-only tests consume it instead of spawning a
+# namespace+flow+execution each (server-side state feeds the CI OOM).
+# Tests that DELETE logs use `fresh_execution` (or their own flow) so the
+# shared execution's logs stay intact for later tests.
 
 
 # ========================================================================
 # List logs
 # ========================================================================
 
-def test_list_logs_from_execution_basic(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_list_logs_from_execution_basic(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     logs = client.logs.list_logs_from_execution(execution_id, TENANT)
 
@@ -31,8 +34,8 @@ def test_list_logs_from_execution_basic(client):
     assert logs[0].execution_id == execution_id
 
 
-def test_list_logs_from_execution_with_min_level(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_list_logs_from_execution_with_min_level(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     logs = client.logs.list_logs_from_execution(execution_id, TENANT, min_level="INFO")
 
@@ -41,8 +44,8 @@ def test_list_logs_from_execution_with_min_level(client):
         assert log.level is not None
 
 
-def test_list_logs_from_execution_with_task_id(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_list_logs_from_execution_with_task_id(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     # Retry to allow indexing
     for _ in range(20):
@@ -60,8 +63,8 @@ def test_list_logs_from_execution_with_task_id(client):
 # Download logs
 # ========================================================================
 
-def test_download_logs_from_execution_basic(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_download_logs_from_execution_basic(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     content = client.logs.download_logs_from_execution(execution_id, TENANT)
 
@@ -69,8 +72,8 @@ def test_download_logs_from_execution_basic(client):
     assert len(content) > 0
 
 
-def test_download_logs_from_execution_with_min_level(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_download_logs_from_execution_with_min_level(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     content = client.logs.download_logs_from_execution(
         execution_id, TENANT, min_level="INFO",
@@ -78,8 +81,8 @@ def test_download_logs_from_execution_with_min_level(client):
     assert content is not None
 
 
-def test_download_logs_from_execution_with_task_filters(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_download_logs_from_execution_with_task_filters(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     content = client.logs.download_logs_from_execution(
         execution_id, TENANT, task_id="hello", attempt=0,
@@ -87,8 +90,8 @@ def test_download_logs_from_execution_with_task_filters(client):
     assert content is not None
 
 
-def test_list_logs_from_execution_with_attempt_and_trace_level(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_list_logs_from_execution_with_attempt_and_trace_level(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     logs = client.logs.list_logs_from_execution(
         execution_id, TENANT, min_level="TRACE", attempt=0,
@@ -96,8 +99,8 @@ def test_list_logs_from_execution_with_attempt_and_trace_level(client):
     assert logs is not None
 
 
-def test_list_logs_from_execution_with_debug_level(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_list_logs_from_execution_with_debug_level(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     logs = client.logs.list_logs_from_execution(
         execution_id, TENANT, min_level="DEBUG",
@@ -105,8 +108,8 @@ def test_list_logs_from_execution_with_debug_level(client):
     assert logs is not None
 
 
-def test_list_logs_from_execution_with_error_level(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_list_logs_from_execution_with_error_level(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     # A successful flow emits only INFO; an ERROR filter should yield
     # an empty list (the call still succeeds).
@@ -121,9 +124,7 @@ def test_list_logs_from_execution_with_error_level(client):
 # Search logs
 # ========================================================================
 
-def test_search_logs_basic(client):
-    create_execution_with_logs(client)
-
+def test_search_logs_basic(client, succeeded_execution):
     result = client.logs.search_logs(TENANT, 1, 10)
 
     assert result is not None
@@ -140,12 +141,8 @@ def test_search_logs_with_pagination(client):
     assert len(result.results) <= 5
 
 
-def test_search_logs_with_namespace_filter(client):
-    ns = random_id()
-    flow_id = random_id()
-    create_flow(client, log_flow_yaml(flow_id, ns))
-    exec_resp = client.executions.create_execution(TENANT, ns, flow_id)
-    wait_for_execution(client, exec_resp.id)
+def test_search_logs_with_namespace_filter(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     # Retry to allow log indexing
     result = None
@@ -160,12 +157,8 @@ def test_search_logs_with_namespace_filter(client):
     assert len(result.results) > 0
 
 
-def test_search_logs_with_flow_id_and_namespace_filter(client):
-    ns = random_id()
-    flow_id = random_id()
-    create_flow(client, log_flow_yaml(flow_id, ns))
-    exec_resp = client.executions.create_execution(TENANT, ns, flow_id)
-    wait_for_execution(client, exec_resp.id)
+def test_search_logs_with_flow_id_and_namespace_filter(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     result = None
     for _ in range(20):
@@ -181,8 +174,8 @@ def test_search_logs_with_flow_id_and_namespace_filter(client):
     assert len(result.results) > 0
 
 
-def test_search_logs_with_execution_id_filter(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_search_logs_with_execution_id_filter(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     result = None
     for _ in range(20):
@@ -199,12 +192,8 @@ def test_search_logs_with_execution_id_filter(client):
     assert all(r.execution_id == execution_id for r in result.results)
 
 
-def test_search_logs_with_flow_id_filter(client):
-    ns = random_id()
-    flow_id = random_id()
-    create_flow(client, log_flow_yaml(flow_id, ns))
-    exec_resp = client.executions.create_execution(TENANT, ns, flow_id)
-    wait_for_execution(client, exec_resp.id)
+def test_search_logs_with_flow_id_filter(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     result = None
     for _ in range(20):
@@ -220,10 +209,8 @@ def test_search_logs_with_flow_id_filter(client):
     assert len(result.results) > 0
 
 
-def test_search_logs_with_sort(client):
-    ns = random_id()
-    flow_id = random_id()
-    create_flow(client, log_flow_yaml(flow_id, ns))
+def test_search_logs_with_sort(client, shared_flow):
+    ns, flow_id = shared_flow
 
     client.executions.create_execution(TENANT, ns, flow_id)
     # Server sorts at millisecond precision, so space the two runs apart
@@ -249,8 +236,8 @@ def test_search_logs_with_sort(client):
         assert _to_ms(result.results[i].timestamp) >= _to_ms(result.results[i + 1].timestamp)
 
 
-def test_search_logs_with_min_level_filter(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_search_logs_with_min_level_filter(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     result = None
     for _ in range(20):
@@ -281,15 +268,15 @@ def test_search_logs_no_results(client):
 # Delete logs
 # ========================================================================
 
-def test_delete_logs_from_execution_basic(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_delete_logs_from_execution_basic(client, fresh_execution):
+    execution_id, ns, flow_id = fresh_execution
 
     # Should not raise
     client.logs.delete_logs_from_execution(execution_id, TENANT)
 
 
-def test_delete_logs_from_execution_with_min_level(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_delete_logs_from_execution_with_min_level(client, fresh_execution):
+    execution_id, ns, flow_id = fresh_execution
 
     # Should not raise
     client.logs.delete_logs_from_execution(execution_id, TENANT, min_level="TRACE")
@@ -300,8 +287,8 @@ def test_delete_logs_from_execution_with_min_level(client):
 # ========================================================================
 
 
-def test_follow_logs_from_execution_basic(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_follow_logs_from_execution_basic(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     # The server interleaves empty {} keepalive frames with real log
     # events; collect a handful and assert on the real ones.
@@ -320,8 +307,8 @@ def test_follow_logs_from_execution_basic(client):
     assert real_events[0].message is not None
 
 
-def test_follow_logs_from_execution_with_min_level(client):
-    execution_id, ns, flow_id = create_execution_with_logs(client)
+def test_follow_logs_from_execution_with_min_level(client, succeeded_execution):
+    execution_id, ns, flow_id = succeeded_execution
 
     # min_level=INFO matches the log flow's emitted level; we exercise
     # the parameter and verify the events that come through respect it.
@@ -341,8 +328,10 @@ def test_follow_logs_from_execution_with_min_level(client):
             assert level_str in ("INFO", "WARN", "ERROR")
 
 
-def test_delete_logs_from_flow_basic(client):
-    ns = random_id()
+def test_delete_logs_from_flow_basic(client, shared_flow):
+    # Deleting logs is flow-wide, so use a private flow (in the shared
+    # namespace) to keep the shared execution's logs intact.
+    ns, _ = shared_flow
     flow_id = random_id()
     create_flow(client, log_flow_yaml(flow_id, ns))
 

--- a/python/python-sdk/testApis/test_namespaces_api.py
+++ b/python/python-sdk/testApis/test_namespaces_api.py
@@ -4,6 +4,7 @@ import pytest
 from test_helpers import (
     TENANT,
     random_id,
+    random_namespace,
     log_flow_yaml,
     create_flow,
     ns_filter,
@@ -23,7 +24,7 @@ from kestrapy import (
 
 
 def test_create_namespace_basic(client):
-    ns_id = random_id()
+    ns_id = random_namespace()
     ns = Namespace(id=ns_id, deleted=False, description="Test namespace")
 
     result = client.namespaces.create_namespace(tenant=TENANT, namespace=ns)
@@ -34,7 +35,7 @@ def test_create_namespace_basic(client):
 
 
 def test_namespace_get_by_id(client):
-    ns_id = random_id()
+    ns_id = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns_id, deleted=False))
 
     result = client.namespaces.namespace(id=ns_id, tenant=TENANT)
@@ -44,7 +45,7 @@ def test_namespace_get_by_id(client):
 
 
 def test_update_namespace_change_description(client):
-    ns_id = random_id()
+    ns_id = random_namespace()
     client.namespaces.create_namespace(
         tenant=TENANT, namespace=Namespace(id=ns_id, deleted=False, description="original")
     )
@@ -57,7 +58,7 @@ def test_update_namespace_change_description(client):
 
 
 def test_delete_namespace_basic(client):
-    ns_id = random_id()
+    ns_id = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns_id, deleted=False))
 
     # Should not raise
@@ -77,7 +78,7 @@ def test_search_namespaces_basic(client):
 
 
 def test_search_namespaces_with_query(client):
-    ns_id = random_id()
+    ns_id = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns_id, deleted=False))
 
     result = client.namespaces.search_namespaces(tenant=TENANT, q=ns_id, page=1, size=10)
@@ -97,7 +98,7 @@ def test_search_namespaces_with_pagination(client):
 
 
 def test_search_namespaces_existing_only(client):
-    ns_id = random_id()
+    ns_id = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns_id, deleted=False))
 
     result = client.namespaces.search_namespaces(
@@ -139,7 +140,7 @@ def test_search_namespaces_no_results(client):
 
 
 def test_autocomplete_namespaces_basic(client):
-    ns_id = random_id()
+    ns_id = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns_id, deleted=False))
 
     request = ApiAutocomplete(q=ns_id[:8])
@@ -154,7 +155,7 @@ def test_autocomplete_namespaces_basic(client):
 
 
 def test_put_secrets_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     secret = ApiSecretValue(key="MY_SECRET", value="secret_value")
@@ -164,7 +165,7 @@ def test_put_secrets_basic(client):
 
 
 def test_delete_secret_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.namespaces.put_secrets(
@@ -178,7 +179,7 @@ def test_delete_secret_basic(client):
 
 
 def test_inherited_secrets_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     result = client.namespaces.inherited_secrets(namespace=ns, tenant=TENANT)
@@ -192,7 +193,7 @@ def test_inherited_secrets_basic(client):
 
 
 def test_inherited_variables_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     result = client.namespaces.inherited_variables(id=ns, tenant=TENANT)
@@ -206,7 +207,7 @@ def test_inherited_variables_basic(client):
 
 
 def test_inherited_plugin_defaults_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     result = client.namespaces.inherited_plugin_defaults(id=ns, tenant=TENANT)
@@ -220,7 +221,7 @@ def test_inherited_plugin_defaults_basic(client):
 
 
 def test_patch_secret_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
 
     client.namespaces.put_secrets(
@@ -243,7 +244,7 @@ def test_patch_secret_basic(client):
 
 
 def test_export_plugin_defaults_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     # plugin_defaults must be a list (not None) — the server NPEs in /plugindefaults/export
     # when Namespace.pluginDefaults is null.
     client.namespaces.create_namespace(
@@ -256,7 +257,7 @@ def test_export_plugin_defaults_basic(client):
 
 
 def test_import_plugin_defaults_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     # Import with None file -- may return error or empty list
@@ -292,7 +293,7 @@ def _oauth2_credential_body(name):
 
 
 def test_list_namespace_credentials_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     try:
@@ -304,7 +305,7 @@ def test_list_namespace_credentials_basic(client):
 
 
 def test_list_namespace_credentials_with_pagination(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     try:
@@ -317,7 +318,7 @@ def test_list_namespace_credentials_with_pagination(client):
 
 
 def test_create_namespace_credential_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     body = _oauth2_credential_body(f"cred-{random_id()[:8]}")
@@ -333,7 +334,7 @@ def test_create_namespace_credential_basic(client):
 
 
 def test_get_inherited_credentials_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     try:
@@ -345,7 +346,7 @@ def test_get_inherited_credentials_basic(client):
 
 
 def test_namespace_credential_not_found(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     with pytest.raises(ApiException) as exc_info:
@@ -357,7 +358,7 @@ def test_namespace_credential_not_found(client):
 
 
 def test_update_namespace_credential_not_found(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     body = {"type": "OAUTH2", "description": "updated"}
@@ -369,7 +370,7 @@ def test_update_namespace_credential_not_found(client):
 
 
 def test_delete_namespace_credential_not_found(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     # Delete of a missing credential should not raise on a happy path with
@@ -383,7 +384,7 @@ def test_delete_namespace_credential_not_found(client):
 
 
 def test_test_namespace_connection_not_found(client):
-    ns = random_id()
+    ns = random_namespace()
     client.namespaces.create_namespace(tenant=TENANT, namespace=Namespace(id=ns, deleted=False))
 
     with pytest.raises(ApiException) as exc_info:
@@ -399,7 +400,7 @@ def test_test_namespace_connection_not_found(client):
 
 
 def test_list_secrets_basic(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
     client.namespaces.put_secrets(
         namespace=ns, tenant=TENANT,
@@ -412,7 +413,7 @@ def test_list_secrets_basic(client):
 
 
 def test_list_secrets_with_namespace_filter(client):
-    ns = random_id()
+    ns = random_namespace()
     create_flow(client, log_flow_yaml(random_id(), ns))
     client.namespaces.put_secrets(
         namespace=ns, tenant=TENANT,

--- a/python/python-sdk/testApis/test_test_suites_api.py
+++ b/python/python-sdk/testApis/test_test_suites_api.py
@@ -4,6 +4,7 @@ import pytest
 from test_helpers import (
     TENANT,
     random_id,
+    random_namespace,
     log_flow_yaml,
     create_flow,
 )
@@ -34,7 +35,7 @@ def _test_suite_yaml(suite_id, namespace, flow_id):
 
 
 def _create_flow_and_suite(client, suite_id=None):
-    ns = random_id()
+    ns = random_namespace()
     flow_id = random_id()
     if suite_id is None:
         suite_id = random_id()

--- a/python/python-sdk/testApis/test_triggers_api.py
+++ b/python/python-sdk/testApis/test_triggers_api.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone, timedelta
 from test_helpers import (
     TENANT,
     random_id,
+    random_namespace,
     create_flow,
     ns_filter,
     flow_id_filter,
@@ -42,7 +43,7 @@ def trigger_id_dict(ns, flow_id):
 
 
 def _create_schedule_flow(client):
-    ns = random_id()
+    ns = random_namespace()
     flow_id = random_id()
     create_flow(client, schedule_flow_yaml(flow_id, ns))
     time.sleep(0.5)
@@ -124,7 +125,7 @@ def test_search_triggers_no_results(client):
 
 
 def test_search_triggers_with_sort(client):
-    ns = random_id()
+    ns = random_namespace()
     flow_id1 = f"aaa{random_id()}"
     flow_id2 = f"zzz{random_id()}"
     create_flow(client, schedule_flow_yaml(flow_id1, ns))


### PR DESCRIPTION
## Summary

The `develop` EE image (pulled fresh on every CI run) moved to Kestra 2.0, which removed per-request HTTP Basic auth and replaced the config-based super-admin bootstrap with `POST /api/v1/setup`. As a result, every Python SDK test now fails with 401 — 478 failures in the [last run](https://github.com/kestra-io/client-sdk/actions/runs/26878360811) on #262, unrelated to that PR's content.

This mirrors the Go SDK fix (548c7a5a) in `testApis/conftest.py`:

1. `POST /api/v1/setup` — create the first super-admin + `main` tenant (405 = already set up)
2. `POST /login` — JWT cookie on a shared `requests.Session`
3. `GET /ui/` — server sets the `csrfToken` cookie; parse the matching token from the meta tag
4. `POST /api/v1/me/api-tokens` with `X-CSRF-TOKEN` (double-submit) — mint `ci-token`
5. Run the test client with `KestraClient(host=..., token=...)` — Bearer auth, already supported

No infra change needed: `test-utils/docker-setup/application.yml` already forces `micronaut.security.filter.enabled: true` (from the Go migration), so the image honors JWT/Bearer.

## Notes

- Unblocks #262 and any future Python PR
- The Java/JS SDK suites use the same docker setup and Basic auth, so they will need the same migration on their next CI run
- The Go migration also had to skip some filter-dependent search tests on 2.0; if equivalent functional failures surface here once auth works, they'll show in this PR's run

🤖 Generated with [Claude Code](https://claude.com/claude-code)