### PR TITLE
docs(go): document the tag-only release mechanism

### DIFF
--- a/README_GO_SDK.md
+++ b/README_GO_SDK.md
@@ -48,3 +48,37 @@ request := apiClient.FlowsAPI.SearchFlows(ctx, tenantId).Page(1).Size(10)
 flows, resp, err := request.Execute()
 ```
 
+## Releasing
+
+Releasing is therefore a single action — pushing a Git tag.
+
+```bash
+git tag go-sdk/v1.1.0 <commit>
+git push origin go-sdk/v1.1.0
+```
+
+Consumers then pull that exact version with:
+
+```bash
+go get github.com/kestra-io/client-sdk/go-sdk@v1.1.0
+```
+
+On the first request for a new version, `proxy.golang.org` fetches this repo,
+finds the matching tag, zips the source, and caches it immutably (its checksum is
+also recorded in `sum.golang.org`). Nothing is published by CI — the tag *is* the
+release.
+
+### Tag format: `go-sdk/vX.Y.Z` (not `vX.Y.Z-go`)
+
+The other SDKs use a language suffix (`v1.2.3-java`, `-javascript`, `-python`) —
+an arbitrary string that only exists to trigger the right release workflow; the
+version is passed *into* the publish command, so the registry never sees the tag
+name.
+
+Go is the opposite: **the Go toolchain parses the tag name itself.** Because the
+module lives in the `go-sdk/` subdirectory (its module path ends in `/go-sdk`),
+the spec *requires* the tag to be `go-sdk/vMAJOR.MINOR.PATCH`. A `v1.1.0-go` tag
+would never be resolved by `go get` — so the per-language suffix convention
+deliberately does not apply here. The version is always the bare semver after the
+`go-sdk/` prefix.
+

--- a/README_GO_SDK.md
+++ b/README_GO_SDK.md
@@ -70,7 +70,7 @@ release.
 
 ### Tag format: `go-sdk/vX.Y.Z` (not `vX.Y.Z-go`)
 
-The other SDKs use a language suffix (`v1.2.3-java`, `-javascript`, `-python`) —
+The other SDKs use a language suffix (`v1.2.3-java`, `v1.2.3-javascript`, `v1.2.3-python`) —
 an arbitrary string that only exists to trigger the right release workflow; the
 version is passed *into* the publish command, so the registry never sees the tag
 name.


### PR DESCRIPTION
## What

Adds a **Releasing** section to `README_GO_SDK.md`.

Go is the only SDK with no publish job and no release workflow — and it doesn't need one. A Go module is served directly from the repo by `proxy.golang.org`, so a release is just a Git tag push. Until now that was tribal knowledge, encoded only in the existing `go-sdk/v1.0.0…v1.1.0` tags.

## Why

While aligning the SDKs on the tag-only release model (Python #281/#282, Java #283/#284, JavaScript #285/#286), Go stood out: a `*-release.yml` can't publish what the tag already publishes. The real gap was documentation, not a workflow.

The new section covers:
- releasing = push `go-sdk/vX.Y.Z`; consuming = `go get github.com/kestra-io/client-sdk/go-sdk@vX.Y.Z`;
- how `proxy.golang.org` / `sum.golang.org` serve the tag (no CI publish);
- **why the `vX.Y.Z-<lang>` suffix convention deliberately doesn't apply** — the Go toolchain parses the tag name, so a subdirectory module *must* be tagged `go-sdk/vX.Y.Z`.

Docs-only; no workflow or code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)