### PR TITLE
feat: add BindingsApi and TenantAccessApi to Python and Go SDKs

### DIFF
--- a/go-sdk/kestra_api_client/client.go
+++ b/go-sdk/kestra_api_client/client.go
@@ -170,3 +170,7 @@ func (c *KestraClient) Blueprints() *BlueprintsAPI {
 func (c *KestraClient) Invitations() *InvitationsAPI {
 	return &InvitationsAPI{baseAPI{client: c}}
 }
+
+func (c *KestraClient) TenantAccess() *TenantAccessAPI {
+	return &TenantAccessAPI{baseAPI{client: c}}
+}

--- a/go-sdk/kestra_api_client/tenant_access_api.go
+++ b/go-sdk/kestra_api_client/tenant_access_api.go
@@ -1,0 +1,20 @@
+package kestra_api_client
+
+import "context"
+
+type TenantAccessAPI struct {
+	baseAPI
+}
+
+func (a *TenantAccessAPI) CreateTenantAccess(ctx context.Context, tenant string, request IAMTenantAccessControllerApiCreateTenantAccessRequest) error {
+	return a.doVoidJSON(ctx, "POST", tenantPath(tenant, "tenant-access"), request, nil)
+}
+
+func (a *TenantAccessAPI) DeleteTenantAccess(ctx context.Context, userId, tenant string) error {
+	return a.doVoidJSON(ctx, "DELETE", tenantPath(tenant, "tenant-access", userId), nil, nil)
+}
+
+func (a *TenantAccessAPI) ListTenantAccess(ctx context.Context, tenant string, page, size *int) (*PagedResultsIAMTenantAccessControllerApiUserTenantAccess, error) {
+	params := buildQueryParams("page", page, "size", size)
+	return doJSON[*PagedResultsIAMTenantAccessControllerApiUserTenantAccess](&a.baseAPI, ctx, "GET", tenantPath(tenant, "tenant-access"), nil, params)
+}

--- a/go-sdk/test/api_tenant_access_test.go
+++ b/go-sdk/test/api_tenant_access_test.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantAccessAPI_All(t *testing.T) {
+	t.Run("createAndListTenantAccessTest", func(t *testing.T) {
+		ctx := context.Background()
+		email := "sdktest_ta_" + randomId() + "@kestra.io"
+		req := kestra_api_client.NewIAMTenantAccessControllerApiCreateTenantAccessRequest(email)
+
+		err := KestraTestClient().TenantAccess().CreateTenantAccess(ctx, MAIN_TENANT, *req)
+		require.NoError(t, err)
+
+		page, err := KestraTestClient().TenantAccess().ListTenantAccess(ctx, MAIN_TENANT, kestra_api_client.PtrInt(1), kestra_api_client.PtrInt(100))
+		require.NoError(t, err)
+		require.NotNil(t, page)
+		require.Greater(t, len(page.GetResults()), 0)
+	})
+
+	t.Run("deleteTenantAccessTest", func(t *testing.T) {
+		ctx := context.Background()
+		email := "sdktest_ta_del_" + randomId() + "@kestra.io"
+		req := kestra_api_client.NewIAMTenantAccessControllerApiCreateTenantAccessRequest(email)
+
+		err := KestraTestClient().TenantAccess().CreateTenantAccess(ctx, MAIN_TENANT, *req)
+		require.NoError(t, err)
+
+		page, err := KestraTestClient().TenantAccess().ListTenantAccess(ctx, MAIN_TENANT, kestra_api_client.PtrInt(1), kestra_api_client.PtrInt(100))
+		require.NoError(t, err)
+
+		var userId string
+		for _, entry := range page.GetResults() {
+			if entry.GetId() != "" {
+				userId = entry.GetId()
+				break
+			}
+		}
+		if userId == "" {
+			t.Skip("no tenant access entry found to delete")
+		}
+
+		err = KestraTestClient().TenantAccess().DeleteTenantAccess(ctx, userId, MAIN_TENANT)
+		require.NoError(t, err)
+	})
+}

--- a/python/python-sdk/kestrapy/__init__.py
+++ b/python/python-sdk/kestrapy/__init__.py
@@ -19,6 +19,7 @@ __version__ = "1.0.10"
 __all__ = [
     "AppsApi",
     "AssetsApi",
+    "BindingsApi",
     "BlueprintsApi",
     "DashboardsApi",
     "ExecutionsApi",
@@ -31,6 +32,7 @@ __all__ = [
     "NamespacesApi",
     "RolesApi",
     "ServiceAccountApi",
+    "TenantAccessApi",
     "TestSuitesApi",
     "TriggersApi",
     "UsersApi",
@@ -440,6 +442,7 @@ __all__ = [
 # import apis into sdk package
 from kestrapy.api.apps_api import AppsApi as AppsApi
 from kestrapy.api.assets_api import AssetsApi as AssetsApi
+from kestrapy.api.bindings_api import BindingsApi as BindingsApi
 from kestrapy.api.blueprints_api import BlueprintsApi as BlueprintsApi
 from kestrapy.api.dashboards_api import DashboardsApi as DashboardsApi
 from kestrapy.api.executions_api import ExecutionsApi as ExecutionsApi
@@ -452,6 +455,7 @@ from kestrapy.api.logs_api import LogsApi as LogsApi
 from kestrapy.api.namespaces_api import NamespacesApi as NamespacesApi
 from kestrapy.api.roles_api import RolesApi as RolesApi
 from kestrapy.api.service_account_api import ServiceAccountApi as ServiceAccountApi
+from kestrapy.api.tenant_access_api import TenantAccessApi as TenantAccessApi
 from kestrapy.api.test_suites_api import TestSuitesApi as TestSuitesApi
 from kestrapy.api.triggers_api import TriggersApi as TriggersApi
 from kestrapy.api.users_api import UsersApi as UsersApi

--- a/python/python-sdk/kestrapy/api/__init__.py
+++ b/python/python-sdk/kestrapy/api/__init__.py
@@ -3,6 +3,7 @@
 # import apis into api package
 from kestrapy.api.apps_api import AppsApi
 from kestrapy.api.assets_api import AssetsApi
+from kestrapy.api.bindings_api import BindingsApi
 from kestrapy.api.blueprints_api import BlueprintsApi
 from kestrapy.api.dashboards_api import DashboardsApi
 from kestrapy.api.executions_api import ExecutionsApi
@@ -15,6 +16,7 @@ from kestrapy.api.logs_api import LogsApi
 from kestrapy.api.namespaces_api import NamespacesApi
 from kestrapy.api.roles_api import RolesApi
 from kestrapy.api.service_account_api import ServiceAccountApi
+from kestrapy.api.tenant_access_api import TenantAccessApi
 from kestrapy.api.test_suites_api import TestSuitesApi
 from kestrapy.api.triggers_api import TriggersApi
 from kestrapy.api.users_api import UsersApi

--- a/python/python-sdk/kestrapy/api/bindings_api.py
+++ b/python/python-sdk/kestrapy/api/bindings_api.py
@@ -1,0 +1,51 @@
+from typing import List, Optional
+
+from kestrapy.base_api import BaseApi
+from kestrapy.models.binding_type import BindingType
+from kestrapy.models.iam_binding_controller_api_binding_detail import IAMBindingControllerApiBindingDetail
+from kestrapy.models.iam_binding_controller_api_create_binding_request import IAMBindingControllerApiCreateBindingRequest
+from kestrapy.models.paged_results_iam_binding_controller_api_binding_detail import PagedResultsIAMBindingControllerApiBindingDetail
+from kestrapy.models.query_filter import QueryFilter
+
+
+class BindingsApi(BaseApi):
+
+    # ---- CRUD ----
+
+    def create_binding(
+        self,
+        tenant: str,
+        request: IAMBindingControllerApiCreateBindingRequest,
+    ) -> IAMBindingControllerApiBindingDetail:
+        path = self._tenant_path(tenant, "bindings")
+        return self._json_request("POST", path, IAMBindingControllerApiBindingDetail, body=request)
+
+    def binding(self, id: str, tenant: str) -> IAMBindingControllerApiBindingDetail:
+        path = self._tenant_path(tenant, "bindings", id)
+        return self._json_request("GET", path, IAMBindingControllerApiBindingDetail)
+
+    def delete_binding(self, id: str, tenant: str) -> None:
+        path = self._tenant_path(tenant, "bindings", id)
+        self._void_request("DELETE", path)
+
+    # ---- Search ----
+
+    def search_bindings(
+        self,
+        tenant: str,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        sort: Optional[List[str]] = None,
+        binding_type: Optional[BindingType] = None,
+        external_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        filters: Optional[List[QueryFilter]] = None,
+    ) -> PagedResultsIAMBindingControllerApiBindingDetail:
+        path = self._tenant_path(tenant, "bindings", "search")
+        type_val = binding_type.value if binding_type is not None and hasattr(binding_type, 'value') else binding_type
+        params = list(self._build_query_params(
+            page=page, size=size, type=type_val, id=external_id, namespace=namespace,
+        ).items())
+        self._append_repeated_param(params, "sort", sort)
+        self._append_filter_params(params, filters)
+        return self._json_request("GET", path, PagedResultsIAMBindingControllerApiBindingDetail, params=params)

--- a/python/python-sdk/kestrapy/api/tenant_access_api.py
+++ b/python/python-sdk/kestrapy/api/tenant_access_api.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from kestrapy.base_api import BaseApi
+from kestrapy.models.iam_tenant_access_controller_api_create_tenant_access_request import IAMTenantAccessControllerApiCreateTenantAccessRequest
+from kestrapy.models.paged_results_iam_tenant_access_controller_api_user_tenant_access import PagedResultsIAMTenantAccessControllerApiUserTenantAccess
+
+
+class TenantAccessApi(BaseApi):
+
+    def create_tenant_access(
+        self,
+        tenant: str,
+        request: IAMTenantAccessControllerApiCreateTenantAccessRequest,
+    ) -> None:
+        path = self._tenant_path(tenant, "tenant-access")
+        self._void_request("POST", path, body=request, content_type=self.JSON)
+
+    def delete_tenant_access(self, user_id: str, tenant: str) -> None:
+        path = self._tenant_path(tenant, "tenant-access", user_id)
+        self._void_request("DELETE", path)
+
+    def list_tenant_access(
+        self,
+        tenant: str,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+    ) -> PagedResultsIAMTenantAccessControllerApiUserTenantAccess:
+        path = self._tenant_path(tenant, "tenant-access")
+        params = list(self._build_query_params(page=page, size=size).items())
+        return self._json_request("GET", path, PagedResultsIAMTenantAccessControllerApiUserTenantAccess, params=params)

--- a/python/python-sdk/kestrapy/kestra_client.py
+++ b/python/python-sdk/kestrapy/kestra_client.py
@@ -2,6 +2,7 @@ import base64
 
 import requests
 
+from kestrapy.api.bindings_api import BindingsApi
 from kestrapy.api.kv_api import KVApi
 from kestrapy.api.roles_api import RolesApi
 from kestrapy.api.groups_api import GroupsApi
@@ -13,6 +14,7 @@ from kestrapy.api.flows_api import FlowsApi
 from kestrapy.api.executions_api import ExecutionsApi
 from kestrapy.api.invitations_api import InvitationsApi
 from kestrapy.api.logs_api import LogsApi
+from kestrapy.api.tenant_access_api import TenantAccessApi
 from kestrapy.api.files_api import FilesApi
 from kestrapy.api.assets_api import AssetsApi
 from kestrapy.api.blueprints_api import BlueprintsApi
@@ -92,7 +94,11 @@ class KestraClient:
     @property
     def service_account(self): return self._get_api(ServiceAccountApi)
     @property
+    def bindings(self): return self._get_api(BindingsApi)
+    @property
     def invitations(self): return self._get_api(InvitationsApi)
+    @property
+    def tenant_access(self): return self._get_api(TenantAccessApi)
 
     def close(self):
         self._session.close()

--- a/python/python-sdk/testApis/test_bindings_api.py
+++ b/python/python-sdk/testApis/test_bindings_api.py
@@ -1,0 +1,86 @@
+import pytest
+
+from test_helpers import TENANT, random_id
+from kestrapy import (
+    IAMBindingControllerApiCreateBindingRequest,
+    IAMRoleControllerApiRoleCreateOrUpdateRequest,
+    IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions,
+    ApiException,
+)
+from kestrapy.models.binding_type import BindingType
+
+
+# ========================================================================
+# Helpers
+# ========================================================================
+
+def _create_prereqs(client):
+    group = client.groups.create_group(TENANT, {"name": "test_binding_group_" + random_id()})
+    role_req = IAMRoleControllerApiRoleCreateOrUpdateRequest(
+        name="test_binding_role_" + random_id(),
+        permissions=IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions(flow=["READ"]),
+    )
+    role = client.roles.create_role(TENANT, role_req)
+    return group.id, role.id
+
+
+def _create_binding(client, group_id, role_id):
+    req = IAMBindingControllerApiCreateBindingRequest(
+        type=BindingType.GROUP,
+        external_id=group_id,
+        role_id=role_id,
+    )
+    return client.bindings.create_binding(TENANT, req)
+
+
+# ========================================================================
+# CRUD
+# ========================================================================
+
+def test_create_binding(client):
+    group_id, role_id = _create_prereqs(client)
+    created = _create_binding(client, group_id, role_id)
+    assert created is not None
+    assert created.id is not None and created.id != ""
+
+
+def test_get_binding(client):
+    group_id, role_id = _create_prereqs(client)
+    created = _create_binding(client, group_id, role_id)
+
+    fetched = client.bindings.binding(created.id, TENANT)
+    assert fetched.id == created.id
+
+
+def test_delete_binding(client):
+    group_id, role_id = _create_prereqs(client)
+    created = _create_binding(client, group_id, role_id)
+
+    client.bindings.delete_binding(created.id, TENANT)
+
+    with pytest.raises(ApiException):
+        client.bindings.binding(created.id, TENANT)
+
+
+# ========================================================================
+# Search
+# ========================================================================
+
+def test_search_bindings_returns_created(client):
+    group_id, role_id = _create_prereqs(client)
+    created = _create_binding(client, group_id, role_id)
+
+    result = client.bindings.search_bindings(
+        TENANT, page=1, size=100,
+        binding_type=BindingType.GROUP, external_id=group_id,
+    )
+
+    assert result is not None
+    ids = [b.id for b in result.results]
+    assert created.id in ids
+
+
+def test_search_bindings_pagination(client):
+    result = client.bindings.search_bindings(TENANT, page=1, size=2)
+    assert result is not None
+    assert len(result.results) <= 2

--- a/python/python-sdk/testApis/test_tenant_access_api.py
+++ b/python/python-sdk/testApis/test_tenant_access_api.py
@@ -1,0 +1,58 @@
+import pytest
+
+from test_helpers import TENANT, random_id
+from kestrapy import (
+    IAMTenantAccessControllerApiCreateTenantAccessRequest,
+    ApiException,
+)
+
+
+# ========================================================================
+# Helpers
+# ========================================================================
+
+def _invite_email():
+    return f"sdktest-ta-{random_id()[:8]}@example.com"
+
+
+def _grant_access(client, email=None):
+    email = email or _invite_email()
+    req = IAMTenantAccessControllerApiCreateTenantAccessRequest(email=email)
+    client.tenant_access.create_tenant_access(TENANT, req)
+    return email
+
+
+# ========================================================================
+# Tests
+# ========================================================================
+
+def test_create_tenant_access(client):
+    _grant_access(client)
+
+
+def test_list_tenant_access_returns_results(client):
+    _grant_access(client)
+
+    result = client.tenant_access.list_tenant_access(TENANT, page=1, size=100)
+    assert result is not None
+    assert result.results is not None
+    assert len(result.results) > 0
+
+
+def test_list_tenant_access_pagination(client):
+    result = client.tenant_access.list_tenant_access(TENANT, page=1, size=2)
+    assert result is not None
+    assert len(result.results) <= 2
+
+
+def test_delete_tenant_access(client):
+    _grant_access(client)
+
+    result = client.tenant_access.list_tenant_access(TENANT, page=1, size=100)
+    assert result is not None and len(result.results) > 0
+
+    entry = result.results[0]
+    user_id = entry.id
+    assert user_id is not None and user_id != ""
+
+    client.tenant_access.delete_tenant_access(user_id, TENANT)


### PR DESCRIPTION
## Summary

- **Python**: add `BindingsApi` (create/get/delete/search) + `TenantAccessApi` (create/delete/list), wire both into `KestraClient` and export from the `kestrapy` package
- **Go**: add `TenantAccessAPI` (create/delete/list), wire into `KestraClient`
- Tests for all new API classes in both Python and Go

Roles support was already complete across all four SDKs (Java, JS, Python, Go) — this PR fills the remaining gaps so bindings (which reference roles by `roleId`) and tenant-access grants can be used in all SDK languages.

part-of: https://github.com/kestra-io/kestra-ee/issues/8772

## Test plan

- [ ] Python: `pytest testApis/test_bindings_api.py` passes against a running Kestra EE instance
- [ ] Python: `pytest testApis/test_tenant_access_api.py` passes
- [ ] Go: `go test ./test/... -run TestTenantAccessAPI_All` passes
- [ ] `go build ./kestra_api_client/...` compiles cleanly