### PR TITLE
fix(python): make Python SDK tests pass against real Kestra 1.3

### DIFF
--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -35,7 +35,7 @@ services:
   # ---------------------------------------------------------------------------
   kestra:
     container_name: python-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop-no-plugins"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-no-plugins"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/python/python-sdk/kestrapy/api/apps_api.py
+++ b/python/python-sdk/kestrapy/api/apps_api.py
@@ -10,7 +10,6 @@ from kestrapy.models.file_metas import FileMetas
 from kestrapy.models.level import Level
 from kestrapy.models.paged_results_apps_controller_api_app import PagedResultsAppsControllerApiApp
 from kestrapy.models.paged_results_apps_controller_api_app_catalog_item import PagedResultsAppsControllerApiAppCatalogItem
-from kestrapy.models.query_filter import QueryFilter
 
 
 class AppsApi(BaseApi):
@@ -98,7 +97,6 @@ class AppsApi(BaseApi):
         flow_id: Optional[str] = None,
         sort: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
-        filters: Optional[List[QueryFilter]] = None,
     ) -> PagedResultsAppsControllerApiApp:
         path = self._tenant_path(tenant, "apps", "search")
         params = list(self._build_query_params(
@@ -106,7 +104,6 @@ class AppsApi(BaseApi):
         ).items())
         self._append_repeated_param(params, "sort", sort)
         self._append_repeated_param(params, "tags", tags)
-        self._append_filter_params(params, filters)
         return self._json_request("GET", path, PagedResultsAppsControllerApiApp, params=params)
 
     def search_apps_from_catalog(
@@ -114,11 +111,12 @@ class AppsApi(BaseApi):
         tenant: str,
         page: Optional[int] = None,
         size: Optional[int] = None,
-        filters: Optional[List[QueryFilter]] = None,
+        q: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> PagedResultsAppsControllerApiAppCatalogItem:
         path = self._tenant_path(tenant, "apps", "catalog")
-        params = list(self._build_query_params(page=page, size=size).items())
-        self._append_filter_params(params, filters)
+        params = list(self._build_query_params(page=page, size=size, q=q).items())
+        self._append_repeated_param(params, "tags", tags)
         return self._json_request("GET", path, PagedResultsAppsControllerApiAppCatalogItem, params=params)
 
     # ========================================================================

--- a/python/python-sdk/kestrapy/api/blueprints_api.py
+++ b/python/python-sdk/kestrapy/api/blueprints_api.py
@@ -26,7 +26,7 @@ class BlueprintsApi(BaseApi):
 
     def blueprint_source(self, id: str, kind: BlueprintControllerKind, tenant: str) -> str:
         path = self._tenant_path(tenant, "blueprints", "community", kind.value, id, "source")
-        return self._text_request("GET", path, accept=self.YAML)
+        return self._text_request("GET", path, accept=self.YAML_ACCEPT)
 
     def search_blueprints(
         self,
@@ -81,7 +81,7 @@ class BlueprintsApi(BaseApi):
 
     def internal_blueprint_flow(self, id: str, tenant: str) -> str:
         path = self._tenant_path(tenant, "blueprints", "custom", id, "source")
-        return self._text_request("GET", path, accept=self.YAML)
+        return self._text_request("GET", path, accept=self.YAML_ACCEPT)
 
     def update_internal_blueprints(self, id: str, tenant: str, request: BlueprintControllerApiBlueprintItemWithSource) -> BlueprintWithFlowEntity:
         path = self._tenant_path(tenant, "blueprints", "custom", id)

--- a/python/python-sdk/kestrapy/api/executions_api.py
+++ b/python/python-sdk/kestrapy/api/executions_api.py
@@ -159,10 +159,10 @@ class ExecutionsApi(BaseApi):
 
     def kill_execution(
         self, execution_id: str, tenant: str, is_on_kill_cascade: Optional[bool] = None,
-    ) -> Execution:
+    ) -> None:
         path = self._tenant_path(tenant, "executions", execution_id,"kill")
         params = self._build_query_params(isOnKillCascade=is_on_kill_cascade)
-        return self._json_request("DELETE", path, Execution, params=params)
+        self._void_request("DELETE", path, params=params)
 
     def kill_executions_by_ids(self, tenant: str, ids: List[str]) -> Any:
         path = self._tenant_path(tenant, "executions", "kill", "by-ids")
@@ -231,9 +231,9 @@ class ExecutionsApi(BaseApi):
     # Pause / Resume
     # ========================================================================
 
-    def pause_execution(self, execution_id: str, tenant: str) -> Execution:
+    def pause_execution(self, execution_id: str, tenant: str) -> None:
         path = self._tenant_path(tenant, "executions", execution_id,"pause")
-        return self._json_request("POST", path, Execution)
+        self._void_request("POST", path)
 
     def pause_executions_by_ids(self, tenant: str, ids: List[str]) -> Any:
         path = self._tenant_path(tenant, "executions", "pause", "by-ids")
@@ -247,9 +247,9 @@ class ExecutionsApi(BaseApi):
         self._append_filter_params(params, filters)
         return self._raw_json_request("POST", path, params=params)
 
-    def resume_execution(self, execution_id: str, tenant: str) -> Execution:
+    def resume_execution(self, execution_id: str, tenant: str) -> None:
         path = self._tenant_path(tenant, "executions", execution_id,"resume")
-        return self._json_request("POST", path, Execution)
+        self._void_request("POST", path)
 
     def resume_executions_by_ids(self, tenant: str, ids: List[str]) -> Any:
         path = self._tenant_path(tenant, "executions", "resume", "by-ids")

--- a/python/python-sdk/kestrapy/api/groups_api.py
+++ b/python/python-sdk/kestrapy/api/groups_api.py
@@ -106,12 +106,11 @@ class GroupsApi(BaseApi):
         page: Optional[int] = None,
         size: Optional[int] = None,
         sort: Optional[List[str]] = None,
-        filters: Optional[List[QueryFilter]] = None,
+        q: Optional[str] = None,
     ) -> PagedResultsApiGroupSummary:
         path = self._tenant_path(tenant, "groups", "search")
