### PR TITLE
ci(javascript): move npm release publish to tag-only release

### DIFF
--- a/.github/workflows/javascript-sdk-release.yml
+++ b/.github/workflows/javascript-sdk-release.yml
@@ -1,0 +1,60 @@
+name: Javascript SDK release
+
+# Tag-only release, aligned with terraform-provider-kestra / kestractl.
+# Push a tag like `v1.0.13-javascript` to publish that version to npm. The tag
+# is cut from an already-green release branch, so this workflow only builds and
+# publishes — tests run on push/PR via javascript-sdk.yml. The tag is the source
+# of truth for the version (no npm auto-increment). Per-commit develop snapshots
+# stay in javascript-sdk.yml (publish-develop job, main only).
+on:
+  push:
+    tags:
+      - "v*-javascript"
+
+jobs:
+  publish:
+    name: Publish Release to Npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.18"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve version from tag
+        id: resolveVersion
+        run: |
+          # v1.0.13-javascript -> 1.0.13
+          VERSION=${GITHUB_REF_NAME#v}
+          VERSION=${VERSION%-javascript}
+          # moving dist-tag for the minor line, e.g. v1.0
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          echo "kestra_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "kestra_tag=v$MAJOR_MINOR" >> $GITHUB_OUTPUT
+
+      # Trusted publishing need npm 11.+
+      - name: Upgrade npm
+        run: |
+          npm install -g npm@latest
+          npm version
+
+      - name: Generate SDK
+        working-directory: .
+        run: |
+          ./generate-sdks.sh ${{ steps.resolveVersion.outputs.kestra_version }} \
+          javascript
+
+      - name: Publish to npm with latest tag
+        working-directory: ./javascript/javascript-sdk
+        run: npm publish --access public
+
+      - name: Add version tag
+        working-directory: ./javascript/javascript-sdk
+        run: npm dist-tag add @kestra-io/kestra-sdk@${{
+          steps.resolveVersion.outputs.kestra_version }} --tag ${{
+          steps.resolveVersion.outputs.kestra_tag }} --access public

--- a/.github/workflows/javascript-sdk.yml
+++ b/.github/workflows/javascript-sdk.yml
@@ -1,4 +1,4 @@
-name: Javascript SDK release
+name: Javascript SDK tests
 
 on:
   push:
@@ -132,79 +132,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: node .github/scripts/coverage-comment.mjs javascript/coverage/coverage-final.json javascript/coverage/test-results.json
-
-  publish-release:
-    name: Publish Release to Npm
-    runs-on: ubuntu-latest
-    needs: test
-    permissions:
-      contents: write
-      id-token: write
-    if: startsWith(github.ref, 'refs/heads/releases/')
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Compute Kestra version
-        id: version
-        uses: ./.github/actions/compute-version
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22.18"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Compute next version
-        id: resolveVersion
-        run: |
-          INPUT_VERSION=${{ steps.version.outputs.kestra_version }}
-
-          # strip leading "v" (npm versions are not v-prefixed) and trailing ".x"/".X"
-          VERSION_PREFIX=$(echo "$INPUT_VERSION" | sed -e 's/^v//' -e 's/\.[xX]$//')
-
-          echo "Version prefix: $VERSION_PREFIX"
-
-          # list all versions and filter those that start with the current version prefix (e.g., 1.2.)
-          # `|| true` so an empty grep does not abort the step under `bash -e`
-          VERSIONS=$(npm view @kestra-io/kestra-sdk versions --json 2>/dev/null | jq -r '.[]' 2>/dev/null | grep "^${VERSION_PREFIX}\." || true)
-
-          echo "Existing versions with prefix $VERSION_PREFIX: $VERSIONS"
-
-          # get the highest patch version, default to -1 when no prior patches exist
-          HIGHEST_PATCH=$(echo "$VERSIONS" | awk -F. '{print $NF}' | sort -nr | head -n 1)
-          if [ -z "$HIGHEST_PATCH" ]; then
-            HIGHEST_PATCH=-1
-          fi
-
-          echo "Highest patch version: $HIGHEST_PATCH"
-
-          # increment the patch version
-          NEXT_PATCH=$((HIGHEST_PATCH + 1))
-          NEXT_VERSION="$VERSION_PREFIX.$NEXT_PATCH"
-
-          echo "kestra_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-          echo "kestra_tag=v$VERSION_PREFIX" >> $GITHUB_OUTPUT
-
-      # Trusted publishing need npm 11.+
-      - name: Upgrade npm
-        run: |
-          npm install -g npm@latest
-          npm version
-
-      - name: Generate SDK
-        working-directory: .
-        run: |
-          ./generate-sdks.sh ${{ steps.resolveVersion.outputs.kestra_version }} \
-          javascript
-
-      - name: Publish to npm with latest tag
-        working-directory: ./javascript/javascript-sdk
-        run: npm publish --access public
-
-      - name: Add version tag
-        working-directory: ./javascript/javascript-sdk
-        run: npm dist-tag add @kestra-io/kestra-sdk@${{
-          steps.resolveVersion.outputs.kestra_version }} --tag ${{
-          steps.resolveVersion.outputs.kestra_tag }} --access public
 
   publish-develop:
     name: Publish Develop to Npm


### PR DESCRIPTION
Aligns the JavaScript SDK release with the tag-only model already adopted by terraform-provider-kestra / kestractl, matching the Python (#281) and Java (#283) splits.

## What changed
- **`javascript-sdk.yml`** → renamed *Javascript SDK release* → *Javascript SDK tests*; dropped the `publish-release` job. It keeps the `test` job **and** `publish-develop` (per-commit `2.0.0-kdevelop.*` snapshots on push to `main`), since those are not tag-driven releases.
- **`javascript-sdk-release.yml`** (new) → triggered on `v*-javascript` tag pushes. Resolves the version from the tag (`v1.3.5-javascript` → `1.3.5`), regenerates the SDK at that version, `npm publish`es it, and moves the `vX.Y` dist-tag — same publish/dist-tag steps as the old job.

## Decisions
- **Tag is authoritative for the version.** The old `publish-release` ignored any committed version and auto-incremented the patch by querying `npm view ... versions`. Per the alignment goal ("the tag is the version" across all four repos), that npm auto-increment is dropped — the tag states the full version, consistent with Python/Java/kestractl/terraform.
- **`publish-develop` stays put** in `javascript-sdk.yml`: it's a main-push dev-snapshot pipeline, not a release, so it can't be tag-driven. The file is now the main-push pipeline (test + develop snapshot).

## Pre-existing behavior kept as-is
`npm publish` still moves the `latest` dist-tag; the moving `vX.Y` dist-tag remains the per-line mitigation. Not changed here.

Go is the last language — it has no publish job (tag-native), so that one is convention-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)