### PR TITLE
ci(javascript): move npm release publish to tag-only release

### DIFF
--- a/.github/workflows/javascript-sdk-release.yml
+++ b/.github/workflows/javascript-sdk-release.yml
@@ -1,0 +1,60 @@
+name: Javascript SDK release
+
+# Tag-only release, aligned with terraform-provider-kestra / kestractl.
+# Push a tag like `v1.0.13-javascript` to publish that version to npm. The tag
+# is cut from an already-green release branch, so this workflow only builds and
+# publishes — tests run on push/PR via javascript-sdk.yml. The tag is the source
+# of truth for the version (no npm auto-increment). Per-commit develop snapshots
+# stay in javascript-sdk.yml (publish-develop job, main only).
+on:
+  push:
+    tags:
+      - "v*-javascript"
+
+jobs:
+  publish:
+    name: Publish Release to Npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.18"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve version from tag
+        id: resolveVersion
+        run: |
+          # v1.0.13-javascript -> 1.0.13
+          VERSION=${GITHUB_REF_NAME#v}
+          VERSION=${VERSION%-javascript}
+          # moving dist-tag for the minor line, e.g. v1.0
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          echo "kestra_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "kestra_tag=v$MAJOR_MINOR" >> $GITHUB_OUTPUT
+
+      # Trusted publishing need npm 11.+
+      - name: Upgrade npm
+        run: |
+          npm install -g npm@latest
+          npm version
+
+      - name: Generate SDK
+        working-directory: .
+        run: |
+          ./generate-sdks.sh ${{ steps.resolveVersion.outputs.kestra_version }} \
+          javascript
+
+      - name: Publish to npm with latest tag
+        working-directory: ./javascript/javascript-sdk
+        run: npm publish --access public
+
+      - name: Add version tag
+        working-directory: ./javascript/javascript-sdk
+        run: npm dist-tag add @kestra-io/kestra-sdk@${{
+          steps.resolveVersion.outputs.kestra_version }} --tag ${{
+          steps.resolveVersion.outputs.kestra_tag }} --access public

--- a/.github/workflows/javascript-sdk.yml
+++ b/.github/workflows/javascript-sdk.yml
@@ -1,4 +1,4 @@
-name: Javascript SDK release
+name: Javascript SDK tests
 
 on:
   push:
@@ -105,88 +105,6 @@ jobs:
         with:
           name: coverage-report
           path: ./coverage
-
-  publish-release:
-    name: Publish Release to Npm
-    runs-on: ubuntu-latest
-    needs: test
-    permissions:
-      contents: write
-      id-token: write
-    if: startsWith(github.ref, 'refs/heads/releases/')
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Compute Kestra version
-        id: version
-        uses: ./.github/actions/compute-version
-
-      - name: Get OIDC Token
-        env:
-          AUDIENCE: "npm:registry.npmjs.org"
-        run: |
-          TOKEN_JSON=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$AUDIENCE")
-          ID_TOKEN=$(echo "$TOKEN_JSON" | jq -r .value)
-          echo "$TOKEN_JSON"
-          echo "NODE_AUTH_TOKEN=$ID_TOKEN" >> "$GITHUB_ENV"
-          echo "$ID_TOKEN" | awk -F. '{print $2}' | base64 -d 2>/dev/null | jq -r
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22.18"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Compute next version
-        id: resolveVersion
-        run: |
-          INPUT_VERSION=${{ steps.version.outputs.kestra_version }}
-
-          # strip leading "v" (npm versions are not v-prefixed) and trailing ".x"/".X"
-          VERSION_PREFIX=$(echo "$INPUT_VERSION" | sed -e 's/^v//' -e 's/\.[xX]$//')
-
-          echo "Version prefix: $VERSION_PREFIX"
-
-          # list all versions and filter those that start with the current version prefix (e.g., 1.2.)
-          # `|| true` so an empty grep does not abort the step under `bash -e`
-          VERSIONS=$(npm view @kestra-io/kestra-sdk versions --json 2>/dev/null | jq -r '.[]' 2>/dev/null | grep "^${VERSION_PREFIX}\." || true)
-
-          echo "Existing versions with prefix $VERSION_PREFIX: $VERSIONS"
-
-          # get the highest patch version, default to -1 when no prior patches exist
-          HIGHEST_PATCH=$(echo "$VERSIONS" | awk -F. '{print $NF}' | sort -nr | head -n 1)
-          if [ -z "$HIGHEST_PATCH" ]; then
-            HIGHEST_PATCH=-1
-          fi
-
-          echo "Highest patch version: $HIGHEST_PATCH"
-
-          # increment the patch version
-          NEXT_PATCH=$((HIGHEST_PATCH + 1))
-          NEXT_VERSION="$VERSION_PREFIX.$NEXT_PATCH"
-
-          echo "kestra_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-          echo "kestra_tag=v$VERSION_PREFIX" >> $GITHUB_OUTPUT
-
-      # Trusted publishing need npm 11.+
-      - name: Upgrade npm
-        run: |
-          npm install -g npm@latest
-          npm version
-
-      - name: Generate SDK
-        working-directory: .
-        run: ./generate-sdks.sh ${{ steps.resolveVersion.outputs.kestra_version }}
-          javascript
-
-      - name: Publish to npm with latest tag
-        working-directory: ./javascript/javascript-sdk
-        run: npm publish --access public
-
-      - name: Add version tag
-        working-directory: ./javascript/javascript-sdk
-        run: npm dist-tag add @kestra-io/kestra-sdk@${{
-          steps.resolveVersion.outputs.kestra_version }} --tag ${{
-          steps.resolveVersion.outputs.kestra_tag }} --access public
 
   publish-develop:
     name: Publish Develop to Npm


### PR DESCRIPTION
Backport of #285 to the `releases/v1.3.x` line — moves the JavaScript SDK release to the tag-only model (terraform-provider-kestra / kestractl), mirroring the Python (#282) and Java (#284) backports.

## What changed
- **`javascript-sdk.yml`** → renamed *Javascript SDK release* → *Javascript SDK tests*; dropped the `publish-release` job. Keeps `test` + `publish-develop` (main-only dev snapshots).
- **`javascript-sdk-release.yml`** (new) → triggered on `v*-javascript` tags; resolves the version from the tag, regenerates the SDK at that version, publishes to npm, and moves the `vX.Y` dist-tag.

## Decisions (per #285)
- **Tag is authoritative for the version** — drops the old `npm view`-based patch auto-increment so the tag states the full version, consistent with the other repos.
- **`publish-develop` stays** in `javascript-sdk.yml` — it's a main-push snapshot pipeline, not a release.

## Notes
- Cherry-picked from #285. The cherry-pick conflicted only on the `publish-release` removal — `releases/v1.3.x` is behind `main` on `javascript-sdk.yml` (it still carries the manual `Get OIDC Token` step). I kept the release branch's own `test`/`publish-develop` jobs untouched and applied only the `publish-release` removal, so this PR pulls in no unrelated `main`-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)