### PR TITLE
feat(javascript): make the README example a single source of truth (#144)

### DIFF
--- a/.github/workflows/javascript-sdk.yml
+++ b/.github/workflows/javascript-sdk.yml
@@ -10,6 +10,8 @@ on:
       - "javascript/test_javascript_sdk/**"
       - "kestra-ee.yml"
       - "generation-helpers/**"
+      - "README_JAVASCRIPT_SDK.md"
+      - "test-utils/embed_snippets.py"
   pull_request:
     branches:
       - main
@@ -19,6 +21,8 @@ on:
       - "javascript/test_javascript_sdk/**"
       - "kestra-ee.yml"
       - "generation-helpers/**"
+      - "README_JAVASCRIPT_SDK.md"
+      - "test-utils/embed_snippets.py"
   workflow_dispatch:
     inputs:
       skip-test:
@@ -62,6 +66,14 @@ jobs:
           root_version=$(echo "${{ steps.version.outputs.kestra_version }}" | sed 's/\.[xX]$//')
 
           echo "root_version=$root_version" >> $GITHUB_OUTPUT
+
+      # Static doc check — reads only the README and the example source (no SDK
+      # generation or Kestra container needed, so it fails fast). Guarantees the
+      # README usage snippet is identical to the CI-tested example
+      # (basicSDKUsageExample.ts). #144.
+      - name: Check README example is in sync with its tested source
+        working-directory: .
+        run: python3 test-utils/embed_snippets.py --check README_JAVASCRIPT_SDK.md
 
       - name: Generate SDK
         # Generate SDK with develop version to check

--- a/README_JAVASCRIPT_SDK.md
+++ b/README_JAVASCRIPT_SDK.md
@@ -90,47 +90,14 @@ import * as WorkerAuthAPI           from "@kestra-io/kestra-sdk/worker-auth";
 import * as WorkerGroupsAPI         from "@kestra-io/kestra-sdk/worker-groups";
 ```
 
-### Example: search and create a flow
+### Example: a flow lifecycle
+
+Configure the client once (see [Configure the client](#configure-the-client)), pick a tenant, then
+call the domain modules:
 
 ```ts
 import { client } from "@kestra-io/kestra-sdk/client";
 import * as FlowsAPI from "@kestra-io/kestra-sdk/flows";
-
-client.setConfig({
-    baseURL: "https://<your-kestra-host>",
-    auth: () => "root@root.com:Root!1234",
-});
-
-const tenantId = "main";
-
-// Search flows
-const searchRes = await FlowsAPI.searchFlows({
-    page: 1,
-    size: 10,
-    tenant: tenantId,
-});
-console.log(searchRes.data);
-
-// Create a flow
-const createRes = await FlowsAPI.createFlow({
-    tenant: tenantId,
-    body: `
-id: hello-world
-namespace: my.namespace
-
-tasks:
-  - id: hello
-    type: io.kestra.plugin.core.log.Log
-    message: Hello World! 🚀
-`,
-});
-console.log(createRes.data);
-```
-
-### Example: trigger an execution
-
-```ts
-import { client } from "@kestra-io/kestra-sdk/client";
 import * as ExecutionsAPI from "@kestra-io/kestra-sdk/executions";
 
 client.setConfig({
@@ -138,10 +105,43 @@ client.setConfig({
     auth: () => "root@root.com:Root!1234",
 });
 
-const execution = await ExecutionsAPI.createExecution({
-    tenant: "main",
-    namespace: "my.namespace",
-    id: "hello-world",
-});
-console.log(execution.data);
+const tenant = "main";
 ```
+
+The snippet below — search flows, create one, then trigger an execution and wait for it — is injected
+from `javascript/test_javascript_sdk/basicSDKUsageExample.ts`, which runs in CI against a live Kestra,
+so it stays in sync with the SDK. Edit the example there (not this block) and re-run the injector with
+`python3 test-utils/embed_snippets.py --write README_JAVASCRIPT_SDK.md`.
+
+<!-- snippet:flow-lifecycle src=javascript/test_javascript_sdk/basicSDKUsageExample.ts lang=ts -->
+```ts
+const namespace = "company.team";
+const flowId = "hello_from_sdk";
+
+// List the first page of flows in the tenant.
+const flows = await FlowsAPI.searchFlows({ tenant, page: 1, size: 10 });
+console.log(`Found ${flows.results?.length ?? 0} flows`);
+
+// Create a flow from its YAML source.
+const flow = `
+id: hello_from_sdk
+namespace: company.team
+
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: Hello from the Kestra JavaScript SDK!
+`;
+const created = await FlowsAPI.createFlow({ tenant, body: flow });
+console.log(`Created flow ${created.namespace}.${created.id}`);
+
+// Trigger an execution of that flow and wait for it to finish.
+const execution = await ExecutionsAPI.createExecution({
+    tenant,
+    namespace,
+    id: flowId,
+    wait: true,
+});
+console.log(`Execution ${execution.id} finished in state ${execution.state?.current}`);
+```
+<!-- /snippet -->

--- a/javascript/test_javascript_sdk/basicSDKUsageExample.spec.ts
+++ b/javascript/test_javascript_sdk/basicSDKUsageExample.spec.ts
@@ -1,13 +1,31 @@
 import { describe, it, expect } from "vitest";
-import { searchAndCreateFlowsExample } from "./basicSDKUsageExample.js";
+import * as FlowsAPI from "@kestra-io/kestra-sdk/flows";
+import { flowLifecycleExample } from "./basicSDKUsageExample.js";
+import fixtures from "./fixtures.json" with { type: "json" };
 
-describe("searchAndCreateFlowsExample", () => {
-    it("should execute the search and create flows example without errors", async () => {
-        // Call the function to ensure it runs without throwing errors
-        await searchAndCreateFlowsExample();
-
-        // Add assertions here if the function provides return values or modifies state
-        // For now, we assume no errors indicate success
-        expect(true).toBe(true);
+describe("flowLifecycleExample", () => {
+    it("runs the README example end-to-end against a live Kestra", async () => {
+        // The throwOnError client makes the example itself the assertion: any
+        // drift from the SDK (wrong arg shape, renamed method, bad response
+        // field) throws and fails the test. This is the CI guarantee behind the
+        // injected README snippet (#144).
+        try {
+            const execution = await flowLifecycleExample(fixtures.tenantId);
+            expect(execution.id).toBeTruthy();
+        } finally {
+            // Best-effort cleanup so the example is re-runnable within a session
+            // (it creates a fixed company.team/hello_from_sdk flow). The example
+            // configures the shared client before its first call, so the module
+            // functions are usable here. Mirrors the Java/Python example tests.
+            try {
+                await FlowsAPI.deleteFlow({
+                    tenant: fixtures.tenantId,
+                    namespace: "company.team",
+                    id: "hello_from_sdk",
+                });
+            } catch {
+                // flow may not exist if the example failed before creating it
+            }
+        }
     });
 });

--- a/javascript/test_javascript_sdk/basicSDKUsageExample.ts
+++ b/javascript/test_javascript_sdk/basicSDKUsageExample.ts
@@ -1,37 +1,64 @@
+/**
+ * Basic, runnable usage example for the Kestra JavaScript SDK.
+ *
+ * The region between the `region:`/`endregion` markers below is the *single
+ * source of truth* for the usage snippet in `README_JAVASCRIPT_SDK.md`: it is
+ * injected verbatim by `test-utils/embed_snippets.py` and exercised against a
+ * live Kestra by `basicSDKUsageExample.spec.ts`. Keeping the README snippet
+ * physically identical to tested code is what stops the docs from drifting
+ * (issue #144), so edit the example here — never the README block — and re-run
+ * the injector:
+ *
+ *     python3 test-utils/embed_snippets.py --write README_JAVASCRIPT_SDK.md
+ *
+ * The shared `client` is configured by the caller (the README shows how, just
+ * above the injected block); `tenant` is passed in. The region body is written
+ * flush-left so the YAML literal stays at column 0 (valid flow source) and the
+ * injector dedents it cleanly.
+ */
 import { client } from "@kestra-io/kestra-sdk/client";
-import * as Flows from "@kestra-io/kestra-sdk/flows";
+import * as FlowsAPI from "@kestra-io/kestra-sdk/flows";
+import * as ExecutionsAPI from "@kestra-io/kestra-sdk/executions";
 import fixtures from "./fixtures.json" with { type: "json" };
 
-const { baseURL, username, password, tenantId } = fixtures;
+const { baseURL, username, password } = fixtures;
 
-export async function searchAndCreateFlowsExample() {
+export async function flowLifecycleExample(tenant: string) {
     client.setConfig({
-        auth: () => {
-            return username + ":" + password;
-        },
         baseURL,
+        auth: () => `${username}:${password}`,
     });
 
-    const searchRes = await Flows.searchFlows({
-        page: 1,
-        size: 10,
-        tenant: tenantId,
-    });
+// region:flow-lifecycle
+const namespace = "company.team";
+const flowId = "hello_from_sdk";
 
-    const flowId = "flow-" + Math.floor(Math.random() * 1000);
-    const namespace = "namespace-" + Math.floor(Math.random() * 1000);
-    const flow = `
-id: ${flowId}
-namespace: ${namespace}
+// List the first page of flows in the tenant.
+const flows = await FlowsAPI.searchFlows({ tenant, page: 1, size: 10 });
+console.log(`Found ${flows.results?.length ?? 0} flows`);
+
+// Create a flow from its YAML source.
+const flow = `
+id: hello_from_sdk
+namespace: company.team
 
 tasks:
   - id: hello
     type: io.kestra.plugin.core.log.Log
-    message: Hello World! 🚀
+    message: Hello from the Kestra JavaScript SDK!
 `;
+const created = await FlowsAPI.createFlow({ tenant, body: flow });
+console.log(`Created flow ${created.namespace}.${created.id}`);
 
-    const createRes = await Flows.createFlow({
-        tenant: tenantId,
-        body: flow,
-    });
+// Trigger an execution of that flow and wait for it to finish.
+const execution = await ExecutionsAPI.createExecution({
+    tenant,
+    namespace,
+    id: flowId,
+    wait: true,
+});
+console.log(`Execution ${execution.id} finished in state ${execution.state?.current}`);
+// endregion
+
+    return execution;
 }


### PR DESCRIPTION
## Why

The root JS README snippet was a hand-maintained **copy** of the SDK calls, so nothing failed when it drifted from the generated code — the root cause of #144. Of the two example blocks, only *search and create* had a CI-tested counterpart; *trigger an execution* was an unverified duplicate.

This applies the same **examples-as-source-of-truth** approach already shipped for Java (#268) and Python (#266) — see `design/examples-as-source-of-truth.md` — reusing the shared injector `test-utils/embed_snippets.py`.

## What

- **`basicSDKUsageExample.ts`** — rewritten into `flowLifecycleExample(tenant)`: search → create → `createExecution({ wait: true })` → log final state, wrapped in a `// region:flow-lifecycle` marker. `setConfig` stays outside the region; the body is flush-left so the YAML literal is valid (column 0) and the injector dedents it cleanly.
- **`basicSDKUsageExample.spec.ts`** — runs the example end-to-end against the live Kestra; the `throwOnError` client *is* the assertion, so any drift (wrong arg shape, renamed method, bad response field) fails the test.
- **`README_JAVASCRIPT_SDK.md`** — the two hand-written blocks are replaced by a single `<!-- snippet:flow-lifecycle -->` section injected from the tested example. No more un-injected duplicate.
- **`javascript-sdk.yml`** — adds a fast static `embed_snippets.py --check` step (no SDK generation / Kestra container needed) before the build, and adds the README + injector to the workflow `paths` so a hand-edit is caught.

## Verification

- Injector `--check` passes and is idempotent.
- All operations (`searchFlows`, `createFlow`, `createExecution`) verified against `kestra-ee.yml`; response fields checked against the schemas.
- `npm run check:types` + the vitest example test run in CI (they need the generated SDK + a live Kestra).

Closes #144 for the JavaScript SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)