### PR TITLE
fix(java): make SDK compatible with Kestra 1.3 search/filter and trigger endpoints

### DIFF
--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/TestUtils.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/TestUtils.java
@@ -309,10 +309,10 @@ public class TestUtils {
     }
 
     public static QueryFilter minLevelFilter(String level) {
-        // Kestra 2.0 only supports >= / <= for the level field
+        // Kestra 1.3 only supports EQUALS / NOT_EQUALS for the MIN_LEVEL field
         return new QueryFilter()
                 .field(QueryFilterField.MIN_LEVEL)
-                .operation(QueryFilterOp.GREATER_THAN_OR_EQUAL_TO)
+                .operation(QueryFilterOp.EQUALS)
                 .value(level);
     }
 

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/AppsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/AppsApiTest.java
@@ -248,7 +248,7 @@ public class AppsApiTest {
         api().createApp(TENANT, appYaml(randomId(), ns2, flowId2));
 
         PagedResultsAppsControllerApiApp result = api().searchApps(
-                TENANT, 1, 10, null, null, null, null, null, List.of(nsFilter(ns1)));
+                TENANT, 1, 10, null, ns1, null, null, null, null);
 
         assertThat(result.getResults()).isNotEmpty();
         assertThat(result.getResults()).allSatisfy(app ->

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/GroupsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/GroupsApiTest.java
@@ -90,7 +90,7 @@ public class GroupsApiTest {
     void searchGroups_basic() throws ApiException {
         createTestGroup("searchable-" + randomId());
 
-        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 10, null, null);
+        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 10, null, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotNull().isNotEmpty();
@@ -98,7 +98,7 @@ public class GroupsApiTest {
 
     @Test
     void searchGroups_withPagination() throws ApiException {
-        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 2, null, null);
+        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 2, null, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotNull();
@@ -110,7 +110,7 @@ public class GroupsApiTest {
         String name = "name-filter-" + randomId();
         createTestGroup(name);
 
-        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 10, null, List.of(queryFilter(name)));
+        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 10, name, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotNull().isNotEmpty();
@@ -124,7 +124,7 @@ public class GroupsApiTest {
         String prefix = "qfgrp" + randomId();
         createTestGroup(prefix);
 
-        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 10, null, List.of(queryFilter(prefix)));
+        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 10, prefix, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotNull().isNotEmpty();
@@ -137,7 +137,7 @@ public class GroupsApiTest {
         createTestGroup(name2);
         createTestGroup(name1);
 
-        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 100, List.of("name:asc"), null);
+        PagedResultsApiGroupSummary result = api().searchGroups(TENANT, 1, 100, null, List.of("name:asc"), null);
 
         assertThat(result.getResults()).hasSizeGreaterThanOrEqualTo(2);
         List<String> names = result.getResults().stream()
@@ -183,7 +183,7 @@ public class GroupsApiTest {
     @Test
     void searchGroups_noResults() throws ApiException {
         PagedResultsApiGroupSummary result = api().searchGroups(
-                TENANT, 1, 10, null, List.of(queryFilter("nonexistent_group_" + randomId())));
+                TENANT, 1, 10, "nonexistent_group_" + randomId(), null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults() == null || result.getResults().isEmpty() || result.getTotal() == 0).isTrue();

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/LogsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/LogsApiTest.java
@@ -7,6 +7,7 @@ import reactor.core.publisher.Flux;
 
 import java.io.File;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -273,8 +274,8 @@ public class LogsApiTest {
 
             assertThat(result.getResults()).hasSizeGreaterThanOrEqualTo(2);
             for (int i = 0; i < result.getResults().size() - 1; i++) {
-                assertThat(result.getResults().get(i).getTimestamp())
-                        .isAfterOrEqualTo(result.getResults().get(i + 1).getTimestamp());
+                assertThat(result.getResults().get(i).getTimestamp().truncatedTo(ChronoUnit.MILLIS))
+                        .isAfterOrEqualTo(result.getResults().get(i + 1).getTimestamp().truncatedTo(ChronoUnit.MILLIS));
             }
         });
     }

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/RolesApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/RolesApiTest.java
@@ -92,7 +92,7 @@ public class RolesApiTest {
     void searchRoles_basic() throws ApiException {
         createTestRole("searchable-" + randomId());
 
-        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 10, null, null);
+        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 10, null, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotNull().isNotEmpty();
@@ -100,7 +100,7 @@ public class RolesApiTest {
 
     @Test
     void searchRoles_withPagination() throws ApiException {
-        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 2, null, null);
+        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 2, null, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotNull();
@@ -112,7 +112,7 @@ public class RolesApiTest {
         String name = "name-filter-" + randomId();
         IAMRoleControllerApiRoleDetail created = createTestRole(name);
 
-        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 10, null, List.of(queryFilter(name)));
+        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 10, name, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotEmpty();
@@ -126,7 +126,7 @@ public class RolesApiTest {
         String name = "query-filter-" + randomId();
         createTestRole(name);
 
-        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 10, null, List.of(queryFilter(name)));
+        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 10, name, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotEmpty();
@@ -139,7 +139,7 @@ public class RolesApiTest {
         createTestRole(name2);
         createTestRole(name1);
 
-        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 100, List.of("name:asc"), null);
+        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 100, null, List.of("name:asc"), null);
 
         assertThat(result.getResults()).hasSizeGreaterThanOrEqualTo(2);
         List<String> names = result.getResults().stream()
@@ -153,8 +153,8 @@ public class RolesApiTest {
 
     @Test
     void searchRoles_noResults() throws ApiException {
-        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 10, null,
-                List.of(queryFilter("nonexistent_role_" + randomId())));
+        PagedResultsApiRoleSummary result = api().searchRoles(TENANT, 1, 10,
+                "nonexistent_role_" + randomId(), null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isEmpty();

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ServiceAccountApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ServiceAccountApiTest.java
@@ -113,10 +113,10 @@ public class ServiceAccountApiTest {
                         .name(uniqueName)
                         .description("Search test");
 
-        api().createServiceAccount(request);
+        IAMServiceAccountControllerApiServiceAccountDetail created = api().createServiceAccount(request);
 
         PagedResultsIAMServiceAccountControllerApiServiceAccountDetail result =
-                api().listServiceAccounts(1, 10, null, List.of(queryFilter(uniqueName)));
+                api().listServiceAccounts(1, 10, null, List.of(queryFilter(created.getId())));
 
         assertThat(result).isNotNull();
         assertThat(result.getResults()).isNotEmpty();

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/GroupsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/GroupsApi.java
@@ -168,6 +168,7 @@ public class GroupsApi extends BaseApi {
             @jakarta.annotation.Nonnull String tenant,
             @jakarta.annotation.Nullable Integer page,
             @jakarta.annotation.Nullable Integer size,
+            @jakarta.annotation.Nullable String q,
             @jakarta.annotation.Nullable List<String> sort,
             @jakarta.annotation.Nullable List<QueryFilter> filters) throws ApiException {
         List<Pair> collectionParams = new ArrayList<>();
@@ -175,7 +176,7 @@ public class GroupsApi extends BaseApi {
         collectionParams.addAll(filterParams(filters));
         return get(
                 tenantPath(tenant, "groups", "search"),
-                queryParams("page", page, "size", size),
+                queryParams("page", page, "size", size, "q", q),
                 collectionParams,
                 new TypeReference<>() {});
     }

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/RolesApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/RolesApi.java
@@ -101,6 +101,7 @@ public class RolesApi extends BaseApi {
             @jakarta.annotation.Nonnull String tenant,
             @jakarta.annotation.Nullable Integer page,
             @jakarta.annotation.Nullable Integer size,
+            @jakarta.annotation.Nullable String q,
             @jakarta.annotation.Nullable List<String> sort,
             @jakarta.annotation.Nullable List<QueryFilter> filters) throws ApiException {
         List<Pair> collectionParams = new ArrayList<>();
@@ -108,7 +109,7 @@ public class RolesApi extends BaseApi {
         collectionParams.addAll(filterParams(filters));
         return get(
                 tenantPath(tenant, "roles", "search"),
-                queryParams("page", page, "size", size),
+                queryParams("page", page, "size", size, "q", q),
                 collectionParams,
                 new TypeReference<>() {});
     }

--- a/java/java-sdk/src/main/java/io/kestra/sdk/model/ApiTriggerAndState.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/model/ApiTriggerAndState.java
@@ -33,10 +33,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiTriggerAndState {
-  public static final String JSON_PROPERTY_TRIGGER = "trigger";
+  public static final String JSON_PROPERTY_TRIGGER = "abstractTrigger";
   @jakarta.annotation.Nonnull  private AbstractTrigger trigger;
 
-  public static final String JSON_PROPERTY_STATE = "state";
+  public static final String JSON_PROPERTY_STATE = "triggerContext";
   @jakarta.annotation.Nonnull  private ApiTriggerState state;
 
   public ApiTriggerAndState() {


### PR DESCRIPTION
Kestra 1.3's search endpoints (groups, roles) only honor flat query params, silently ignoring the filters[] array the hand-migrated SDK sent; add a flat `q` parameter to `GroupsApi.searchGroups` and `RolesApi.searchRoles` and update the tests accordingly.

Also fix:
- `AppsApiTest` to use the flat `namespace` param (`searchApps` already sent it)
- `ServiceAccountApiTest` to filter by `id` since the server matches `q` against `id`, not `name`
- `LogsApiTest`'s `minLevel` filter to use the only supported operator (`EQUALS`)
- `ApiTriggerAndState`'s wire property names (`abstractTrigger`/`triggerContext`) to match the actual 1.3 API response shape

Verified locally against a live Kestra 1.3.24 EE instance: 0 failures (was 9), no regressions.