### PR TITLE
ci(java): move Maven Central publish to tag-only release

### DIFF
--- a/.github/workflows/java-sdk-release.yml
+++ b/.github/workflows/java-sdk-release.yml
@@ -1,0 +1,93 @@
+name: Java SDK release
+
+# Tag-only release, aligned with terraform-provider-kestra / kestractl.
+# Push a tag like `v1.0.13-java` to publish that version to Maven Central. The
+# tag is cut from an already-green release branch, so this workflow only builds
+# and publishes — tests run on push/PR via java-sdk.yml.
+on:
+  push:
+    tags:
+      - "v*-java"
+
+jobs:
+  publish:
+    name: Publish Java SDK
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+    defaults:
+      run:
+        working-directory: ./java/java-sdk
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve version from tag
+        id: version
+        run: |
+          # v1.0.13-java -> 1.0.13
+          VERSION=${GITHUB_REF_NAME#v}
+          VERSION=${VERSION%-java}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Caches
+      - name: Gradle cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*',
+            '**/gradle*.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # JDK
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: 21
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      # Publish
+      - name: Publish - Release package to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_GPG_KEYID: ${{ secrets.SONATYPE_GPG_KEYID }}
+          SONATYPE_GPG_PASSWORD: ${{ secrets.SONATYPE_GPG_PASSWORD }}
+          SONATYPE_GPG_FILE: ${{ secrets.SONATYPE_GPG_FILE}}
+        run: |
+          mkdir -p ~/.gradle/
+          echo "signing.keyId=${SONATYPE_GPG_KEYID}" > ~/.gradle/gradle.properties
+          echo "signing.password=${SONATYPE_GPG_PASSWORD}" >> ~/.gradle/gradle.properties
+          echo "signing.secretKeyRingFile=${HOME}/.gradle/secring.gpg" >> ~/.gradle/gradle.properties
+          echo ${SONATYPE_GPG_FILE} | base64 -d > ~/.gradle/secring.gpg
+          ./gradlew publishToMavenCentral -Pversion=${{ steps.version.outputs.version }}
+
+      # GitHub Release
+      - name: Create GitHub release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            build/libs/*.jar
+
+      # Slack
+      - name: Slack notification
+        uses: 8398a7/action-slack@v3
+        if: ${{ always() && env.SLACK_WEBHOOK_URL != 0 }}
+        with:
+          status: ${{ job.status }}
+          job_name: Publish
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+          username: GitHub Actions
+          icon_emoji: ":github-actions:"
+          channel: "C02DQ1A7JLR"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/java-sdk.yml
+++ b/.github/workflows/java-sdk.yml
@@ -1,4 +1,4 @@
-name: Java SDK release
+name: Java SDK tests
 
 on:
   push:
@@ -102,79 +102,3 @@ jobs:
           list-tests: "all"
           fail-on-error: "false"
           token: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
-    name: Publish Java SDK
-    runs-on: ubuntu-latest
-    needs: test
-    if: startsWith(github.ref, 'refs/heads/releases/')
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-    defaults:
-      run:
-        working-directory: ./java/java-sdk
-    steps:
-      - uses: actions/checkout@v5
-
-      # Caches
-      - name: Gradle cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*',
-            '**/gradle*.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      # JDK
-      - name: Set up JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: "temurin"
-          java-version: 21
-
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
-
-      # Publish
-      - name: Publish - Release package to Maven Central
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USER }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_GPG_KEYID: ${{ secrets.SONATYPE_GPG_KEYID }}
-          SONATYPE_GPG_PASSWORD: ${{ secrets.SONATYPE_GPG_PASSWORD }}
-          SONATYPE_GPG_FILE: ${{ secrets.SONATYPE_GPG_FILE}}
-        run: |
-          mkdir -p ~/.gradle/
-          echo "signing.keyId=${SONATYPE_GPG_KEYID}" > ~/.gradle/gradle.properties
-          echo "signing.password=${SONATYPE_GPG_PASSWORD}" >> ~/.gradle/gradle.properties
-          echo "signing.secretKeyRingFile=${HOME}/.gradle/secring.gpg" >> ~/.gradle/gradle.properties
-          echo ${SONATYPE_GPG_FILE} | base64 -d > ~/.gradle/secring.gpg
-          ./gradlew publishToMavenCentral
-
-      # GitHub Release
-      - name: Create GitHub release
-        uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
-          files: |
-            build/libs/*.jar
-
-      # Slack
-      - name: Slack notification
-        uses: 8398a7/action-slack@v3
-        if: ${{ always() && env.SLACK_WEBHOOK_URL != 0 }}
-        with:
-          status: ${{ job.status }}
-          job_name: Publish
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-          username: GitHub Actions
-          icon_emoji: ":github-actions:"
-          channel: "C02DQ1A7JLR"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Backport of #283 to the `releases/v1.3.x` line — moves the Java SDK release to the tag-only model (terraform-provider-kestra / kestractl), mirroring the Python backport #282.

## What changed
- **`java-sdk.yml`** → renamed *Java SDK release* → *Java SDK tests*; dropped the `publish` job (it ran on every push to `releases/v*`). Tests still run on push/PR.
- **`java-sdk-release.yml`** (new) → triggered on `v*-java` tags; resolves the version from the tag and runs the Maven Central publish + GitHub release + Slack steps.

## Notes
- Cherry-picked from #283. The cherry-pick conflicted only on the publish-job removal — `releases/v1.3.x` is behind `main` on `java-sdk.yml` (`actions/cache@v4` in the test job). I kept the release branch's own test job untouched and applied only the release-model change, so this PR pulls in no unrelated `main`-only changes.
- The tag is the source of truth for the published version (`-Pversion=`), avoiding `ciVersionOverride` which disables signing + Maven Central upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)