### PR TITLE
fix(go): allow string/int/object in AssertionResult expected and actual (#154)

### DIFF
--- a/go-sdk/kestra_api_client/model_assertion_result.go
+++ b/go-sdk/kestra_api_client/model_assertion_result.go
@@ -21,8 +21,8 @@ var _ MappedNullable = &AssertionResult{}
 // AssertionResult struct for AssertionResult
 type AssertionResult struct {
 	Operator string `json:"operator"`
-	Expected map[string]interface{} `json:"expected"`
-	Actual map[string]interface{} `json:"actual"`
+	Expected interface{} `json:"expected"`
+	Actual interface{} `json:"actual"`
 	IsSuccess bool `json:"isSuccess"`
 	TaskId *string `json:"taskId,omitempty"`
 	Description *string `json:"description,omitempty"`
@@ -36,7 +36,7 @@ type _AssertionResult AssertionResult
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewAssertionResult(operator string, expected map[string]interface{}, actual map[string]interface{}, isSuccess bool) *AssertionResult {
+func NewAssertionResult(operator string, expected interface{}, actual interface{}, isSuccess bool) *AssertionResult {
 	this := AssertionResult{}
 	this.Operator = operator
 	this.Expected = expected
@@ -78,9 +78,9 @@ func (o *AssertionResult) SetOperator(v string) {
 }
 
 // GetExpected returns the Expected field value
-func (o *AssertionResult) GetExpected() map[string]interface{} {
+func (o *AssertionResult) GetExpected() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -89,22 +89,22 @@ func (o *AssertionResult) GetExpected() map[string]interface{} {
 
 // GetExpectedOk returns a tuple with the Expected field value
 // and a boolean to check if the value has been set.
-func (o *AssertionResult) GetExpectedOk() (map[string]interface{}, bool) {
+func (o *AssertionResult) GetExpectedOk() (*interface{}, bool) {
 	if o == nil {
-		return map[string]interface{}{}, false
+		return nil, false
 	}
-	return o.Expected, true
+	return &o.Expected, true
 }
 
 // SetExpected sets field value
-func (o *AssertionResult) SetExpected(v map[string]interface{}) {
+func (o *AssertionResult) SetExpected(v interface{}) {
 	o.Expected = v
 }
 
 // GetActual returns the Actual field value
-func (o *AssertionResult) GetActual() map[string]interface{} {
+func (o *AssertionResult) GetActual() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -113,15 +113,15 @@ func (o *AssertionResult) GetActual() map[string]interface{} {
 
 // GetActualOk returns a tuple with the Actual field value
 // and a boolean to check if the value has been set.
-func (o *AssertionResult) GetActualOk() (map[string]interface{}, bool) {
+func (o *AssertionResult) GetActualOk() (*interface{}, bool) {
 	if o == nil {
-		return map[string]interface{}{}, false
+		return nil, false
 	}
-	return o.Actual, true
+	return &o.Actual, true
 }
 
 // SetActual sets field value
-func (o *AssertionResult) SetActual(v map[string]interface{}) {
+func (o *AssertionResult) SetActual(v interface{}) {
 	o.Actual = v
 }
 

--- a/go-sdk/test/api_testsuites_test.go
+++ b/go-sdk/test/api_testsuites_test.go
@@ -349,7 +349,6 @@ func TestTestSuitesAPI_All(t *testing.T) {
 		require.ElementsMatch(t, []string{testSuiteId4}, foundIds)
 	})
 	t.Run("runTestSuiteTest", func(t *testing.T) {
-		t.Skip("need to fix AssertionResult expected and actual deserialization first")
 		testSuiteId := randomId()
 		namespace := randomId()
 		flowId := randomId()
@@ -367,7 +366,6 @@ func TestTestSuitesAPI_All(t *testing.T) {
 		require.NotEmpty(t, res.GetEndDate())
 	})
 	t.Run("runTestSuiteTest_failed", func(t *testing.T) {
-		t.Skip("need to fix AssertionResult expected and actual deserialization first")
 		testSuiteId := randomId()
 		namespace := randomId()
 		flowId := randomId()


### PR DESCRIPTION
## Summary

Fixes #154 — the test runs API in `TestSuitesApi` could not be used from the Go SDK because of a deserialization failure around `AssertionResult.Expected` and `.Actual`.

These fields can legitimately be a string, int, or any object, but they were typed as `map[string]interface{}`, so any response carrying a scalar value (e.g. `"Hi there"`) failed to unmarshal.

## Changes

- **`go-sdk/kestra_api_client/model_assertion_result.go`** — retype `Expected` and `Actual` from `map[string]interface{}` to `interface{}`:
  - struct fields + `NewAssertionResult` constructor params
  - `GetExpected`/`GetActual` return `interface{}`
  - `GetExpectedOk`/`GetActualOk` return `(*interface{}, bool)` (the convention for required free-form fields, matching `model_kv_detail.go`)
  - `SetExpected`/`SetActual` take `interface{}`
  - `ToMap`/`UnmarshalJSON` already operate on `interface{}` — no change needed
- **`go-sdk/test/api_testsuites_test.go`** — un-skip the two reproducer tests with real bodies (`runTestSuiteTest`, `runTestSuiteTest_failed`); the latter asserts scalar `expected`/`actual` values. The four empty placeholder sub-tests remain skipped.

> Note: the Go SDK is hand-maintained (since #230), so this is fixed directly in the source rather than in the OpenAPI spec.

## Verification

`go build ./...`, `go vet ./kestra_api_client/`, and `go vet ./test/` all pass. Live integration tests (Docker Kestra) not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)