-        params = list(self._build_query_params(page=page, size=size).items())
+        params = list(self._build_query_params(page=page, size=size, q=q).items())
         self._append_repeated_param(params, "sort", sort)
-        self._append_filter_params(params, filters)
         return self._json_request("GET", path, PagedResultsApiGroupSummary, params=params)
 
     def autocomplete_groups(

--- a/python/python-sdk/kestrapy/api/roles_api.py
+++ b/python/python-sdk/kestrapy/api/roles_api.py
@@ -7,7 +7,6 @@ from kestrapy.models.api_role_summary import ApiRoleSummary
 from kestrapy.models.iam_role_controller_api_role_create_or_update_request import IAMRoleControllerApiRoleCreateOrUpdateRequest
 from kestrapy.models.iam_role_controller_api_role_detail import IAMRoleControllerApiRoleDetail
 from kestrapy.models.paged_results_api_role_summary import PagedResultsApiRoleSummary
-from kestrapy.models.query_filter import QueryFilter
 from kestrapy.models.role import Role
 
 
@@ -56,12 +55,11 @@ class RolesApi(BaseApi):
         page: Optional[int] = None,
         size: Optional[int] = None,
         sort: Optional[List[str]] = None,
-        filters: Optional[List[QueryFilter]] = None,
+        q: Optional[str] = None,
     ) -> PagedResultsApiRoleSummary:
         path = self._tenant_path(tenant, "roles", "search")
-        params = list(self._build_query_params(page=page, size=size).items())
+        params = list(self._build_query_params(page=page, size=size, q=q).items())
         self._append_repeated_param(params, "sort", sort)
