### PR TITLE
test(go): retry log download to fix flaky downloadLogsFromExecution_basic

### DIFF
--- a/go-sdk/test/api_logs_test.go
+++ b/go-sdk/test/api_logs_test.go
@@ -128,13 +128,17 @@ func TestLogsAPI_All(t *testing.T) {
 		ctx := context.Background()
 		executionId, _, _ := createExecutionWithLogs(t, ctx)
 
-		file, err := KestraTestClient().Logs().DownloadLogsFromExecution(ctx, executionId, MAIN_TENANT, nil, nil, nil, nil)
-		require.NoError(t, err)
-		require.NotNil(t, file)
-
-		stat, err := file.Stat()
-		require.NoError(t, err)
-		require.Greater(t, stat.Size(), int64(0))
+		// Log persistence can trail slightly behind the execution reaching a
+		// terminal state, so the download endpoint may briefly 200 with an
+		// empty body right after createExecutionWithLogs returns.
+		require.Eventually(t, func() bool {
+			file, err := KestraTestClient().Logs().DownloadLogsFromExecution(ctx, executionId, MAIN_TENANT, nil, nil, nil, nil)
+			if err != nil || file == nil {
+				return false
+			}
+			stat, err := file.Stat()
+			return err == nil && stat.Size() > 0
+		}, 5*time.Second, 200*time.Millisecond, "downloaded log file should eventually be non-empty")
 	})
 
 	t.Run("searchLogs_basic", func(t *testing.T) {


### PR DESCRIPTION
## What

The `SDK freshness check (latest Kestra)` job intermittently fails on `TestLogsAPI_All/downloadLogsFromExecution_basic` with:

```
go-sdk/test/api_logs_test.go:137: "0" is not greater than "0"
```

(seen in [run 28731754080](https://github.com/kestra-io/client-sdk/actions/runs/28731754080/job/85198608335); the very next scheduled run was green — confirming a flake, not an upstream break).

## Why

Log persistence can trail slightly behind the execution reaching a terminal state, so the `/logs/{id}/download` endpoint occasionally returns `200` with an empty body right after `createExecutionWithLogs` returns, tripping the `size > 0` assertion.

## Fix

Wrap the download in `require.Eventually` (5s / 200ms) so it retries until the file is non-empty — matching the pattern already used by the other log-repository tests in this file (e.g. `listLogsFromExecution_withTaskId`). Note the same guard already exists on `releases/v1.3.x`; this brings `main` in line.

## Verification

Ran against a live Kestra instance — `downloadLogsFromExecution_basic` passes 5/5 consecutively; `go vet ./test/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)