### PR TITLE
fix: add missing FORM value to Type enum in Go, Java, and Python SDKs

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -59,11 +59,6 @@ jobs:
       - name: Install tests deps
         run: pip install -r test-requirements.txt
 
-      - name: Run model unit tests (no Kestra container needed)
-        run: |
-          pip install -e .
-          python3 -m pytest tests/ -v
-
       - name: GCP - Auth with github service account
         uses: "google-github-actions/auth@v2"
         with:

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install tests deps
         run: pip install -r test-requirements.txt
 
+      - name: Run model unit tests (no Kestra container needed)
+        run: python3 -m pytest tests/ -v
+
       - name: GCP - Auth with github service account
         uses: "google-github-actions/auth@v2"
         with:

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -60,7 +60,9 @@ jobs:
         run: pip install -r test-requirements.txt
 
       - name: Run model unit tests (no Kestra container needed)
-        run: python3 -m pytest tests/ -v
+        run: |
+          pip install -e .
+          python3 -m pytest tests/ -v
 
       - name: GCP - Auth with github service account
         uses: "google-github-actions/auth@v2"

--- a/go-sdk/kestra_api_client/model_type.go
+++ b/go-sdk/kestra_api_client/model_type.go
@@ -37,6 +37,7 @@ const (
 	TYPE_MULTISELECT Type = "MULTISELECT"
 	TYPE_YAML Type = "YAML"
 	TYPE_EMAIL Type = "EMAIL"
+	TYPE_FORM Type = "FORM"
 )
 
 // All allowed values of Type enum
