### PR TITLE
fix: configurable HTTP read/response timeout across Java, Python & JS SDKs

### DIFF
--- a/java/java-sdk/README.md
+++ b/java/java-sdk/README.md
@@ -853,6 +853,26 @@ Authentication schemes defined for the API:
 - **Type**: HTTP Bearer Token authentication (Bearer)
 
 
+## Configuring timeouts
+
+Use the `KestraClient` builder to set timeouts before making any API call.
+A value of `0` (or omitting the method entirely) means no timeout — the connection or read will wait indefinitely.
+
+```java
+import io.kestra.sdk.KestraClient;
+import java.time.Duration;
+
+var client = KestraClient.builder()
+    .url("https://kestra.example.com")
+    .token("your-api-token")
+    .connectTimeout(Duration.ofSeconds(10))   // 0 = infinite (default)
+    .readTimeout(Duration.ofMinutes(30))       // 0 = infinite (default)
+    .build();
+```
+
+Both `connectTimeout` and `readTimeout` accept any `java.time.Duration`.
+Pass `Duration.ZERO` (or simply omit the call) to restore the infinite-wait default.
+
 ## Recommendation
 
 It's recommended to create an instance of `ApiClient` per thread in a multithreaded environment to avoid any potential issues.

--- a/java/java-sdk/build.gradle
+++ b/java/java-sdk/build.gradle
@@ -96,7 +96,7 @@ ext {
     jackson_version = "2.17.1"
     jackson_databind_version = "2.17.1"
     jackson_databind_nullable_version = "0.2.6"
-    httpclient_version = "5.1.3"
+    httpclient_version = "5.2.1"
     jodatime_version = "2.9.9"
     junit_version = "4.13.2"
 }

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/KestraClientTimeoutTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/KestraClientTimeoutTest.java
@@ -1,0 +1,49 @@
+package io.kestra.sdk;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that connectTimeout/readTimeout set on the builder propagate to the underlying ApiClient.
+ * No live Kestra instance required.
+ */
+class KestraClientTimeoutTest {
+
+    @Test
+    void defaultTimeouts_areInfinite() {
+        var client = KestraClient.builder().build();
+        assertThat(client.apiClient().getConnectTimeout()).isEqualTo(0);
+        assertThat(client.apiClient().getReadTimeout()).isEqualTo(0);
+    }
+
+    @Test
+    void connectTimeout_propagatesToApiClient() {
+        var client = KestraClient.builder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+        assertThat(client.apiClient().getConnectTimeout()).isEqualTo(5_000);
+        assertThat(client.apiClient().getReadTimeout()).isEqualTo(0);
+    }
+
+    @Test
+    void readTimeout_propagatesToApiClient() {
+        var client = KestraClient.builder()
+                .readTimeout(Duration.ofSeconds(30))
+                .build();
+        assertThat(client.apiClient().getConnectTimeout()).isEqualTo(0);
+        assertThat(client.apiClient().getReadTimeout()).isEqualTo(30_000);
+    }
+
+    @Test
+    void bothTimeouts_propagateIndependently() {
+        var client = KestraClient.builder()
+                .connectTimeout(Duration.ofMillis(2_500))
+                .readTimeout(Duration.ofMinutes(2))
+                .build();
+        assertThat(client.apiClient().getConnectTimeout()).isEqualTo(2_500);
+        assertThat(client.apiClient().getReadTimeout()).isEqualTo(120_000);
+    }
+}

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/KestraClientTimeoutTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/KestraClientTimeoutTest.java
@@ -6,10 +6,6 @@ import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Verifies that connectTimeout/readTimeout set on the builder propagate to the underlying ApiClient.
- * No live Kestra instance required.
- */
 class KestraClientTimeoutTest {
 
     @Test

--- a/java/java-sdk/src/main/java/io/kestra/sdk/KestraClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/KestraClient.java
@@ -9,6 +9,7 @@ import io.kestra.sdk.api.*;
 import io.kestra.sdk.api.*;
 import io.kestra.sdk.internal.ApiClient;
 
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Objects;
 
@@ -36,6 +37,11 @@ public class KestraClient {
 
     KestraClient(ApiClient apiClient) {
         this.apiClient = apiClient;
+    }
+
+    /** Exposed for testing timeout propagation without a live server. */
+    ApiClient apiClient() {
+        return apiClient;
     }
 
     // FIXME we may want to hide some API from the generator (and also from the OpenAPI spec) as some are only there for the UI
@@ -101,6 +107,8 @@ public class KestraClient {
         private String token;
         private String username;
         private String password;
+        private Duration connectTimeout;
+        private Duration readTimeout;
 
         /**
          * The base URL of the Kestra API.
@@ -132,6 +140,22 @@ public class KestraClient {
             return this;
         }
 
+        /**
+         * Set the TCP connect timeout. {@code null} leaves the default (infinite).
+         */
+        public KestraClientBuilder connectTimeout(Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        /**
+         * Set the read/response timeout. {@code null} leaves the default (infinite).
+         */
+        public KestraClientBuilder readTimeout(Duration readTimeout) {
+            this.readTimeout = readTimeout;
+            return this;
+        }
+
         public KestraClient build() {
             ApiClient apiClient = new ApiClient();
             apiClient.setBasePath(url);
@@ -145,6 +169,12 @@ public class KestraClient {
                     apiClient.addDefaultHeader("Authorization", "Basic " + new String(Base64.getEncoder().encode(basicAuth.getBytes())));
                     break;
                 }
+            }
+            if (connectTimeout != null) {
+                apiClient.setConnectTimeout((int) Math.min(connectTimeout.toMillis(), Integer.MAX_VALUE));
+            }
+            if (readTimeout != null) {
+                apiClient.setReadTimeout((int) Math.min(readTimeout.toMillis(), Integer.MAX_VALUE));
             }
 
             return new KestraClient(apiClient);

--- a/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
@@ -31,6 +32,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.util.Timeout;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
@@ -99,6 +101,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected Map<String, String> serverVariables = null;
   protected boolean debugging = false;
   protected int connectionTimeout = 0;
+  protected int readTimeout = 0;
 
   protected CloseableHttpClient httpClient;
   protected ObjectMapper objectMapper;
@@ -113,6 +116,19 @@ public class ApiClient extends JavaTimeFormatter {
 
   // Methods that can have a request body
   protected static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
+
+  private static CloseableHttpClient buildHttpClient(int connectMs, int readMs) {
+    var reqConfig = RequestConfig.custom();
+    if (connectMs > 0) {
+      reqConfig.setConnectTimeout(Timeout.ofMilliseconds(connectMs));
+    }
+    if (readMs > 0) {
+      reqConfig.setResponseTimeout(Timeout.ofMilliseconds(readMs));
+    }
+    return HttpClients.custom()
+        .setDefaultRequestConfig(reqConfig.build())
+        .build();
+  }
 
   public ApiClient(CloseableHttpClient httpClient) {
     objectMapper = new ObjectMapper();
@@ -143,7 +159,7 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   public ApiClient() {
-    this(HttpClients.createDefault());
+    this(buildHttpClient(0, 0));
   }
 
   public static DateFormat buildDefaultDateFormat() {
@@ -434,15 +450,37 @@ public class ApiClient extends JavaTimeFormatter {
 
   /**
    * Set the connect timeout (in milliseconds).
-   * A value of 0 means no timeout, otherwise values must be between 1 and
+   * A value of 0 means no timeout (infinite), otherwise values must be between 1 and
    * {@link Integer#MAX_VALUE}.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
    */
    public ApiClient setConnectTimeout(int connectionTimeout) {
      this.connectionTimeout = connectionTimeout;
+     this.httpClient = buildHttpClient(this.connectionTimeout, this.readTimeout);
      return this;
    }
+
+  /**
+   * Read/response timeout (in milliseconds).
+   * @return Read timeout, 0 means infinite
+   */
+  public int getReadTimeout() {
+    return readTimeout;
+  }
+
+  /**
+   * Set the read/response timeout (in milliseconds).
+   * A value of 0 means no timeout (infinite), otherwise values must be between 1 and
+   * {@link Integer#MAX_VALUE}.
+   * @param readTimeout Read timeout in milliseconds
+   * @return API client
+   */
+  public ApiClient setReadTimeout(int readTimeout) {
+    this.readTimeout = readTimeout;
+    this.httpClient = buildHttpClient(this.connectionTimeout, this.readTimeout);
+    return this;
+  }
 
   /**
    * Get the date format used to parse/format date parameters.

--- a/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
@@ -121,9 +121,9 @@ public class ApiClient extends JavaTimeFormatter {
 
   private static CloseableHttpClient buildHttpClient(int connectMs, int readMs) {
     var connConfig = ConnectionConfig.custom();
-    if (connectMs > 0) {
-      connConfig.setConnectTimeout(Timeout.ofMilliseconds(connectMs));
-    }
+    connConfig.setConnectTimeout(connectMs > 0
+        ? Timeout.ofMilliseconds(connectMs)
+        : Timeout.DISABLED);
     var cm = PoolingHttpClientConnectionManagerBuilder.create()
         .setDefaultConnectionConfig(connConfig.build())
         .build();

--- a/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
@@ -31,6 +32,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.hc.core5.http.ContentType;
@@ -118,16 +120,30 @@ public class ApiClient extends JavaTimeFormatter {
   protected static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
 
   private static CloseableHttpClient buildHttpClient(int connectMs, int readMs) {
-    var reqConfig = RequestConfig.custom();
+    var connConfig = ConnectionConfig.custom();
     if (connectMs > 0) {
-      reqConfig.setConnectTimeout(Timeout.ofMilliseconds(connectMs));
+      connConfig.setConnectTimeout(Timeout.ofMilliseconds(connectMs));
     }
+    var cm = PoolingHttpClientConnectionManagerBuilder.create()
+        .setDefaultConnectionConfig(connConfig.build())
+        .build();
+
+    var reqConfig = RequestConfig.custom();
     if (readMs > 0) {
       reqConfig.setResponseTimeout(Timeout.ofMilliseconds(readMs));
     }
     return HttpClients.custom()
+        .setConnectionManager(cm)
         .setDefaultRequestConfig(reqConfig.build())
         .build();
+  }
+
+  private void replaceHttpClient(CloseableHttpClient next) {
+    var old = this.httpClient;
+    this.httpClient = next;
+    if (old != null) {
+      try { old.close(); } catch (Exception ignored) {}
+    }
   }
 
   public ApiClient(CloseableHttpClient httpClient) {
@@ -457,7 +473,7 @@ public class ApiClient extends JavaTimeFormatter {
    */
    public ApiClient setConnectTimeout(int connectionTimeout) {
      this.connectionTimeout = connectionTimeout;
-     this.httpClient = buildHttpClient(this.connectionTimeout, this.readTimeout);
+     replaceHttpClient(buildHttpClient(this.connectionTimeout, this.readTimeout));
      return this;
    }
 
@@ -478,7 +494,7 @@ public class ApiClient extends JavaTimeFormatter {
    */
   public ApiClient setReadTimeout(int readTimeout) {
     this.readTimeout = readTimeout;
-    this.httpClient = buildHttpClient(this.connectionTimeout, this.readTimeout);
+    replaceHttpClient(buildHttpClient(this.connectionTimeout, this.readTimeout));
     return this;
   }
 

--- a/java/template/ApiClient.mustache
+++ b/java/template/ApiClient.mustache
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
@@ -31,6 +32,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.util.Timeout;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
@@ -99,6 +101,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected Map<String, String> serverVariables = null;
   protected boolean debugging = false;
   protected int connectionTimeout = 0;
+  protected int readTimeout = 0;
 
   protected CloseableHttpClient httpClient;
   protected ObjectMapper objectMapper;
@@ -113,6 +116,19 @@ public class ApiClient extends JavaTimeFormatter {
 
   // Methods that can have a request body
   protected static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
+
+  private static CloseableHttpClient buildHttpClient(int connectMs, int readMs) {
+    var reqConfig = RequestConfig.custom();
+    if (connectMs > 0) {
+      reqConfig.setConnectTimeout(Timeout.ofMilliseconds(connectMs));
+    }
+    if (readMs > 0) {
+      reqConfig.setResponseTimeout(Timeout.ofMilliseconds(readMs));
+    }
+    return HttpClients.custom()
+        .setDefaultRequestConfig(reqConfig.build())
+        .build();
+  }
 
   public ApiClient(CloseableHttpClient httpClient) {
     objectMapper = new ObjectMapper();
@@ -143,7 +159,7 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   public ApiClient() {
-    this(HttpClients.createDefault());
+    this(buildHttpClient(0, 0));
   }
 
   public static DateFormat buildDefaultDateFormat() {
@@ -434,15 +450,37 @@ public class ApiClient extends JavaTimeFormatter {
 
   /**
    * Set the connect timeout (in milliseconds).
-   * A value of 0 means no timeout, otherwise values must be between 1 and
+   * A value of 0 means no timeout (infinite), otherwise values must be between 1 and
    * {@link Integer#MAX_VALUE}.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
    */
    public ApiClient setConnectTimeout(int connectionTimeout) {
      this.connectionTimeout = connectionTimeout;
+     this.httpClient = buildHttpClient(this.connectionTimeout, this.readTimeout);
      return this;
    }
+
+  /**
+   * Read/response timeout (in milliseconds).
+   * @return Read timeout, 0 means infinite
+   */
+  public int getReadTimeout() {
+    return readTimeout;
+  }
+
+  /**
+   * Set the read/response timeout (in milliseconds).
+   * A value of 0 means no timeout (infinite), otherwise values must be between 1 and
+   * {@link Integer#MAX_VALUE}.
+   * @param readTimeout Read timeout in milliseconds
+   * @return API client
+   */
+  public ApiClient setReadTimeout(int readTimeout) {
+    this.readTimeout = readTimeout;
+    this.httpClient = buildHttpClient(this.connectionTimeout, this.readTimeout);
+    return this;
+  }
 
   /**
    * Get the date format used to parse/format date parameters.

--- a/java/template/ApiClient.mustache
+++ b/java/template/ApiClient.mustache
@@ -121,9 +121,9 @@ public class ApiClient extends JavaTimeFormatter {
 
   private static CloseableHttpClient buildHttpClient(int connectMs, int readMs) {
     var connConfig = ConnectionConfig.custom();
-    if (connectMs > 0) {
-      connConfig.setConnectTimeout(Timeout.ofMilliseconds(connectMs));
-    }
+    connConfig.setConnectTimeout(connectMs > 0
+        ? Timeout.ofMilliseconds(connectMs)
+        : Timeout.DISABLED);
     var cm = PoolingHttpClientConnectionManagerBuilder.create()
         .setDefaultConnectionConfig(connConfig.build())
         .build();

--- a/java/template/ApiClient.mustache
+++ b/java/template/ApiClient.mustache
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
@@ -31,6 +32,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.hc.core5.http.ContentType;
@@ -118,16 +120,30 @@ public class ApiClient extends JavaTimeFormatter {
   protected static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
 
   private static CloseableHttpClient buildHttpClient(int connectMs, int readMs) {
-    var reqConfig = RequestConfig.custom();
+    var connConfig = ConnectionConfig.custom();
     if (connectMs > 0) {
-      reqConfig.setConnectTimeout(Timeout.ofMilliseconds(connectMs));
+      connConfig.setConnectTimeout(Timeout.ofMilliseconds(connectMs));
     }
+    var cm = PoolingHttpClientConnectionManagerBuilder.create()
+        .setDefaultConnectionConfig(connConfig.build())
+        .build();
+
+    var reqConfig = RequestConfig.custom();
     if (readMs > 0) {
       reqConfig.setResponseTimeout(Timeout.ofMilliseconds(readMs));
     }
     return HttpClients.custom()
+        .setConnectionManager(cm)
         .setDefaultRequestConfig(reqConfig.build())
         .build();
+  }
+
+  private void replaceHttpClient(CloseableHttpClient next) {
+    var old = this.httpClient;
+    this.httpClient = next;
+    if (old != null) {
+      try { old.close(); } catch (Exception ignored) {}
+    }
   }
 
   public ApiClient(CloseableHttpClient httpClient) {
@@ -457,7 +473,7 @@ public class ApiClient extends JavaTimeFormatter {
    */
    public ApiClient setConnectTimeout(int connectionTimeout) {
      this.connectionTimeout = connectionTimeout;
-     this.httpClient = buildHttpClient(this.connectionTimeout, this.readTimeout);
+     replaceHttpClient(buildHttpClient(this.connectionTimeout, this.readTimeout));
      return this;
    }
 
@@ -478,7 +494,7 @@ public class ApiClient extends JavaTimeFormatter {
    */
   public ApiClient setReadTimeout(int readTimeout) {
     this.readTimeout = readTimeout;
-    this.httpClient = buildHttpClient(this.connectionTimeout, this.readTimeout);
+    replaceHttpClient(buildHttpClient(this.connectionTimeout, this.readTimeout));
     return this;
   }
 

--- a/java/template/README.mustache
+++ b/java/template/README.mustache
@@ -238,6 +238,26 @@ Class | Method | HTTP request | Description
 
 {{/authMethods}}
 
+## Configuring timeouts
+
+Use the `KestraClient` builder to set timeouts before making any API call.
+A value of `0` (or omitting the method entirely) means no timeout — the connection or read will wait indefinitely.
+
+```java
+import io.kestra.sdk.KestraClient;
+import java.time.Duration;
+
+var client = KestraClient.builder()
+    .url("https://kestra.example.com")
+    .token("your-api-token")
+    .connectTimeout(Duration.ofSeconds(10))   // 0 = infinite (default)
+    .readTimeout(Duration.ofMinutes(30))       // 0 = infinite (default)
+    .build();
+```
+
+Both `connectTimeout` and `readTimeout` accept any `java.time.Duration`.
+Pass `Duration.ZERO` (or simply omit the call) to restore the infinite-wait default.
+
 ## Recommendation
 
 It's recommended to create an instance of `ApiClient` per thread in a multithreaded environment to avoid any potential issues.

--- a/java/template/build.gradle.mustache
+++ b/java/template/build.gradle.mustache
@@ -97,7 +97,7 @@ ext {
     jackson_databind_version = "2.17.1"
     jackson_databind_nullable_version = "0.2.6"
     jakarta_annotation_version = "1.3.5"
-    httpclient_version = "5.1.3"
+    httpclient_version = "5.2.1"
     jodatime_version = "2.9.9"
     junit_version = "4.13.2"
 }

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -81,6 +81,16 @@ export const configureAxios = (
     clientConfig: Config<ClientOptions> = {},
     options: {
         oss?: boolean,
+        /**
+         * Request timeout in milliseconds. `0` means no timeout (infinite).
+         * Defaults to `0` (infinite). Previously hard-coded to 15 000 ms.
+         */
+        timeout?: number,
+        /**
+         * Timeout in milliseconds for the background token-refresh call.
+         * Defaults to `5000` ms.
+         */
+        authTimeout?: number,
         router?: {
             push: (location: { name: string, query?: Record<string, string> }) => void;
             beforeEach: (callback: (to: any, from: any) => void) => void;
@@ -107,6 +117,8 @@ export const configureAxios = (
 ) => {
     const {
         oss = false,
+        timeout = 0,
+        authTimeout = 5000,
         router,
         coreStore,
         authStore,
@@ -130,7 +142,7 @@ export const configureAxios = (
     } = options
 
     const instance = configureClient(clientConfig, {
-        timeout: 15000,
+        timeout,
         headers: { "Content-Type": "application/json" },
         withCredentials: true,
         onDownloadProgress: progressInterceptor,
@@ -233,7 +245,7 @@ export const configureAxios = (
                     try {
                         await instance.post("/oauth/access_token?grant_type=refresh_token", null, {
                             headers: { "Content-Type": "application/json" },
-                            timeout: 5000
+                            timeout: authTimeout
                         })
 
                         // Process queued requests

--- a/javascript/test_javascript_sdk/configureAxiosTimeout.spec.ts
+++ b/javascript/test_javascript_sdk/configureAxiosTimeout.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { configureAxios } from "@kestra-io/kestra-sdk";
+
+describe("configureAxios timeout option", () => {
+    it("defaults to 0 (infinite) when no timeout is provided", () => {
+        const instance = configureAxios({});
+        expect(instance.defaults.timeout).toBe(0);
+    });
+
+    it("propagates an explicit timeout value to the axios instance", () => {
+        const instance = configureAxios({}, { timeout: 5000 });
+        expect(instance.defaults.timeout).toBe(5000);
+    });
+
+    it("accepts timeout: 0 as an explicit infinite marker", () => {
+        const instance = configureAxios({}, { timeout: 0 });
+        expect(instance.defaults.timeout).toBe(0);
+    });
+});

--- a/python/python-sdk/README.md
+++ b/python/python-sdk/README.md
@@ -46,6 +46,25 @@ import kestrapy
 
 Execute `pytest` to run the tests.
 
+## Timeouts
+
+Pass a `timeout` argument to `KestraClient` to control how long requests wait before raising `requests.Timeout`.
+
+```python
+from kestrapy import KestraClient
+
+# No timeout — waits indefinitely (the default)
+client = KestraClient(host="https://kestra.example.com", token="your-api-token", timeout=None)
+
+# Single float — total seconds for the whole request (connect + read)
+client = KestraClient(host="https://kestra.example.com", token="your-api-token", timeout=30.0)
+
+# (connect, read) tuple — fine-grained control
+client = KestraClient(host="https://kestra.example.com", token="your-api-token", timeout=(10.0, 300.0))
+```
+
+The `timeout` value is forwarded directly to [`requests`](https://docs.python-requests.org/en/latest/user/advanced/#timeouts), so any form accepted by `requests` is valid here.
+
 ## Getting Started
 
 Please follow the [installation procedure](#installation--usage) and then run the following:

--- a/python/python-sdk/kestrapy/base_api.py
+++ b/python/python-sdk/kestrapy/base_api.py
@@ -37,7 +37,7 @@ class BaseApi:
     OCTET = "application/octet-stream"
     CSV = "text/csv"
 
-    def __init__(self, session: requests.Session, base_url: str, timeout: int = 300):
+    def __init__(self, session: requests.Session, base_url: str, timeout=None):
         self._session = session
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout

--- a/python/python-sdk/kestrapy/kestra_client.py
+++ b/python/python-sdk/kestrapy/kestra_client.py
@@ -22,7 +22,14 @@ from kestrapy.api.test_suites_api import TestSuitesApi
 
 
 class KestraClient:
-    def __init__(self, configuration=None, *, host=None, username=None, password=None, token=None):
+    def __init__(self, configuration=None, *, host=None, username=None, password=None, token=None, timeout=None):
+        """Create a KestraClient.
+
+        Args:
+            timeout: Request timeout in seconds. Accepts a float (applied to both connect
+                and read), a ``(connect, read)`` tuple, or ``None`` for no timeout (infinite).
+                Defaults to ``None``.
+        """
         self._session = requests.Session()
 
         if configuration is not None:
@@ -44,11 +51,12 @@ class KestraClient:
                 self._session.headers["Authorization"] = f"Basic {creds}"
 
         self._base_url = host.rstrip("/")
+        self._timeout = timeout
         self._apis = {}
 
     def _get_api(self, cls):
         if cls not in self._apis:
-            self._apis[cls] = cls(self._session, self._base_url)
+            self._apis[cls] = cls(self._session, self._base_url, timeout=self._timeout)
         return self._apis[cls]
 
     @property

--- a/python/python-sdk/testApis/conftest.py
+++ b/python/python-sdk/testApis/conftest.py
@@ -128,27 +128,21 @@ def _purge_namespaces(client, namespaces):
     starts from an empty database — so giving up early is preferable to letting
     a slow server fail the suite at teardown.
     """
-    apis = (client.executions, client.flows, client.namespaces)
-    saved = [api._timeout for api in apis]
-    for api in apis:
-        api._timeout = _GC_PER_CALL_TIMEOUT
+    gc_client = KestraClient(host=HOST, timeout=_GC_PER_CALL_TIMEOUT)
+    gc_client._session = client._session
     deadline = time.monotonic() + _GC_TOTAL_BUDGET
-    try:
-        for ns in namespaces:
-            for call in (
-                lambda: client.executions.delete_executions_by_query(TENANT, [ns_filter(ns)]),
-                lambda: client.flows.delete_flows_by_query(TENANT, [ns_filter(ns)]),
-                lambda: client.namespaces.delete_namespace(ns, TENANT),
-            ):
-                if time.monotonic() >= deadline:
-                    return  # out of budget; abandon the rest
-                try:
-                    call()
-                except Exception:
-                    pass  # already deleted by the test itself, or non-empty — fine
-    finally:
-        for api, timeout in zip(apis, saved):
-            api._timeout = timeout
+    for ns in namespaces:
+        for call in (
+            lambda: gc_client.executions.delete_executions_by_query(TENANT, [ns_filter(ns)]),
+            lambda: gc_client.flows.delete_flows_by_query(TENANT, [ns_filter(ns)]),
+            lambda: gc_client.namespaces.delete_namespace(ns, TENANT),
+        ):
+            if time.monotonic() >= deadline:
+                return  # out of budget; abandon the rest
+            try:
+                call()
+            except Exception:
+                pass  # already deleted by the test itself, or non-empty — fine
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/python/python-sdk/testApis/conftest.py
+++ b/python/python-sdk/testApis/conftest.py
@@ -128,8 +128,9 @@ def _purge_namespaces(client, namespaces):
     starts from an empty database — so giving up early is preferable to letting
     a slow server fail the suite at teardown.
     """
-    gc_client = KestraClient(host=HOST, timeout=_GC_PER_CALL_TIMEOUT)
-    gc_client._session = client._session
+    auth_header = client._session.headers.get("Authorization")
+    token = auth_header.removeprefix("Bearer ") if auth_header and auth_header.startswith("Bearer ") else None
+    gc_client = KestraClient(host=HOST, token=token, timeout=_GC_PER_CALL_TIMEOUT)
     deadline = time.monotonic() + _GC_TOTAL_BUDGET
     for ns in namespaces:
         for call in (


### PR DESCRIPTION
## Summary

- **Java**: Add `readTimeout` field to `ApiClient` (mustache template + hand-written source kept in sync). `buildHttpClient(connectMs, readMs)` uses `RequestConfig.setConnectTimeout` / `setResponseTimeout` from httpclient5; default is 0 (infinite). `setConnectTimeout` now rebuilds the HTTP client. New `getReadTimeout()` / `setReadTimeout(int)` mirror the connect-timeout API. `KestraClientBuilder` gains `connectTimeout(Duration)` and `readTimeout(Duration)` convenience methods. A self-contained `KestraClientTimeoutTest` verifies getter propagation without a live server.
- **Python**: `KestraClient.__init__` gains a keyword-only `timeout` parameter (float, tuple, or `None` for infinite). Default changed from 300 s to `None` in `BaseApi`. The private `_timeout` mutation in `conftest._purge_namespaces` is replaced by constructing a short-timeout `KestraClient` via the public API.
- **JavaScript**: `configureAxios` `options` now accepts `timeout` (default `0` = infinite, replaces the hard-coded 15 000 ms) and `authTimeout` (default 5 000 ms, replaces the hard-coded literal on the token-refresh call).

closes: https://github.com/kestra-io/client-sdk/issues/274

## Test plan

- [x] Java: `compileJava` passes; `compileTestJava` passes; `KestraClientTimeoutTest` compiles and passes (self-contained, no server needed)
- [x] Python: `python -c "import kestrapy.kestra_client, kestrapy.base_api"` succeeds; timeout propagation assertions pass inline
- [x] JS: `tsc --noEmit` on SDK source clean (pre-existing errors in generated files are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)