### PR TITLE
ci: run SDK freshness check daily instead of weekly

### DIFF
--- a/.github/workflows/sdk-freshness-check.yml
+++ b/.github/workflows/sdk-freshness-check.yml
@@ -1,6 +1,6 @@
 name: SDK freshness check (latest Kestra)
 
-# Weekly, non-blocking early-warning run. It exercises every SDK's e2e test
+# Daily, non-blocking early-warning run. It exercises every SDK's e2e test
 # suite against a Kestra EE server built from the *latest* line (`develop`,
 # i.e. the 2.x bleeding edge) so we catch API breaking changes proactively
 # instead of discovering the drift at release time (#250).
@@ -15,7 +15,7 @@ name: SDK freshness check (latest Kestra)
 
 on:
   schedule:
-    - cron: "0 14 * * 0" # every Sunday 14:00 UTC
+    - cron: "0 14 * * *" # every day 14:00 UTC
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/sdk-freshness-check.yml
+++ b/.github/workflows/sdk-freshness-check.yml
@@ -15,7 +15,7 @@ name: SDK freshness check (latest Kestra)
 
 on:
   schedule:
-    - cron: "0 14 * * *" # every day 14:00 UTC
+    - cron: "0 5 * * *" # every day 05:00 UTC
   workflow_dispatch: {}
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ tasks:
 The per-PR pipelines test each SDK against the Kestra version resolved for the
 branch and only run when that SDK's files change. To catch upstream API
 breaking changes early, `.github/workflows/sdk-freshness-check.yml` runs **every
-day (14:00 UTC)** — and on manual `workflow_dispatch` — exercising all four
+day (05:00 UTC)** — and on manual `workflow_dispatch` — exercising all four
 SDK test suites against a Kestra server built from the **latest line**
 (`develop`).
 

--- a/README.md
+++ b/README.md
@@ -357,12 +357,12 @@ tasks:
 - ⚠ If an existing test fails, you're probably introducing a breaking change (or someone's prior commit did). If that's the case, make sure it's safe to introduce that before merging
 - Commit and make a PR
 
-## CI: weekly SDK freshness check
+## CI: daily SDK freshness check
 
 The per-PR pipelines test each SDK against the Kestra version resolved for the
 branch and only run when that SDK's files change. To catch upstream API
 breaking changes early, `.github/workflows/sdk-freshness-check.yml` runs **every
-Sunday (14:00 UTC)** — and on manual `workflow_dispatch` — exercising all four
+day (14:00 UTC)** — and on manual `workflow_dispatch` — exercising all four
 SDK test suites against a Kestra server built from the **latest line**
 (`develop`).
 


### PR DESCRIPTION
## What

Changes the schedule of the SDK freshness check ([added in #272](https://github.com/kestra-io/client-sdk/pull/272)) from **weekly** to **daily**:

- cron `"0 14 * * 0"` (every Sunday 14:00 UTC) → `"0 14 * * *"` (every day 14:00 UTC)

## Why

The check is a non-blocking early-warning signal for upstream Kestra API drift breaking the generated SDKs. Running it daily shrinks the worst-case detection window from ~7 days to ~1 day, so drift surfaces close to when it's introduced rather than accumulating until the next weekly run.

README updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)