@@ -58,6 +59,7 @@ var AllowedTypeEnumValues = []Type{
 	"MULTISELECT",
 	"YAML",
 	"EMAIL",
+	"FORM",
 }
 
 func (v *Type) UnmarshalJSON(src []byte) error {

--- a/go-sdk/kestra_api_client/model_type_test.go
+++ b/go-sdk/kestra_api_client/model_type_test.go
@@ -1,0 +1,41 @@
+/*
+Kestra EE
+
+API version: 2.0.0-SNAPSHOT
+*/
+
+package kestra_api_client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestType_UnmarshalJSON_Form(t *testing.T) {
+	var v Type
+	if err := json.Unmarshal([]byte(`"FORM"`), &v); err != nil {
+		t.Fatalf("expected FORM to unmarshal without error, got: %v", err)
+	}
+	if v != TYPE_FORM {
+		t.Fatalf("expected TYPE_FORM, got: %v", v)
+	}
+}
+
+func TestType_UnmarshalJSON_Invalid(t *testing.T) {
+	var v Type
+	err := json.Unmarshal([]byte(`"BOGUS"`), &v)
+	if err == nil {
+		t.Fatal("expected error for unknown Type value, got nil")
+	}
+}
+
+func TestInputObject_UnmarshalJSON_FormType(t *testing.T) {
+	payload := []byte(`{"id":"myform","type":"FORM"}`)
+	var obj InputObject
+	if err := json.Unmarshal(payload, &obj); err != nil {
+		t.Fatalf("expected InputObject with FORM type to unmarshal without error, got: %v", err)
+	}
+	if obj.GetType() != TYPE_FORM {
+		t.Fatalf("expected TYPE_FORM, got: %v", obj.GetType())
+	}
+}

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/model/FormInputTypeTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/model/FormInputTypeTest.java
@@ -1,0 +1,28 @@
+package io.kestra.sdk.model;
+
+import io.kestra.sdk.internal.ApiClient;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FormInputTypeTest {
+
+    @Test
+    void flow_withFormInput_decodesWithoutError() throws Exception {
+        String json = """
+                {
+                  "id": "f",
+                  "namespace": "ns",
+                  "disabled": false,
+                  "deleted": false,
+                  "tasks": [{"id": "t", "type": "io.kestra.plugin.core.log.Log"}],
+                  "inputs": [{"id": "myform", "type": "FORM"}]
+                }
+                """;
+
+        Flow flow = new ApiClient().getObjectMapper().readValue(json, Flow.class);
+
+        assertThat(flow.getInputs()).hasSize(1);
+        assertThat(flow.getInputs().get(0).getType()).isEqualTo(Type.FORM);
+    }
+}

--- a/java/java-sdk/src/main/java/io/kestra/sdk/model/Type.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/model/Type.java
@@ -58,7 +58,9 @@ public enum Type {
   YAML("YAML"),
   
   EMAIL("EMAIL"),
-  
+
+  FORM("FORM"),
+
   UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
   private String value;

--- a/javascript/test_javascript_sdk/formInputType.typecheck.ts
+++ b/javascript/test_javascript_sdk/formInputType.typecheck.ts
@@ -1,0 +1,8 @@
+// Compile-time guard: the generated `Type` union must include 'FORM'.
+// Not a `.spec.ts` — it has no runtime behavior and isn't picked up by vitest.
+// It's checked by `npm run check:types` (`tsc --noEmit`), which has no live-server
+// dependency, unlike the vitest suite (see globalSetup.ts).
+import type { Type } from '@kestra-io/kestra-sdk';
+
+const formType: Type = 'FORM';
+void formType;

--- a/python/python-sdk/kestrapy/models/type.py
+++ b/python/python-sdk/kestrapy/models/type.py
@@ -44,6 +44,7 @@ class Type(str, Enum):
     MULTISELECT = 'MULTISELECT'
     YAML = 'YAML'
     EMAIL = 'EMAIL'
+    FORM = 'FORM'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python/python-sdk/run-tests.sh
+++ b/python/python-sdk/run-tests.sh
@@ -22,6 +22,9 @@ log_and_run pip install -r requirements.txt -r test-requirements.txt --break-sys
 echo "install SDK locally so it can be imported and used in e2e tests"
 log_and_run pip install -e . --break-system-packages
 
+echo "run model unit tests (no Kestra container needed)"
+log_and_run python3 -m pytest tests/ -v
+
 for KESTRA_VERSION in $versions; do
   if [ -z "$KESTRA_VERSION" ]; then
     continue

--- a/python/python-sdk/tests/test_model_types.py
+++ b/python/python-sdk/tests/test_model_types.py
@@ -1,0 +1,26 @@
+"""Pure model decode tests — no live Kestra server required."""
+
+from kestrapy.models.type import Type
+from kestrapy.models.input_object import InputObject
+from kestrapy.models.flow import Flow
+
+
+def test_type_form_value_exists():
+    assert Type("FORM") == Type.FORM
+
+
+def test_input_object_decodes_form_type():
+    obj = InputObject.from_dict({"id": "myform", "type": "FORM"})
+    assert obj.type == Type.FORM
+
+
+def test_flow_decodes_input_with_form_type():
+    flow = Flow.from_dict({
+        "id": "f",
+        "namespace": "ns",
+        "disabled": False,
+        "deleted": False,
+        "tasks": [{"id": "t", "type": "io.kestra.plugin.core.log.Log"}],
+        "inputs": [{"id": "myform", "type": "FORM"}],
+    })
+    assert flow.inputs[0].type == Type.FORM


### PR DESCRIPTION
Backport of #310 for `releases/v1.3.x`, which has the same closed-enum issue.

## Summary
- Kestra's `FORM` input type isn't recognized by the SDKs' `Type` enum, so a flow with a FORM input fails to decode (hard error in Go/Python, silent `UNKNOWN_DEFAULT_OPEN_API` fallback in Java).
- Added `FORM` to the enum in Go (`model_type.go`), Java (`Type.java`), and Python (`type.py`), each with a decode test.
- JavaScript has no runtime enum validation, so it wasn't actually broken; added a compile-time (`tsc`) guard test asserting the generated `Type` union includes `FORM`.
- Wired the new Python unit tests into `python-sdk.yml` CI (fast, no live Kestra container needed).