### PR TITLE
feat: add BindingsApi, InvitationsApi, TenantAccessApi and tenant-scoped ServiceAccount list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ except ApiException as err:
 
 ### Java (`io.kestra:kestra-api-client`)
 
-- Add the dependency to your build: `io.kestra:kestra-api-client:1.0.0`.
+- Add the dependency to your build: `io.kestra:kestra-api-client:1.3.0`.
 - Basic authentication uses the builder method `.basicAuth(username, password)`. Service accounts call `.tokenAuth("<service-account-api-key>")` instead.
 
 <details>
@@ -128,7 +128,7 @@ except ApiException as err:
 <summary>Gradle (Kotlin DSL)</summary>
 
 ```kotlin
-implementation("io.kestra:kestra-api-client:1.0.0")
+implementation("io.kestra:kestra-api-client:1.3.0")
 ```
 
 </details>

--- a/java/java-sdk/gradle.properties
+++ b/java/java-sdk/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.11
+version=1.0.12

--- a/java/java-sdk/gradle.properties
+++ b/java/java-sdk/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.12
+version=1.3.0

--- a/java/java-sdk/gradle.properties
+++ b/java/java-sdk/gradle.properties
@@ -1,1 +1,1 @@
-version=1.3.0
+version=1.0.12

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BindingsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BindingsApiTest.java
@@ -1,0 +1,120 @@
+package io.kestra.sdk.api;
+
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.*;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+
+import static io.kestra.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class BindingsApiTest {
+
+    static BindingsApi api() {
+        return client().bindings();
+    }
+
+    static RolesApi rolesApi() {
+        return client().roles();
+    }
+
+    static UsersApi usersApi() {
+        return client().users();
+    }
+
+    static IAMRoleControllerApiRoleDetail createTestRole() throws ApiException {
+        IAMRoleControllerApiRoleCreateOrUpdateRequest req = new IAMRoleControllerApiRoleCreateOrUpdateRequest()
+                .name("binding-role-" + randomId())
+                .description("Role for binding tests")
+                .permissions(new IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions());
+        return rolesApi().createRole(TENANT, req);
+    }
+
+    static IAMUserControllerApiUser createTestUser() throws ApiException {
+        IAMUserControllerApiCreateOrUpdateUserRequest req =
+                new IAMUserControllerApiCreateOrUpdateUserRequest()
+                        .email("binding-" + randomId() + "@test.com")
+                        .firstName("Binding")
+                        .lastName("User")
+                        .password("TestPass!1234");
+        return usersApi().createUser(req);
+    }
+
+    // ========================================================================
+    // CRUD
+    // ========================================================================
+
+    @Test
+    void createBinding_userBinding() throws ApiException {
+        IAMRoleControllerApiRoleDetail role = createTestRole();
+        IAMUserControllerApiUser user = createTestUser();
+
+        IAMBindingControllerApiCreateBindingRequest request = new IAMBindingControllerApiCreateBindingRequest()
+                .type(BindingType.USER)
+                .externalId(user.getId())
+                .roleId(role.getId());
+
+        IAMBindingControllerApiBindingDetail result = api().createBinding(TENANT, request);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isNotBlank();
+        assertThat(result.getType()).isEqualTo(BindingType.USER);
+    }
+
+    @Test
+    void deleteBinding_basic() throws ApiException {
+        IAMRoleControllerApiRoleDetail role = createTestRole();
+        IAMUserControllerApiUser user = createTestUser();
+
+        IAMBindingControllerApiCreateBindingRequest request = new IAMBindingControllerApiCreateBindingRequest()
+                .type(BindingType.USER)
+                .externalId(user.getId())
+                .roleId(role.getId());
+
+        IAMBindingControllerApiBindingDetail created = api().createBinding(TENANT, request);
+
+        assertThatCode(() -> api().deleteBinding(created.getId(), TENANT))
+                .doesNotThrowAnyException();
+    }
+
+    // ========================================================================
+    // Search
+    // ========================================================================
+
+    @Test
+    void searchBindings_basic() throws ApiException {
+        IAMRoleControllerApiRoleDetail role = createTestRole();
+        IAMUserControllerApiUser user = createTestUser();
+        api().createBinding(TENANT, new IAMBindingControllerApiCreateBindingRequest()
+                .type(BindingType.USER)
+                .externalId(user.getId())
+                .roleId(role.getId()));
+
+        PagedResultsIAMBindingControllerApiBindingDetail result =
+                api().searchBindings(TENANT, 1, 10, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void searchBindings_withPagination() throws ApiException {
+        PagedResultsIAMBindingControllerApiBindingDetail result =
+                api().searchBindings(TENANT, 1, 2, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull();
+        assertThat(result.getResults().size()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void searchBindings_withSort() throws ApiException {
+        PagedResultsIAMBindingControllerApiBindingDetail result =
+                api().searchBindings(TENANT, 1, 10, List.of("type:asc"), null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull();
+    }
+}

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/InvitationsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/InvitationsApiTest.java
@@ -1,0 +1,81 @@
+package io.kestra.sdk.api;
+
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.*;
+import org.junit.jupiter.api.*;
+
+import static io.kestra.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class InvitationsApiTest {
+
+    static InvitationsApi api() {
+        return client().invitations();
+    }
+
+    static IAMInvitationControllerApiInvitationDetail createTestInvitation(String email) throws ApiException {
+        IAMInvitationControllerApiInvitationCreateRequest request =
+                new IAMInvitationControllerApiInvitationCreateRequest()
+                        .email(email)
+                        .createUserIfNotExist(true);
+        return api().createInvitation(TENANT, request);
+    }
+
+    // ========================================================================
+    // CRUD
+    // ========================================================================
+
+    @Test
+    void createInvitation_basic() throws ApiException {
+        String email = "invite-" + randomId() + "@test.com";
+        IAMInvitationControllerApiInvitationDetail result = createTestInvitation(email);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isNotBlank();
+        assertThat(result.getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    void deleteInvitation_basic() throws ApiException {
+        String email = "invite-del-" + randomId() + "@test.com";
+        IAMInvitationControllerApiInvitationDetail created = createTestInvitation(email);
+
+        assertThatCode(() -> api().deleteInvitation(created.getId(), TENANT))
+                .doesNotThrowAnyException();
+    }
+
+    // ========================================================================
+    // Search
+    // ========================================================================
+
+    @Test
+    void searchInvitations_basic() throws ApiException {
+        createTestInvitation("invite-search-" + randomId() + "@test.com");
+
+        PagedResultsIAMInvitationControllerApiInvitationDetail result =
+                api().searchInvitations(TENANT, 1, 10, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void searchInvitations_withPagination() throws ApiException {
+        PagedResultsIAMInvitationControllerApiInvitationDetail result =
+                api().searchInvitations(TENANT, 1, 2, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull();
+        assertThat(result.getResults().size()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void searchInvitations_withSort() throws ApiException {
+        PagedResultsIAMInvitationControllerApiInvitationDetail result =
+                api().searchInvitations(TENANT, 1, 10, java.util.List.of("email:asc"), null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull();
+    }
+}

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/InvitationsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/InvitationsApiTest.java
@@ -4,6 +4,8 @@ import io.kestra.sdk.internal.ApiException;
 import io.kestra.sdk.model.*;
 import org.junit.jupiter.api.*;
 
+import java.util.List;
+
 import static io.kestra.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -14,12 +16,13 @@ public class InvitationsApiTest {
         return client().invitations();
     }
 
-    static IAMInvitationControllerApiInvitationDetail createTestInvitation(String email) throws ApiException {
+    // Creates an actual invitation (201) — omitting createUserIfNotExist so the
+    // server does not short-circuit to a direct access grant (204).
+    static void createTestInvitation(String email) throws ApiException {
         IAMInvitationControllerApiInvitationCreateRequest request =
                 new IAMInvitationControllerApiInvitationCreateRequest()
-                        .email(email)
-                        .createUserIfNotExist(true);
-        return api().createInvitation(TENANT, request);
+                        .email(email);
+        api().createInvitation(TENANT, request);
     }
 
     // ========================================================================
@@ -29,19 +32,20 @@ public class InvitationsApiTest {
     @Test
     void createInvitation_basic() throws ApiException {
         String email = "invite-" + randomId() + "@test.com";
-        IAMInvitationControllerApiInvitationDetail result = createTestInvitation(email);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getId()).isNotBlank();
-        assertThat(result.getEmail()).isEqualTo(email);
+        assertThatCode(() -> createTestInvitation(email)).doesNotThrowAnyException();
     }
 
     @Test
     void deleteInvitation_basic() throws ApiException {
         String email = "invite-del-" + randomId() + "@test.com";
-        IAMInvitationControllerApiInvitationDetail created = createTestInvitation(email);
+        createTestInvitation(email);
 
-        assertThatCode(() -> api().deleteInvitation(created.getId(), TENANT))
+        List<IAMInvitationControllerApiInvitationDetail> invitations =
+                api().listInvitationsByEmail(TENANT, email);
+        assertThat(invitations).isNotNull().isNotEmpty();
+
+        String id = invitations.get(0).getId();
+        assertThatCode(() -> api().deleteInvitation(id, TENANT))
                 .doesNotThrowAnyException();
     }
 

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ServiceAccountApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ServiceAccountApiTest.java
@@ -217,6 +217,34 @@ public class ServiceAccountApiTest {
     }
 
     // ========================================================================
+    // Listing (tenant-scoped)
+    // ========================================================================
+
+    @Test
+    void listServiceAccountsForTenant_basic() throws ApiException {
+        api().createServiceAccountForTenant(TENANT,
+                new IAMServiceAccountControllerApiServiceAccountRequest()
+                        .name("sa-list-tenant-" + randomId())
+                        .description("Tenant list test"));
+
+        PagedResultsIAMServiceAccountControllerApiServiceAccountDetail result =
+                api().listServiceAccountsForTenant(TENANT, 1, 10, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void listServiceAccountsForTenant_withPagination() throws ApiException {
+        PagedResultsIAMServiceAccountControllerApiServiceAccountDetail result =
+                api().listServiceAccountsForTenant(TENANT, 1, 2, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull();
+        assertThat(result.getResults().size()).isLessThanOrEqualTo(2);
+    }
+
+    // ========================================================================
     // API tokens (tenant-scoped)
     // ========================================================================
 

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/TenantAccessApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/TenantAccessApiTest.java
@@ -1,0 +1,83 @@
+package io.kestra.sdk.api;
+
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.*;
+import org.junit.jupiter.api.*;
+
+import static io.kestra.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TenantAccessApiTest {
+
+    static TenantAccessApi api() {
+        return client().tenantAccess();
+    }
+
+    static UsersApi usersApi() {
+        return client().users();
+    }
+
+    static IAMUserControllerApiUser createTestUser() throws ApiException {
+        IAMUserControllerApiCreateOrUpdateUserRequest req =
+                new IAMUserControllerApiCreateOrUpdateUserRequest()
+                        .email("ta-" + randomId() + "@test.com")
+                        .firstName("TenantAccess")
+                        .lastName("User")
+                        .password("TestPass!1234");
+        return usersApi().createUser(req);
+    }
+
+    // ========================================================================
+    // CRUD
+    // ========================================================================
+
+    @Test
+    void createTenantAccess_basic() throws ApiException {
+        IAMUserControllerApiUser user = createTestUser();
+
+        IAMTenantAccessControllerApiCreateTenantAccessRequest request =
+                new IAMTenantAccessControllerApiCreateTenantAccessRequest()
+                        .email(user.getEmail());
+
+        IAMTenantAccessControllerApiUserTenantAccess result = api().createTenantAccess(TENANT, request);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isNotBlank();
+        assertThat(result.getUsername()).isEqualTo(user.getEmail());
+    }
+
+    @Test
+    void deleteTenantAccess_basic() throws ApiException {
+        IAMUserControllerApiUser user = createTestUser();
+
+        api().createTenantAccess(TENANT,
+                new IAMTenantAccessControllerApiCreateTenantAccessRequest().email(user.getEmail()));
+
+        assertThatCode(() -> api().deleteTenantAccess(user.getId(), TENANT))
+                .doesNotThrowAnyException();
+    }
+
+    // ========================================================================
+    // List
+    // ========================================================================
+
+    @Test
+    void listTenantAccess_basic() throws ApiException {
+        PagedResultsIAMTenantAccessControllerApiUserTenantAccess result =
+                api().listTenantAccess(TENANT, 1, 10);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void listTenantAccess_withPagination() throws ApiException {
+        PagedResultsIAMTenantAccessControllerApiUserTenantAccess result =
+                api().listTenantAccess(TENANT, 1, 2);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResults()).isNotNull();
+        assertThat(result.getResults().size()).isLessThanOrEqualTo(2);
+    }
+}

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/TenantAccessApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/TenantAccessApiTest.java
@@ -40,11 +40,8 @@ public class TenantAccessApiTest {
                 new IAMTenantAccessControllerApiCreateTenantAccessRequest()
                         .email(user.getEmail());
 
-        IAMTenantAccessControllerApiUserTenantAccess result = api().createTenantAccess(TENANT, request);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getId()).isNotBlank();
-        assertThat(result.getUsername()).isEqualTo(user.getEmail());
+        assertThatCode(() -> api().createTenantAccess(TENANT, request))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/java/java-sdk/pom.xml
+++ b/java/java-sdk/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>kestra-api-client</artifactId>
     <packaging>jar</packaging>
     <name>kestra-api-client</name>
-    <version>1.0.11</version>
+    <version>1.3.0</version>
     <url>https://github.com/openapitools/openapi-generator</url>
     <description>OpenAPI Java</description>
     <scm>

--- a/java/java-sdk/src/main/java/io/kestra/sdk/KestraClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/KestraClient.java
@@ -82,6 +82,12 @@ public class KestraClient {
 
     public ServiceAccountApi serviceAccount() { return new ServiceAccountApi(this.apiClient); }
 
+    public BindingsApi bindings() { return new BindingsApi(this.apiClient); }
+
+    public InvitationsApi invitations() { return new InvitationsApi(this.apiClient); }
+
+    public TenantAccessApi tenantAccess() { return new TenantAccessApi(this.apiClient); }
+
     public TestSuitesApi testSuites() { return new TestSuitesApi(this.apiClient); }
 
     public FilesApi files() { return new FilesApi(this.apiClient); }

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/BindingsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/BindingsApi.java
@@ -1,0 +1,89 @@
+package io.kestra.sdk.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.kestra.sdk.internal.ApiClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.internal.BaseApi;
+import io.kestra.sdk.internal.Configuration;
+import io.kestra.sdk.internal.Pair;
+
+import io.kestra.sdk.model.IAMBindingControllerApiBindingDetail;
+import io.kestra.sdk.model.IAMBindingControllerApiCreateBindingRequest;
+import io.kestra.sdk.model.PagedResultsIAMBindingControllerApiBindingDetail;
+import io.kestra.sdk.model.QueryFilter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BindingsApi extends BaseApi {
+
+    public BindingsApi() {
+        super(Configuration.getDefaultApiClient());
+    }
+
+    public BindingsApi(ApiClient apiClient) {
+        super(apiClient);
+    }
+
+    // ---- HTTP helpers ----
+
+    private <T> T get(String path, List<Pair> queryParams, List<Pair> collectionQueryParams,
+                      TypeReference<T> returnType) throws ApiException {
+        return invoke("GET", path, null, queryParams, collectionQueryParams,
+                JSON, null, returnType);
+    }
+
+    private <T> T postJson(String path, Object body, List<Pair> queryParams,
+                           List<Pair> collectionQueryParams,
+                           TypeReference<T> returnType) throws ApiException {
+        return invoke("POST", path, body, queryParams, collectionQueryParams,
+                JSON, JSON, returnType);
+    }
+
+    private void delete(String path) throws ApiException {
+        invoke("DELETE", path, null, Collections.emptyList(), Collections.emptyList(),
+                null, null, null);
+    }
+
+    // ========================================================================
+    // CRUD
+    // ========================================================================
+
+    public IAMBindingControllerApiBindingDetail createBinding(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nonnull IAMBindingControllerApiCreateBindingRequest request) throws ApiException {
+        return postJson(
+                tenantPath(tenant, "bindings"),
+                request, Collections.emptyList(), Collections.emptyList(),
+                new TypeReference<>() {});
+    }
+
+    public void deleteBinding(
+            @jakarta.annotation.Nonnull String id,
+            @jakarta.annotation.Nonnull String tenant) throws ApiException {
+        delete(tenantPath(tenant, "bindings", id));
+    }
+
+    // ========================================================================
+    // Search
+    // ========================================================================
+
+    public PagedResultsIAMBindingControllerApiBindingDetail searchBindings(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nullable Integer page,
+            @jakarta.annotation.Nullable Integer size,
+            @jakarta.annotation.Nullable List<String> sort,
+            @jakarta.annotation.Nullable List<QueryFilter> filters) throws ApiException {
+        List<Pair> collectionParams = new ArrayList<>();
+        collectionParams.addAll(csvParams("sort", sort));
+        collectionParams.addAll(filterParams(filters));
+        return get(
+                tenantPath(tenant, "bindings", "search"),
+                queryParams("page", page, "size", size),
+                collectionParams,
+                new TypeReference<>() {});
+    }
+
+}

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/InvitationsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/InvitationsApi.java
@@ -35,13 +35,6 @@ public class InvitationsApi extends BaseApi {
                 JSON, null, returnType);
     }
 
-    private <T> T postJson(String path, Object body, List<Pair> queryParams,
-                           List<Pair> collectionQueryParams,
-                           TypeReference<T> returnType) throws ApiException {
-        return invoke("POST", path, body, queryParams, collectionQueryParams,
-                JSON, JSON, returnType);
-    }
-
     private void delete(String path) throws ApiException {
         invoke("DELETE", path, null, Collections.emptyList(), Collections.emptyList(),
                 null, null, null);
@@ -51,12 +44,19 @@ public class InvitationsApi extends BaseApi {
     // CRUD
     // ========================================================================
 
-    public IAMInvitationControllerApiInvitationDetail createInvitation(
+    public void createInvitation(
             @jakarta.annotation.Nonnull String tenant,
             @jakarta.annotation.Nonnull IAMInvitationControllerApiInvitationCreateRequest request) throws ApiException {
-        return postJson(
-                tenantPath(tenant, "invitations"),
-                request, Collections.emptyList(), Collections.emptyList(),
+        invoke("POST", tenantPath(tenant, "invitations"), request,
+                Collections.emptyList(), Collections.emptyList(), JSON, JSON, null);
+    }
+
+    public List<IAMInvitationControllerApiInvitationDetail> listInvitationsByEmail(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nonnull String email) throws ApiException {
+        return get(
+                tenantPath(tenant, "invitations", "email", email),
+                Collections.emptyList(), Collections.emptyList(),
                 new TypeReference<>() {});
     }
 

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/InvitationsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/InvitationsApi.java
@@ -1,0 +1,89 @@
+package io.kestra.sdk.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.kestra.sdk.internal.ApiClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.internal.BaseApi;
+import io.kestra.sdk.internal.Configuration;
+import io.kestra.sdk.internal.Pair;
+
+import io.kestra.sdk.model.IAMInvitationControllerApiInvitationCreateRequest;
+import io.kestra.sdk.model.IAMInvitationControllerApiInvitationDetail;
+import io.kestra.sdk.model.PagedResultsIAMInvitationControllerApiInvitationDetail;
+import io.kestra.sdk.model.QueryFilter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class InvitationsApi extends BaseApi {
+
+    public InvitationsApi() {
+        super(Configuration.getDefaultApiClient());
+    }
+
+    public InvitationsApi(ApiClient apiClient) {
+        super(apiClient);
+    }
+
+    // ---- HTTP helpers ----
+
+    private <T> T get(String path, List<Pair> queryParams, List<Pair> collectionQueryParams,
+                      TypeReference<T> returnType) throws ApiException {
+        return invoke("GET", path, null, queryParams, collectionQueryParams,
+                JSON, null, returnType);
+    }
+
+    private <T> T postJson(String path, Object body, List<Pair> queryParams,
+                           List<Pair> collectionQueryParams,
+                           TypeReference<T> returnType) throws ApiException {
+        return invoke("POST", path, body, queryParams, collectionQueryParams,
+                JSON, JSON, returnType);
+    }
+
+    private void delete(String path) throws ApiException {
+        invoke("DELETE", path, null, Collections.emptyList(), Collections.emptyList(),
+                null, null, null);
+    }
+
+    // ========================================================================
+    // CRUD
+    // ========================================================================
+
+    public IAMInvitationControllerApiInvitationDetail createInvitation(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nonnull IAMInvitationControllerApiInvitationCreateRequest request) throws ApiException {
+        return postJson(
+                tenantPath(tenant, "invitations"),
+                request, Collections.emptyList(), Collections.emptyList(),
+                new TypeReference<>() {});
+    }
+
+    public void deleteInvitation(
+            @jakarta.annotation.Nonnull String id,
+            @jakarta.annotation.Nonnull String tenant) throws ApiException {
+        delete(tenantPath(tenant, "invitations", id));
+    }
+
+    // ========================================================================
+    // Search
+    // ========================================================================
+
+    public PagedResultsIAMInvitationControllerApiInvitationDetail searchInvitations(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nullable Integer page,
+            @jakarta.annotation.Nullable Integer size,
+            @jakarta.annotation.Nullable List<String> sort,
+            @jakarta.annotation.Nullable List<QueryFilter> filters) throws ApiException {
+        List<Pair> collectionParams = new ArrayList<>();
+        collectionParams.addAll(csvParams("sort", sort));
+        collectionParams.addAll(filterParams(filters));
+        return get(
+                tenantPath(tenant, "invitations", "search"),
+                queryParams("page", page, "size", size),
+                collectionParams,
+                new TypeReference<>() {});
+    }
+
+}

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/ServiceAccountApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/ServiceAccountApi.java
@@ -191,6 +191,24 @@ public class ServiceAccountApi extends BaseApi {
                 null, null, null);
     }
 
+    public PagedResultsIAMServiceAccountControllerApiServiceAccountDetail listServiceAccountsForTenant(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nullable Integer page,
+            @jakarta.annotation.Nullable Integer size,
+            @jakarta.annotation.Nullable List<String> sort,
+            @jakarta.annotation.Nullable List<QueryFilter> filters) throws ApiException {
+        List<Pair> collectionParams = new ArrayList<>();
+        collectionParams.addAll(csvParams("sort", sort));
+        collectionParams.addAll(filterParams(filters));
+        return invoke("GET",
+                tenantPath(tenant, "service-accounts"),
+                null,
+                queryParams("page", page, "size", size),
+                collectionParams,
+                JSON, null,
+                new TypeReference<>() {});
+    }
+
     // ========================================================================
     // API tokens (Tenant-scoped)
     // ========================================================================

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/TenantAccessApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/TenantAccessApi.java
@@ -1,0 +1,82 @@
+package io.kestra.sdk.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.kestra.sdk.internal.ApiClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.internal.BaseApi;
+import io.kestra.sdk.internal.Configuration;
+import io.kestra.sdk.internal.Pair;
+
+import io.kestra.sdk.model.IAMTenantAccessControllerApiCreateTenantAccessRequest;
+import io.kestra.sdk.model.IAMTenantAccessControllerApiUserTenantAccess;
+import io.kestra.sdk.model.PagedResultsIAMTenantAccessControllerApiUserTenantAccess;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TenantAccessApi extends BaseApi {
+
+    public TenantAccessApi() {
+        super(Configuration.getDefaultApiClient());
+    }
+
+    public TenantAccessApi(ApiClient apiClient) {
+        super(apiClient);
+    }
+
+    // ---- HTTP helpers ----
+
+    private <T> T get(String path, List<Pair> queryParams, List<Pair> collectionQueryParams,
+                      TypeReference<T> returnType) throws ApiException {
+        return invoke("GET", path, null, queryParams, collectionQueryParams,
+                JSON, null, returnType);
+    }
+
+    private <T> T postJson(String path, Object body, List<Pair> queryParams,
+                           List<Pair> collectionQueryParams,
+                           TypeReference<T> returnType) throws ApiException {
+        return invoke("POST", path, body, queryParams, collectionQueryParams,
+                JSON, JSON, returnType);
+    }
+
+    private void delete(String path) throws ApiException {
+        invoke("DELETE", path, null, Collections.emptyList(), Collections.emptyList(),
+                null, null, null);
+    }
+
+    // ========================================================================
+    // CRUD
+    // ========================================================================
+
+    public IAMTenantAccessControllerApiUserTenantAccess createTenantAccess(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nonnull IAMTenantAccessControllerApiCreateTenantAccessRequest request) throws ApiException {
+        return postJson(
+                tenantPath(tenant, "tenant-access"),
+                request, Collections.emptyList(), Collections.emptyList(),
+                new TypeReference<>() {});
+    }
+
+    public void deleteTenantAccess(
+            @jakarta.annotation.Nonnull String userId,
+            @jakarta.annotation.Nonnull String tenant) throws ApiException {
+        delete(tenantPath(tenant, "tenant-access", userId));
+    }
+
+    // ========================================================================
+    // List
+    // ========================================================================
+
+    public PagedResultsIAMTenantAccessControllerApiUserTenantAccess listTenantAccess(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nullable Integer page,
+            @jakarta.annotation.Nullable Integer size) throws ApiException {
+        return get(
+                tenantPath(tenant, "tenant-access"),
+                queryParams("page", page, "size", size),
+                Collections.emptyList(),
+                new TypeReference<>() {});
+    }
+
+}

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/TenantAccessApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/TenantAccessApi.java
@@ -49,13 +49,11 @@ public class TenantAccessApi extends BaseApi {
     // CRUD
     // ========================================================================
 
-    public IAMTenantAccessControllerApiUserTenantAccess createTenantAccess(
+    public void createTenantAccess(
             @jakarta.annotation.Nonnull String tenant,
             @jakarta.annotation.Nonnull IAMTenantAccessControllerApiCreateTenantAccessRequest request) throws ApiException {
-        return postJson(
-                tenantPath(tenant, "tenant-access"),
-                request, Collections.emptyList(), Collections.emptyList(),
-                new TypeReference<>() {});
+        invoke("POST", tenantPath(tenant, "tenant-access"), request,
+                Collections.emptyList(), Collections.emptyList(), JSON, JSON, null);
     }
 
     public void deleteTenantAccess(

--- a/java/java-sdk/src/main/java/io/kestra/sdk/internal/Configuration.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/internal/Configuration.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")public class Configuration {
-  public static final String VERSION = "1.0.11";
+  public static final String VERSION = "1.3.0";
 
   private static final AtomicReference<ApiClient> defaultApiClient = new AtomicReference<>();
   private static volatile Supplier<ApiClient> apiClientFactory = ApiClient::new;


### PR DESCRIPTION
## Summary

- Add `BindingsApi` with `createBinding`, `deleteBinding`, `searchBindings`
- Add `InvitationsApi` with `createInvitation`, `deleteInvitation`, `searchInvitations`
- Add `TenantAccessApi` with `createTenantAccess`, `deleteTenantAccess`, `listTenantAccess`
- Add `ServiceAccountApi.listServiceAccountsForTenant` for tenant-scoped listing
- Wire all three new APIs into `KestraClient`

part-of: https://github.com/kestra-io/kestra-ee/issues/8772

## Test plan

- [ ] `./gradlew build` compiles cleanly with Java 21
- [ ] All new API classes follow the `GroupsApi` pattern (extend `BaseApi`, use helper methods)
- [ ] Companion plugin PR: kestra-io/plugin-kestra feat/iam-tasks

---
*[View as Artifact](https://claude.ai/code/artifact/00822bd0-6aca-4a25-b4d3-6110c395c595)*