### PR TITLE
fix(python): derive published version from the release tag

### DIFF
--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -35,9 +35,11 @@ jobs:
       - name: Install pypa/build
         run: python -m pip install build --user
 
+      - name: Set package version from tag
+        run: python3 scripts/set_release_version.py ${{ steps.version.outputs.version }}
+
       - name: Build a binary wheel and a source tarball
-        run: |
-          VERSION=${{ steps.version.outputs.version }} python -m build --sdist --wheel --outdir dist/ .
+        run: python -m build --sdist --wheel --outdir dist/ .
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/python/python-sdk/scripts/set_release_version.py
+++ b/python/python-sdk/scripts/set_release_version.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Patch every committed copy of the SDK's package version to the given release version.
+
+python-sdk-release.yml calls this right before packaging so the git tag (e.g.
+v1.0.11-python) is the single source of truth for the published version,
+instead of requiring a manual version-bump PR before every release. These are
+the same fields generate-sdks.sh's packageVersion templating renders (see
+python/template/*.mustache) -- patched here because the release workflow
+builds from the committed source rather than a fresh generation.
+"""
+import re
+import sys
+from pathlib import Path
+
+SDK_ROOT = Path(__file__).resolve().parent.parent
+
+
+def patch(path: Path, pattern: str, replacement: str) -> None:
+    text = path.read_text()
+    new_text, count = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise SystemExit(f"expected exactly 1 match for {pattern!r} in {path}, found {count}")
+    path.write_text(new_text)
+
+
+def main() -> None:
+    version = sys.argv[1]
+    patch(SDK_ROOT / "pyproject.toml", r'^version = ".*"$', f'version = "{version}"')
+    patch(SDK_ROOT / "setup.py", r'^VERSION = ".*"$', f'VERSION = "{version}"')
+    patch(SDK_ROOT / "kestrapy" / "__init__.py", r'^__version__ = ".*"$', f'__version__ = "{version}"')
+    patch(SDK_ROOT / "kestrapy" / "configuration.py", r'SDK Package Version: [^"]*', f'SDK Package Version: {version}')
+    patch(SDK_ROOT / "README.md", r'^- Package version: .*$', f'- Package version: {version}')
+
+
+if __name__ == "__main__":
+    main()

--- a/python/python-sdk/tests/test_set_release_version.py
+++ b/python/python-sdk/tests/test_set_release_version.py
@@ -1,0 +1,40 @@
+"""Guards scripts/set_release_version.py against version-field format drift.
+
+Copies the real committed files (proving today's format matches the script's
+regexes) plus the real script (no duplicated logic to drift out of sync), then
+runs it exactly as python-sdk-release.yml does.
+"""
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SDK_ROOT = Path(__file__).parent.parent
+PATCHED_FILES = [
+    Path("pyproject.toml"),
+    Path("setup.py"),
+    Path("README.md"),
+    Path("kestrapy", "__init__.py"),
+    Path("kestrapy", "configuration.py"),
+]
+
+
+def test_set_release_version_patches_every_version_field(tmp_path):
+    sdk_root = tmp_path / "python-sdk"
+    (sdk_root / "scripts").mkdir(parents=True)
+    (sdk_root / "kestrapy").mkdir()
+    shutil.copy(SDK_ROOT / "scripts" / "set_release_version.py", sdk_root / "scripts" / "set_release_version.py")
+    for rel in PATCHED_FILES:
+        shutil.copy(SDK_ROOT / rel, sdk_root / rel)
+
+    subprocess.run(
+        [sys.executable, str(sdk_root / "scripts" / "set_release_version.py"), "9.9.9"],
+        cwd=sdk_root,
+        check=True,
+    )
+
+    assert 'version = "9.9.9"' in (sdk_root / "pyproject.toml").read_text()
+    assert 'VERSION = "9.9.9"' in (sdk_root / "setup.py").read_text()
+    assert "- Package version: 9.9.9" in (sdk_root / "README.md").read_text()
+    assert '__version__ = "9.9.9"' in (sdk_root / "kestrapy" / "__init__.py").read_text()
+    assert "SDK Package Version: 9.9.9" in (sdk_root / "kestrapy" / "configuration.py").read_text()


### PR DESCRIPTION
Backport of #312 to `releases/v1.3.x` — same fix, same rationale.

## Summary

- `python-sdk-release.yml` parses a version out of the release tag (e.g. `v1.0.13-python` → `1.0.13`) into a `VERSION` env var, but nothing ever reads it — `python -m build` packages whatever static version string is already committed in `pyproject.toml`/`setup.py`. Every Python release therefore needed a manual version-bump PR merged *before* the tag, or the workflow would silently try to republish the last version (PyPI rejects that outright since versions are immutable).
- Adds `python/python-sdk/scripts/set_release_version.py`, run as a new step right before packaging, which patches every place `generate-sdks.sh`'s `packageVersion` templating writes the version into committed source: `pyproject.toml`, `setup.py`, `kestrapy/__init__.py`'s `__version__`, `configuration.py`'s debug-report string, and `README.md`. The script hard-fails if any of these regexes don't match exactly once, so a format drift breaks the release loudly instead of silently leaving a stale version string.
- This mirrors what the Java release already does via `-Pversion=` at publish time — the tag becomes the single source of truth, no pre-release bump PR needed.
- This unblocks releasing `v1.0.11-python` for the 1.3.x line (which now includes the FORM-input decode fix from #311) without a separate version-bump PR first.

## Test plan

- New `tests/test_set_release_version.py` copies the real committed files (proving today's format matches the script's regexes) and the real script itself (no duplicated logic to drift), runs it via subprocess exactly as the release workflow does, and asserts all five version fields patched.
- Verified locally in a clean virtualenv: full `tests/` suite passes, and a dry run of `python3 scripts/set_release_version.py 9.8.7` followed by `python -m build` produces `kestrapy-9.8.7.tar.gz`/`.whl`.
