### PR TITLE
fix(go): repair broken README example (#144) and keep it in sync via test + CI

### DIFF
--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -7,12 +7,16 @@ on:
       - "releases/v*"
     paths:
       - 'go-sdk/**'
+      - 'README.md'
+      - 'test-utils/**'
   pull_request:
     branches:
       - main
       - "releases/v*"
     paths:
       - 'go-sdk/**'
+      - 'README.md'
+      - 'test-utils/**'
   workflow_dispatch:
     inputs:
       skip-test:
@@ -45,6 +49,19 @@ jobs:
       - name: build
         id: build
         run: go build ./...
+
+      # JDK for the single-file snippet injector (no build tool needed).
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: 21
+
+      # Static doc check — runs the JDK single-file tool (no Kestra container
+      # needed, so it fails fast). Guarantees the README Go usage snippet is
+      # identical to the CI-tested example (basic_sdk_usage_example.go). #144.
+      - name: Check README example is in sync with its tested source
+        run: java ../test-utils/EmbedSnippets.java --check ../README.md
 
       - name: GCP - Auth with github service account
         uses: "google-github-actions/auth@v2"

--- a/README.md
+++ b/README.md
@@ -254,71 +254,98 @@ await new Promise((resolve, reject) =>
 ### Go (`github.com/kestra-io/client-sdk/go-sdk`)
 
 - Pull the module into your project with `go get github.com/kestra-io/client-sdk/go-sdk@latest`.
-- Update the first server entry (`cfg.Servers[0].URL`) so the client points to your Kestra host.
-- For Basic authentication wrap the request context with `ContextBasicAuth`. To use a service account, set `ContextAccessToken` instead.
+- Build a `KestraClient` with `NewClient`, pointing it at your Kestra host.
+- Authenticate with Basic credentials via `WithBasicAuth`, or with a service-account token via `WithTokenAuth`.
+
+Build a client, then perform a basic flow lifecycle:
 
 ```go
 package main
 
 import (
-    "context"
-    "fmt"
-    "log"
+	"context"
+	"fmt"
+	"log"
 
-    kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
 )
 
 func main() {
-    cfg := kestra.NewConfiguration()
-    cfg.Servers[0].URL = "https://<kestra-host>"
+	client := kestra.NewClient(
+		"https://<kestra-host>",
+		kestra.WithBasicAuth("user@kestra.io", "password"),
+	)
+	// Service account alternative:
+	// client := kestra.NewClient(
+	// 	"https://<kestra-host>",
+	// 	kestra.WithTokenAuth("<service-account-api-key>"),
+	// )
 
-    client := kestra.NewAPIClient(cfg)
-
-    ctx := context.WithValue(context.Background(), kestra.ContextBasicAuth, kestra.BasicAuth{
-        UserName: "user@kestra.io",
-        Password: "password",
-    })
-    // Service account alternative:
-    // ctx := context.WithValue(context.Background(), kestra.ContextAccessToken, "<service-account-api-key>")
-
-    tenant := "main"
-    namespace := "demo"
-    flowID := "hello-from-sdk"
-
-    flowYaml := `id: hello-from-sdk
-namespace: demo
-
-tasks:
-  - id: log
-    type: io.kestra.plugin.core.log.Log
-    message: Hello from the SDK
-`
-
-    if _, _, err := client.FlowsAPI.CreateFlow(ctx, tenant).Body(flowYaml).Execute(); err != nil {
-        log.Fatal(err)
-    }
-
-    updatedYaml := `id: hello-from-sdk
-namespace: demo
-
-tasks:
-  - id: log
-    type: io.kestra.plugin.core.log.Log
-    message: Hello after update
-`
-
-    if _, _, err := client.FlowsAPI.UpdateFlow(ctx, flowID, namespace, tenant).Body(updatedYaml).Execute(); err != nil {
-        log.Fatal(err)
-    }
-
-    executions, _, err := client.ExecutionsAPI.CreateExecution(ctx, namespace, flowID, tenant).Wait(true).Execute()
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    fmt.Println("Execution ID:", executions[0].GetId())
+	if _, err := flowLifecycle(context.Background(), client, "main"); err != nil {
+		log.Fatal(err)
+	}
 }
 ```
+
+The `flowLifecycle` function below is injected from the CI-tested example
+`go-sdk/test/basic_sdk_usage_example.go` (issue #144). Do not edit it by hand —
+change the example and re-run `java test-utils/EmbedSnippets.java --write README.md`.
+
+<!-- snippet:flow-lifecycle src=go-sdk/test/basic_sdk_usage_example.go lang=go -->
+```go
+// flowLifecycle lists the tenant's flows, creates one from YAML, updates it,
+// then triggers an execution and waits for it to finish, returning its id.
+func flowLifecycle(ctx context.Context, client *kestra.KestraClient, tenant string) (string, error) {
+	namespace := "company.team"
+	flowID := "hello_from_sdk"
+
+	// List the first page of flows in the tenant.
+	flows, err := client.Flows().SearchFlows(ctx, tenant, kestra.PtrInt(1), kestra.PtrInt(10), nil, nil)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("Found %d flows\n", flows.GetTotal())
+
+	// Create a flow from its YAML source.
+	flowYAML := `id: hello_from_sdk
+namespace: company.team
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello from the Kestra Go SDK!
+`
+	created, err := client.Flows().CreateFlow(ctx, tenant, flowYAML)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("Created flow %s.%s (revision %d)\n", created.GetNamespace(), created.GetId(), created.GetRevision())
+
+	// Update the flow — UpdateFlow takes (namespace, id, tenant, body).
+	updatedYAML := `id: hello_from_sdk
+namespace: company.team
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello after update!
+`
+	if _, err := client.Flows().UpdateFlow(ctx, namespace, flowID, tenant, updatedYAML); err != nil {
+		return "", err
+	}
+
+	// Trigger an execution and wait for it to complete.
+	execution, err := client.Executions().CreateExecution(ctx, tenant, namespace, flowID, nil, kestra.PtrBool(true), nil, nil, nil, nil)
+	if err != nil {
+		return "", err
+	}
+	state := execution.GetState()
+	fmt.Printf("Execution %s finished in state %s\n", execution.GetId(), state.GetCurrent())
+
+	return execution.GetId(), nil
+}
+```
+<!-- /snippet -->
 
 ## How to update the SDK
 - Generate openapi from Kestra-EE: `./gradlew clean build updateOpenapiVersion -xtest`

--- a/go-sdk/test/basic_sdk_usage_example.go
+++ b/go-sdk/test/basic_sdk_usage_example.go
@@ -1,0 +1,75 @@
+package test
+
+import (
+	"context"
+	"fmt"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+)
+
+// The function between the region:flow-lifecycle / endregion markers below is
+// the single source of truth for the Go usage snippet in the root README.md: it
+// is injected verbatim by test-utils/EmbedSnippets.java and exercised against a
+// live Kestra by TestBasicSDKUsageExample. Keeping the README snippet physically
+// identical to tested code is what stops the docs from drifting (issue #144) —
+// so edit the example here, never the README block, then re-run the injector:
+//
+//	java test-utils/EmbedSnippets.java --write README.md
+//
+// The caller supplies an authenticated client and the tenant; the README shows
+// how to build the client just above the injected block.
+
+// region:flow-lifecycle
+// flowLifecycle lists the tenant's flows, creates one from YAML, updates it,
+// then triggers an execution and waits for it to finish, returning its id.
+func flowLifecycle(ctx context.Context, client *kestra.KestraClient, tenant string) (string, error) {
+	namespace := "company.team"
+	flowID := "hello_from_sdk"
+
+	// List the first page of flows in the tenant.
+	flows, err := client.Flows().SearchFlows(ctx, tenant, kestra.PtrInt(1), kestra.PtrInt(10), nil, nil)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("Found %d flows\n", flows.GetTotal())
+
+	// Create a flow from its YAML source.
+	flowYAML := `id: hello_from_sdk
+namespace: company.team
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello from the Kestra Go SDK!
+`
+	created, err := client.Flows().CreateFlow(ctx, tenant, flowYAML)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("Created flow %s.%s (revision %d)\n", created.GetNamespace(), created.GetId(), created.GetRevision())
+
+	// Update the flow — UpdateFlow takes (namespace, id, tenant, body).
+	updatedYAML := `id: hello_from_sdk
+namespace: company.team
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello after update!
+`
+	if _, err := client.Flows().UpdateFlow(ctx, namespace, flowID, tenant, updatedYAML); err != nil {
+		return "", err
+	}
+
+	// Trigger an execution and wait for it to complete.
+	execution, err := client.Executions().CreateExecution(ctx, tenant, namespace, flowID, nil, kestra.PtrBool(true), nil, nil, nil, nil)
+	if err != nil {
+		return "", err
+	}
+	state := execution.GetState()
+	fmt.Printf("Execution %s finished in state %s\n", execution.GetId(), state.GetCurrent())
+
+	return execution.GetId(), nil
+}
+
+// endregion

--- a/go-sdk/test/basic_sdk_usage_example_test.go
+++ b/go-sdk/test/basic_sdk_usage_example_test.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBasicSDKUsageExample runs the curated README example end-to-end against
+// the live Kestra container. This is the CI guarantee for the injected snippet:
+// if flowLifecycle (and therefore the README block produced from it by
+// test-utils/EmbedSnippets.java) ever stops matching the SDK, this test fails.
+// See issue #144.
+func TestBasicSDKUsageExample(t *testing.T) {
+	ctx := context.Background()
+	client := KestraTestClient()
+
+	// Best-effort cleanup so the example is re-runnable within a session.
+	defer func() {
+		_ = client.Flows().DeleteFlow(ctx, "company.team", "hello_from_sdk", MAIN_TENANT)
+	}()
+
+	executionID, err := flowLifecycle(ctx, client, MAIN_TENANT)
+	require.NoError(t, err)
+	require.NotEmpty(t, executionID)
+}


### PR DESCRIPTION
## Problem

The root README Go snippet had drifted from the SDK and **no longer compiled** (issue #144):

- `UpdateFlow(ctx, flowID, namespace, tenant)` had the **id/namespace args swapped** — the real signature is `UpdateFlow(ctx, namespace, id, tenant, body)`.
- `CreateExecution(...).Execute()` returns a single `*ExecutionControllerExecutionResponse` (exposing `GetId()` directly), but the example indexed it as a slice: `executions[0].GetId()`.
- It also used the legacy OpenAPI-generated `APIClient`/`FlowsAPI` surface rather than the hand-written `KestraClient` the test suite actually exercises (and which mirrors the Java/Python SDKs).

## Fix — examples as a single source of truth

Mirrors the Python (#266) and Java (#268) approach in `design/examples-as-source-of-truth.md`:

- **`go-sdk/test/basic_sdk_usage_example.go`** — a `flowLifecycle(ctx, client, tenant)` function (search → create → update → createExecution) wrapped in a `// region:flow-lifecycle` marker, correct against the current `KestraClient` signatures.
- **`basic_sdk_usage_example_test.go`** — runs the example end-to-end against the live Kestra container (with flow cleanup) so it fails if the example stops matching the SDK.
- **`README.md`** — replaces the broken hand-written block with a `<!-- snippet:flow-lifecycle -->` block injected from the tested example via `test-utils/EmbedSnippets.java`, and switches the setup to the `KestraClient` API (`NewClient` + `WithBasicAuth`/`WithTokenAuth`).
- **`go-sdk.yml`** — adds a fast static `--check` step (JDK single-file `EmbedSnippets`, before the Docker test) that fails the build if README and example diverge; adds `README.md` and `test-utils/**` to the path triggers so a README hand-edit fires the gate.

## Verification

Locally: `go build ./...`, `go vet ./...`, `gofmt`, test-binary compilation, and `EmbedSnippets --check` all pass.

> ⚠️ The new live example test has **not** been run against a Kestra container locally; it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)