### PR TITLE
fix(ci): dynamically resolve latest patch version for release branches

### DIFF
--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -13,10 +13,23 @@ runs:
       id: version
       shell: bash
       run: |
+        resolve_version() {
+          local branch_version="$1"
+          if [[ "${branch_version}" == *.x ]]; then
+            local prefix="${branch_version%.x}"
+            curl -s "https://api.github.com/repos/kestra-io/kestra/releases?per_page=100" \
+              | grep '"tag_name"' \
+              | grep "\"${prefix}\." \
+              | head -1 \
+              | sed 's/.*"tag_name": "\(.*\)".*/\1/'
+          else
+            echo "${branch_version}"
+          fi
+        }
         if [[ "${GITHUB_REF_NAME}" == releases/* ]]; then
-          echo "kestra_version=${GITHUB_REF_NAME#releases/}" >> $GITHUB_OUTPUT
+          echo "kestra_version=$(resolve_version "${GITHUB_REF_NAME#releases/}")" >> $GITHUB_OUTPUT
         elif [[ "${GITHUB_BASE_REF}" == releases/* ]]; then
-          echo "kestra_version=${GITHUB_BASE_REF#releases/}" >> $GITHUB_OUTPUT
+          echo "kestra_version=$(resolve_version "${GITHUB_BASE_REF#releases/}")" >> $GITHUB_OUTPUT
         else
           echo "kestra_version=develop" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
## Summary

- `releases/v1.3.x` branches have no matching Docker image tag (`kestra-ee:v1.3.x-no-plugins` doesn't exist)
- `compute-version` action now queries the GitHub API to resolve the latest `vX.Y.*` release when the branch version ends in `.x`
- Exact versions (e.g. `releases/v1.3.5`) still passed through as-is
- `main` and feature branches still resolve to `develop`

## Test plan

- [ ] Cherry-pick / backport to `releases/v1.3.x` and verify CI picks `v1.3.24-no-plugins`
- [ ] Verify a PR against `main` still resolves to `develop`
- [ ] Verify a future `releases/v1.4.x` branch resolves to the latest `v1.4.*` release