### PR TITLE
feat(js-sdk): add useExpressionResolver composable for Pebble expression resolution

### DIFF
--- a/javascript/javascript-sdk/package.json
+++ b/javascript/javascript-sdk/package.json
@@ -72,6 +72,9 @@
     "nprogress": "0.2.0",
     "axios": "1.16.1"
   },
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.97.3",
     "@types/node": "^25.9.1",

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -5,6 +5,7 @@ import { client } from "./openapi/client.gen"
 import type { ClientOptions, Config } from "./openapi/client"
 
 export * from "./openapi/index"
+export * from "./useExpressionResolver"
 
 declare global {
     interface Window {

--- a/javascript/javascript-sdk/src/useExpressionResolver.ts
+++ b/javascript/javascript-sdk/src/useExpressionResolver.ts
@@ -1,0 +1,104 @@
+import { ref, watch, readonly } from "vue";
+import type { Ref } from "vue";
+
+function resolveStaticPatterns(
+    value: string,
+    contexts: {
+        vars?: Record<string, string>;
+        namespace?: Record<string, string>;
+    },
+): string {
+    return value.replace(/\{\{\s*([\w]+(?:\.[\w]+)*)\s*\}\}/g, (match, path: string) => {
+        const dotIndex = path.indexOf(".");
+        if (dotIndex < 0) return match;
+        const ctx = path.slice(0, dotIndex);
+        const key = path.slice(dotIndex + 1);
+        if (ctx === "vars" && contexts.vars) {
+            const v = contexts.vars[key];
+            return v !== undefined ? v : match;
+        }
+        if (ctx === "namespace" && contexts.namespace) {
+            const v = contexts.namespace[key];
+            return v !== undefined ? v : match;
+        }
+        return match;
+    });
+}
+
+export interface ExpressionResolverFetchers {
+    fetchFlow: (params: {
+        namespace: string;
+        id: string;
+    }) => Promise<{ variables?: Record<string, string> }>;
+
+    fetchNamespaceVars?: (namespace: string) => Promise<Record<string, string>>;
+
+    evalExpression?: (params: {
+        executionId: string;
+        body: string;
+    }) => Promise<{ result?: string; error?: string }>;
+}
+
+export function useExpressionResolver(
+    namespace: Ref<string | undefined>,
+    flowId: Ref<string | undefined>,
+    executionId: Ref<string | undefined> | undefined,
+    fetchers: ExpressionResolverFetchers,
+) {
+    const flowVars = ref<Record<string, string>>({});
+    const nsVars = ref<Record<string, string>>({});
+
+    watch(
+        [namespace, flowId],
+        async ([ns, fid]) => {
+            if (!ns || !fid || ns.startsWith("{") || fid.startsWith("{")) return;
+            try {
+                const f = await fetchers.fetchFlow({ namespace: ns, id: fid });
+                flowVars.value = (f?.variables ?? {}) as Record<string, string>;
+            } catch {
+                /* best-effort */
+            }
+            if (fetchers.fetchNamespaceVars) {
+                try {
+                    nsVars.value = await fetchers.fetchNamespaceVars(ns);
+                } catch {
+                    /* best-effort */
+                }
+            }
+        },
+        { immediate: true },
+    );
+
+    function resolveSync(value: string | undefined): string | undefined {
+        if (!value) return value;
+        return resolveStaticPatterns(value, {
+            vars: flowVars.value,
+            namespace: nsVars.value,
+        });
+    }
+
+    async function resolve(value: string | undefined): Promise<string | undefined> {
+        if (!value) return value;
+        let out = resolveSync(value)!;
+        const execId = executionId?.value;
+        if (execId && fetchers.evalExpression && /\{\{/.test(out)) {
+            try {
+                const r = await fetchers.evalExpression({
+                    executionId: execId,
+                    body: out,
+                });
+                if (r?.result !== undefined) out = r.result;
+            } catch {
+                /* best-effort */
+            }
+        }
+        return out;
+    }
+
+    return {
+        resolve,
+        resolveSync,
+        flowVars: readonly(flowVars),
+        nsVars: readonly(nsVars),
+    };
+}


### PR DESCRIPTION
## Summary

- Ports [kestra-io/artifact-sdk#71](https://github.com/kestra-io/artifact-sdk/pull/71) to `@kestra-io/kestra-sdk`
- Plugin topology-details and modal components display raw task configuration that may contain Pebble expressions (`{{ vars.region }}`, `{{ namespace.x }}`, etc.) — these were shown verbatim instead of resolved values
- Layered resolution: client-side `vars.*` → `namespace.*` → optional server-side `evalExpression` when `executionId` is available

## Resolution layers

1. **`{{ vars.x }}`** — fetches flow `variables` map; works in editor without execution context
2. **`{{ namespace.x }}`** — fetches namespace variables (EE); requires optional `fetchNamespaceVars` fetcher
3. **`evalExpression`** — server-side fallback for remaining `{{ … }}` when `executionId` present; resolves `inputs`, `outputs`, `trigger`, `envs`, `globals`
4. **Unresolvable** — secrets/credentials returned as-is

## API

```ts
import { flow } from "@kestra-io/kestra-sdk/flows";
import { evalExpression } from "@kestra-io/kestra-sdk/executions";
import { useExpressionResolver } from "@kestra-io/kestra-sdk";

const { resolveSync, resolve } = useExpressionResolver(
  computed(() => props.namespace),
  computed(() => props.flowId),
  computed(() => props.execution?.id as string | undefined),
  { fetchFlow: flow, evalExpression },
);

// Sync (editor view, inside computed()):
const region = computed(() => resolveSync(props.taskRunner?.region));

// Async (post-execution, resolves inputs/outputs/trigger/envs):
const region = ref<string>();
watch(() => props.taskRunner?.region, async (v) => { region.value = await resolve(v); }, { immediate: true });
```

## Design notes

Fetchers are injected (not imported internally) so the composable stays decoupled from specific API modules. `vue` added as peer dependency (`^3.0.0`).

## Test plan

- [ ] Build passes (`npm run build` in `javascript/javascript-sdk`)
- [ ] Consumers import `useExpressionResolver` from `@kestra-io/kestra-sdk` and call with `fetchFlow` + optional `evalExpression`
- [ ] `resolveSync` resolves `{{ vars.x }}` against flow variables in editor view (no execution required)
- [ ] `resolve` falls back to `evalExpression` when `executionId` available and unresolved `{{ … }}` remain
- [ ] Unresolvable expressions (secrets, missing vars) returned as-is