-        self._append_filter_params(params, filters)
         return self._json_request("GET", path, PagedResultsApiRoleSummary, params=params)
 
     def autocomplete_roles(

--- a/python/python-sdk/kestrapy/base_api.py
+++ b/python/python-sdk/kestrapy/base_api.py
@@ -33,6 +33,11 @@ T = TypeVar('T')
 class BaseApi:
     JSON = "application/json"
     YAML = "application/x-yaml"
+    # Blueprint source endpoints declare `application/yaml` (no "x-" prefix) as
+    # their response media type, distinct from the `application/x-yaml` request
+    # bodies use elsewhere. Sending YAML as the Accept header on those routes
+    # fails content negotiation and the server responds 401 instead of 200.
+    YAML_ACCEPT = "application/yaml"
     TEXT = "text/plain"
     OCTET = "application/octet-stream"
     CSV = "text/csv"

--- a/python/python-sdk/testApis/test_apps_api.py
+++ b/python/python-sdk/testApis/test_apps_api.py
@@ -12,7 +12,6 @@ from test_helpers import (
     random_namespace,
     log_flow_yaml,
     create_flow,
-    ns_filter,
 )
 
 
@@ -159,11 +158,6 @@ class TestSearch:
         assert len(result.results) > 0
         assert any(app.uid == created.uid for app in result.results)
 
-    @pytest.mark.xfail(
-        reason="kestra-ee 2.0 ignores the search query on this list endpoint and "
-        "returns unrelated rows (pagination/filter regression)",
-        strict=False,
-    )
     def test_search_apps_with_query(self, client):
         ns = random_namespace()
         flow_id = random_id()
@@ -223,7 +217,7 @@ class TestSearch:
         client.apps.create_app(TENANT, _app_yaml(random_id(), ns1, flow_id1))
         client.apps.create_app(TENANT, _app_yaml(random_id(), ns2, flow_id2))
 
-        result = client.apps.search_apps(TENANT, 1, 10, filters=[ns_filter(ns1)])
+        result = client.apps.search_apps(TENANT, 1, 10, namespace=ns1)
         assert len(result.results) > 0
         for app in result.results:
             assert app.namespace == ns1
@@ -234,15 +228,11 @@ class TestSearch:
         create_flow(client, log_flow_yaml(flow_id, ns))
         client.apps.create_app(TENANT, _app_yaml(random_id(), ns, flow_id))
 
-        result = client.apps.search_apps_from_catalog(TENANT, 1, 10, [ns_filter(ns)])
+        # searchAppsFromCatalog only supports page, size, q, tags (no namespace filter).
+        result = client.apps.search_apps_from_catalog(TENANT, 1, 10)
         assert result is not None
         assert len(result.results) > 0
 
-    @pytest.mark.xfail(
-        reason="kestra-ee 2.0 ignores the filter and returns all apps instead of "
-        "an empty result set (pagination/filter regression)",
-        strict=False,
-    )
     def test_search_apps_no_results(self, client):
         result = client.apps.search_apps(TENANT, 1, 10, namespace="nonexistent_ns_" + random_id())
         assert result is not None

--- a/python/python-sdk/testApis/test_blueprints_api.py
+++ b/python/python-sdk/testApis/test_blueprints_api.py
@@ -196,11 +196,6 @@ def test_search_internal_blueprints_with_sort(client):
     assert idx2 > idx1
 
 
-@pytest.mark.xfail(
-    reason="kestra-ee 2.0 returns no tags for internal blueprints, so the "
-    "tag-filtered search yields an empty list",
-    strict=False,
-)
 def test_search_internal_blueprints_with_tags(client):
     tag = f"sdktest{random_id()[:8]}"
     client.blueprints.create_flow_blueprint(

--- a/python/python-sdk/testApis/test_executions_api.py
+++ b/python/python-sdk/testApis/test_executions_api.py
@@ -345,9 +345,8 @@ class TestKillExecution:
 
         _wait_for_state(client, execution_id, [StateType.RUNNING])
 
-        result = client.executions.kill_execution(execution_id, TENANT)
-        assert result is not None
-        assert result.id == execution_id
+        # kill returns no body (202/200 with an empty response) per the 1.3 spec
+        client.executions.kill_execution(execution_id, TENANT)
 
         _wait_for_state(client, execution_id, [StateType.KILLED, StateType.CANCELLED])
 
@@ -658,11 +657,11 @@ class TestKillCascade:
         execution_id = resp.id
         _wait_for_state(client, execution_id, [StateType.RUNNING])
 
-        result = client.executions.kill_execution(
+        # kill returns no body (202/200 with an empty response) per the 1.3 spec
+        client.executions.kill_execution(
             execution_id, TENANT, is_on_kill_cascade=True,
         )
-        assert result is not None
-        assert result.id == execution_id
+        _wait_for_state(client, execution_id, [StateType.KILLED, StateType.CANCELLED])
 
 
 class TestRestartRevision:
@@ -724,14 +723,11 @@ class TestNotFound:
         assert exc_info.value.status in (400, 404, 422)
 
     def test_eval_expression_unknown_id_raises(self, client):
-        # eval is authorized against the target execution; on a missing
-        # execution the controller's permission check returns 403 before
-        # the not-found check fires.
         with pytest.raises(ApiException) as exc_info:
             client.executions.eval_expression(
-                f"missing-{random_id()}", "{{ inputs.x }}", TENANT,
+                f"missing-{random_id()}", TENANT, "{{ inputs.x }}",
             )
-        assert exc_info.value.status in (400, 403, 404, 422, 500)
+        assert exc_info.value.status == 404
 
 
 class TestUpdateTaskRunState:
@@ -786,14 +782,12 @@ class TestPauseResume:
         execution_id = resp.id
         _wait_for_state(client, execution_id, [StateType.RUNNING])
 
-        result = client.executions.pause_execution(execution_id, TENANT)
-        assert result is not None
-        assert result.id == execution_id
+        # pause/resume return no body (204/200 with an empty response) per the 1.3 spec
+        client.executions.pause_execution(execution_id, TENANT)
+        _wait_for_state(client, execution_id, [StateType.PAUSED])
 
-        # Resume
-        resumed = client.executions.resume_execution(execution_id, TENANT)
-        assert resumed is not None
-        assert resumed.id == execution_id
+        client.executions.resume_execution(execution_id, TENANT)
+        _wait_for_state(client, execution_id, [StateType.RUNNING, StateType.SUCCESS])
 
     def test_pause_executions_by_ids_basic(self, client):
         with pytest.raises(Exception):

--- a/python/python-sdk/testApis/test_groups_api.py
+++ b/python/python-sdk/testApis/test_groups_api.py
@@ -114,7 +114,7 @@ def test_search_groups_with_query_filter(client):
     prefix = "qfgrp" + random_id()
     create_test_group(client, prefix)
 
-    result = client.groups.search_groups(TENANT, 1, 10, filters=[query_filter(prefix)])
+    result = client.groups.search_groups(TENANT, 1, 10, q=prefix)
 
     assert result is not None
     assert result.results is not None
@@ -139,7 +139,7 @@ def test_search_groups_with_sort(client):
 
 def test_search_groups_no_results(client):
     result = client.groups.search_groups(
-        TENANT, 1, 10, filters=[query_filter("nonexistent_group_" + random_id())]
+        TENANT, 1, 10, q="nonexistent_group_" + random_id()
     )
 
     assert result is not None

--- a/python/python-sdk/testApis/test_roles_api.py
+++ b/python/python-sdk/testApis/test_roles_api.py
@@ -7,7 +7,7 @@ from kestrapy import (
     ApiIds,
 )
 from kestrapy.exceptions import ApiException
-from test_helpers import TENANT, random_id, query_filter
+from test_helpers import TENANT, random_id
 
 
 # ========================================================================
@@ -104,7 +104,7 @@ def test_search_roles_with_query_filter(client):
     name = "query-filter-" + random_id()
     create_test_role(client, name)
 
-    result = client.roles.search_roles(TENANT, 1, 10, filters=[query_filter(name)])
+    result = client.roles.search_roles(TENANT, 1, 10, q=name)
 
     assert result is not None
     assert len(result.results) > 0
@@ -128,7 +128,7 @@ def test_search_roles_with_sort(client):
 
 def test_search_roles_no_results(client):
     result = client.roles.search_roles(
-        TENANT, 1, 10, filters=[query_filter("nonexistent_role_" + random_id())]
+        TENANT, 1, 10, q="nonexistent_role_" + random_id()
     )
 
     assert result is not None


### PR DESCRIPTION
## Summary

CI ran the Python suite against a hardcoded `kestra-ee:develop` (2.0) image while the SDK had already been migrated to Kestra 1.3, masking real 1.3 bugs behind 2.0/1.3 drift. This PR parameterizes the CI image to `${KESTRA_VERSION}` (matching the other three SDKs) and fixes what surfaced when tested against a real 1.3 instance:

- Blueprint source endpoints (`/blueprints/community/*/source`, `/blueprints/custom/{id}/source`) declare `application/yaml` (no `x-` prefix) as their response media type. Sending `application/x-yaml` as the `Accept` header fails content negotiation and Kestra 1.3 responds 401 instead of 200.
- `killExecution`/`pauseExecution`/`resumeExecution` return empty 202/204 bodies in 1.3. The SDK called `resp.json()` unconditionally and crashed with `JSONDecodeError`.
- `searchApps`, `searchAppsFromCatalog`, `searchGroups`, and `searchRoles` only accept flat query params (`q`, `namespace`, `tags`, ...) in 1.3, not the `filters[field][operation]=value` array syntax. The SDK's `filters` kwarg was silently dropped by the server, so filtering had no effect.

All fixes verified locally against a real Kestra 1.3.24 instance; full sharded suite passes with zero failures.