### PR TITLE
ci(python): move PyPI publish to tag-only release

### DIFF
--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -1,0 +1,47 @@
+name: Python SDK release
+
+# Tag-only release, aligned with terraform-provider-kestra / kestractl.
+# Push a tag like `v1.0.13-python` to publish that version to PyPI. The tag
+# is cut from an already-green release branch, so this workflow only builds
+# and publishes — tests run on push/PR via python-sdk.yml.
+on:
+  push:
+    tags:
+      - "v*-python"
+
+jobs:
+  publish:
+    name: Publish to Pip
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./python/python-sdk
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9.23"
+
+      - name: Resolve version from tag
+        id: version
+        run: |
+          # v1.0.13-python -> 1.0.13
+          VERSION=${GITHUB_REF_NAME#v}
+          VERSION=${VERSION%-python}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install pypa/build
+        run: python -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          VERSION=${{ steps.version.outputs.version }} python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true
+          packages-dir: python/python-sdk/dist

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -1,4 +1,4 @@
-name: Python SDK release
+name: Python SDK tests
 
 on:
   push:
@@ -96,34 +96,3 @@ jobs:
           path: python/python-sdk/kestra-logs/
           if-no-files-found: ignore
           retention-days: 5
-
-  publish:
-    name: Publish to Pip
-    runs-on: ubuntu-latest
-    needs: test
-    if: startsWith(github.ref, 'refs/heads/releases/')
-    defaults:
-      run:
-        working-directory: ./python/python-sdk
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.9.23"
-
-      - name: Install pypa/build
-        run: python -m pip install build --user
-
-      - name: Build a binary wheel and a source tarball
-        run: |
-          VERSION=${GITHUB_REF_NAME#releases/v}
-          VERSION=$VERSION python -m build --sdist --wheel --outdir dist/ .
-
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verbose: true
-          packages-dir: python/python-sdk/dist


### PR DESCRIPTION
First step of aligning client-sdk with the terraform-provider-kestra / kestractl release model: **tag-only publishing**, one language at a time. This PR does **Python only**; java/javascript/go are untouched and will follow in separate PRs.

## What changes

- **`python-sdk.yml`** → now the test/CI workflow only. The `publish` job (gated on push to `releases/v*`) is removed; the workflow is renamed to *Python SDK tests*. It still runs on push/PR to `main` and `releases/v*`, so the per-core e2e matrix is unaffected.
- **`python-sdk-release.yml`** (new) → triggered on `v*-python` tags. Resolves the version from the tag (`v1.0.13-python` → `1.0.13`), builds the wheel, and publishes to PyPI.

## Behavior change

Before: merging to a `releases/v*` branch published to PyPI.
After: you publish by pushing a tag, e.g. `v1.0.13-python` — matching the existing per-language tag convention already in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)