### PR TITLE
ci(python): move PyPI publish to tag-only release

### DIFF
--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -1,0 +1,47 @@
+name: Python SDK release
+
+# Tag-only release, aligned with terraform-provider-kestra / kestractl.
+# Push a tag like `v1.0.13-python` to publish that version to PyPI. The tag
+# is cut from an already-green release branch, so this workflow only builds
+# and publishes — tests run on push/PR via python-sdk.yml.
+on:
+  push:
+    tags:
+      - "v*-python"
+
+jobs:
+  publish:
+    name: Publish to Pip
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./python/python-sdk
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9.23"
+
+      - name: Resolve version from tag
+        id: version
+        run: |
+          # v1.0.13-python -> 1.0.13
+          VERSION=${GITHUB_REF_NAME#v}
+          VERSION=${VERSION%-python}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install pypa/build
+        run: python -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          VERSION=${{ steps.version.outputs.version }} python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true
+          packages-dir: python/python-sdk/dist

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -1,4 +1,4 @@
-name: Python SDK release
+name: Python SDK tests
 
 on:
   push:
@@ -75,34 +75,3 @@ jobs:
         run: |
           echo "${{ steps.license.outputs.license }}" | base64 -d > ../../test-utils/docker-setup/application-secrets.yml
           sh run-tests.sh $KESTRA_VERSION
-
-  publish:
-    name: Publish to Pip
-    runs-on: ubuntu-latest
-    needs: test
-    if: startsWith(github.ref, 'refs/heads/releases/')
-    defaults:
-      run:
-        working-directory: ./python/python-sdk
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.9.23"
-
-      - name: Install pypa/build
-        run: python -m pip install build --user
-
-      - name: Build a binary wheel and a source tarball
-        run: |
-          VERSION=${GITHUB_REF_NAME#releases/v}
-          VERSION=$VERSION python -m build --sdist --wheel --outdir dist/ .
-
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verbose: true
-          packages-dir: python/python-sdk/dist


### PR DESCRIPTION
Backport of #281 to the `releases/v1.3.x` line — Python SDK moves to **tag-only publishing**, aligned with terraform-provider-kestra / kestractl. Python only; java/javascript/go untouched.

## What changes

- **`python-sdk.yml`** → test/CI workflow only. The `publish` job (gated on push to `releases/v*`) is removed and the workflow renamed to *Python SDK tests*. It still runs on push/PR to `main` and `releases/v*`. The release branch's own test job is kept as-is (no unrelated `main`-only changes pulled in).
- **`python-sdk-release.yml`** (new) → triggered on `v*-python` tags. Resolves the version from the tag (`v1.0.13-python` → `1.0.13`), builds the wheel, publishes to PyPI.

## Behavior change

Before: merging to a `releases/v*` branch published to PyPI.
After: publish by pushing a `v*-python` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)