### PR TITLE
feat(dashboards): support CSV/ION format on chart export across all SDKs

### DIFF
--- a/go-sdk/kestra_api_client/dashboards_api.go
+++ b/go-sdk/kestra_api_client/dashboards_api.go
@@ -36,12 +36,14 @@ func (a *DashboardsAPI) PreviewChart(ctx context.Context, tenant string, request
 	return doJSON[*PagedResultsMapStringObject](&a.baseAPI, ctx, "POST", tenantPath(tenant, "dashboards", "charts", "preview"), request, nil)
 }
 
-func (a *DashboardsAPI) ExportChartToCsv(ctx context.Context, tenant string, request interface{}) ([]byte, error) {
-	return a.doDownloadBytes(ctx, "POST", tenantPath(tenant, "dashboards", "charts", "export", "to-csv"), request, nil)
+func (a *DashboardsAPI) ExportChart(ctx context.Context, tenant string, request interface{}, format *string) ([]byte, error) {
+	params := buildQueryParams("format", format)
+	return a.doDownloadBytes(ctx, "POST", tenantPath(tenant, "dashboards", "charts", "export"), request, params)
 }
 
-func (a *DashboardsAPI) ExportDashboardChartDataToCSV(ctx context.Context, id, chartId, tenant string, filters interface{}) ([]byte, error) {
-	return a.doDownloadBytes(ctx, "POST", tenantPath(tenant, "dashboards", id, "charts", chartId, "export", "to-csv"), filters, nil)
+func (a *DashboardsAPI) ExportDashboardChart(ctx context.Context, id, chartId, tenant string, filters interface{}, format *string) ([]byte, error) {
+	params := buildQueryParams("format", format)
+	return a.doDownloadBytes(ctx, "POST", tenantPath(tenant, "dashboards", id, "charts", chartId, "export"), filters, params)
 }
 
 func (a *DashboardsAPI) DefaultDashboards(ctx context.Context, tenant string) (*DashboardSettings, error) {

--- a/go-sdk/test/api_dashboards_test.go
+++ b/go-sdk/test/api_dashboards_test.go
@@ -3,12 +3,37 @@ package test
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
+
+// expectedExportColumns are the executionsTable*Yaml column keys, sorted. The
+// CSV header uses these raw keys (not their displayName) and the SQL layer
+// does not guarantee they come back in declaration order, so tests compare
+// against a sorted copy of the header rather than a fixed string.
+var expectedExportColumns = []string{"flow", "id", "namespace", "state"}
+
+// ionBinaryVersionMarker is the fixed 4-byte header every Amazon Ion 1.0
+// binary stream starts with; FileSerde writes ION exports in binary form.
+var ionBinaryVersionMarker = []byte{0xE0, 0x01, 0x00, 0xEA}
+
+func assertCsvHeader(t *testing.T, csv string) {
+	t.Helper()
+	header := strings.TrimRight(strings.SplitN(csv, "\n", 2)[0], "\r")
+	columns := strings.Split(header, ",")
+	sort.Strings(columns)
+	require.Equal(t, expectedExportColumns, columns)
+}
+
+func assertIonBinaryMarker(t *testing.T, result []byte) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(result), 4)
+	require.Equal(t, ionBinaryVersionMarker, result[:4])
+}
 
 func dashboardYaml(title string) string {
 	return dashboardYamlWithId(randomId(), title)
@@ -24,6 +49,74 @@ timeWindow:
   max: P365D
 charts: []
 `, id, title)
+}
+
+// executionsTableDashboardYaml builds a dashboard with a single OSS-native Table
+// chart over the Executions data type, scoped to namespace so its export content
+// is deterministic even on a shared test instance with unrelated executions.
+func executionsTableDashboardYaml(dashboardId, title, chartId, namespace string) string {
+	return fmt.Sprintf(`
+id: %s
+title: %s
+description: Test dashboard
+timeWindow:
+  default: P30D
+  max: P365D
+charts:
+  - id: %s
+    type: io.kestra.plugin.core.dashboard.chart.Table
+    chartOptions:
+      displayName: Executions
+    data:
+      type: io.kestra.plugin.core.dashboard.data.Executions
+      where:
+        - field: NAMESPACE
+          type: EQUAL_TO
+          value: %s
+      columns:
+        id:
+          field: ID
+          displayName: Execution ID
+        namespace:
+          field: NAMESPACE
+          displayName: Namespace
+        flow:
+          field: FLOW_ID
+          displayName: Flow
+        state:
+          field: STATE
+          displayName: State
+`, dashboardId, title, chartId, namespace)
+}
+
+// executionsTableChartYaml is executionsTableDashboardYaml's chart block on its
+// own, usable directly in an ad-hoc PreviewRequest (no dashboard wrapper).
+func executionsTableChartYaml(chartId, namespace string) string {
+	return fmt.Sprintf(`
+id: %s
+type: io.kestra.plugin.core.dashboard.chart.Table
+chartOptions:
+  displayName: Executions
+data:
+  type: io.kestra.plugin.core.dashboard.data.Executions
+  where:
+    - field: NAMESPACE
+      type: EQUAL_TO
+      value: %s
+  columns:
+    id:
+      field: ID
+      displayName: Execution ID
+    namespace:
+      field: NAMESPACE
+      displayName: Namespace
+    flow:
+      field: FLOW_ID
+      displayName: Flow
+    state:
+      field: STATE
+      displayName: State
+`, chartId, namespace)
 }
 
 func TestDashboardsAPI_All(t *testing.T) {
@@ -242,27 +335,95 @@ columns:
 		}
 	})
 
-	t.Run("exportChartToCsv_basic", func(t *testing.T) {
+	t.Run("exportChart_basic", func(t *testing.T) {
 		ctx := context.Background()
+		namespace := randomId()
+		flowId := randomId()
 
-		chartYaml := strings.TrimSpace(`
-id: csv-chart
-type: io.kestra.plugin.ee.core.dashboard.charts.TimeSeriesChart
-graphStyle: LINES
-columns:
-  date:
-    field: DATE
-`)
-		request := kestra_api_client.NewDashboardControllerPreviewRequest(chartYaml)
+		createSimpleFlow(ctx, flowId, namespace)
+		execution := createExecution(t, ctx, flowId, namespace)
 
-		// May fail with 400/422 if chart type not available
-		_, err := KestraTestClient().Dashboards().ExportChartToCsv(ctx, MAIN_TENANT, request)
-		if err != nil {
-			require.Contains(t, err.Error(), "")
-		}
+		request := kestra_api_client.NewDashboardControllerPreviewRequest(executionsTableChartYaml("adhoc-chart", namespace))
+		result, err := KestraTestClient().Dashboards().ExportChart(ctx, MAIN_TENANT, request, strPtr("CSV"))
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+
+		csv := string(result)
+		require.Contains(t, csv, namespace)
+		require.Contains(t, csv, flowId)
+		require.Contains(t, csv, execution.Id)
+		assertCsvHeader(t, csv)
 	})
 
-	t.Run("exportDashboardChartDataToCSV_notFound", func(t *testing.T) {
+	t.Run("exportChart_ion", func(t *testing.T) {
+		ctx := context.Background()
+		namespace := randomId()
+		flowId := randomId()
+
+		createSimpleFlow(ctx, flowId, namespace)
+		execution := createExecution(t, ctx, flowId, namespace)
+
+		request := kestra_api_client.NewDashboardControllerPreviewRequest(executionsTableChartYaml("adhoc-chart", namespace))
+		result, err := KestraTestClient().Dashboards().ExportChart(ctx, MAIN_TENANT, request, strPtr("ION"))
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+
+		ion := string(result)
+		require.Contains(t, ion, namespace)
+		require.Contains(t, ion, flowId)
+		require.Contains(t, ion, execution.Id)
+		assertIonBinaryMarker(t, result)
+	})
+
+	t.Run("exportDashboardChart_csv", func(t *testing.T) {
+		ctx := context.Background()
+		namespace := randomId()
+		flowId := randomId()
+		chartId := "recent_executions"
+
+		createSimpleFlow(ctx, flowId, namespace)
+		execution := createExecution(t, ctx, flowId, namespace)
+
+		created, err := KestraTestClient().Dashboards().CreateDashboard(ctx, MAIN_TENANT, executionsTableDashboardYaml(randomId(), "export-csv-"+randomId(), chartId, namespace))
+		require.NoError(t, err)
+
+		filters := kestra_api_client.NewChartFiltersOverrides()
+		result, err := KestraTestClient().Dashboards().ExportDashboardChart(ctx, created.Id, chartId, MAIN_TENANT, filters, strPtr("CSV"))
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+
+		csv := string(result)
+		require.Contains(t, csv, namespace)
+		require.Contains(t, csv, flowId)
+		require.Contains(t, csv, execution.Id)
+		assertCsvHeader(t, csv)
+	})
+
+	t.Run("exportDashboardChart_ion", func(t *testing.T) {
+		ctx := context.Background()
+		namespace := randomId()
+		flowId := randomId()
+		chartId := "recent_executions"
+
+		createSimpleFlow(ctx, flowId, namespace)
+		execution := createExecution(t, ctx, flowId, namespace)
+
+		created, err := KestraTestClient().Dashboards().CreateDashboard(ctx, MAIN_TENANT, executionsTableDashboardYaml(randomId(), "export-ion-"+randomId(), chartId, namespace))
+		require.NoError(t, err)
+
+		filters := kestra_api_client.NewChartFiltersOverrides()
+		result, err := KestraTestClient().Dashboards().ExportDashboardChart(ctx, created.Id, chartId, MAIN_TENANT, filters, strPtr("ION"))
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+
+		ion := string(result)
+		require.Contains(t, ion, namespace)
+		require.Contains(t, ion, flowId)
+		require.Contains(t, ion, execution.Id)
+		assertIonBinaryMarker(t, result)
+	})
+
+	t.Run("exportDashboardChart_notFound", func(t *testing.T) {
 		ctx := context.Background()
 		title := "csv-export-" + randomId()
 
@@ -271,7 +432,7 @@ columns:
 
 		filters := kestra_api_client.NewChartFiltersOverrides()
 
-		_, err = KestraTestClient().Dashboards().ExportDashboardChartDataToCSV(ctx, created.Id, "nonexistent", MAIN_TENANT, filters)
+		_, err = KestraTestClient().Dashboards().ExportDashboardChart(ctx, created.Id, "nonexistent", MAIN_TENANT, filters, strPtr("CSV"))
 		require.Error(t, err)
 	})
 }

--- a/java/java-sdk/README.md
+++ b/java/java-sdk/README.md
@@ -169,8 +169,8 @@ Class | Method | HTTP request | Description
 *DashboardsApi* | [**dashboardChartData**](docs/DashboardsApi.md#dashboardChartData) | **POST** /api/v1/{tenant}/dashboards/{id}/charts/{chartId} | Generate a dashboard chart data
 *DashboardsApi* | [**defaultDashboards1**](docs/DashboardsApi.md#defaultDashboards1) | **GET** /api/v1/{tenant}/dashboards/settings/default-dashboards | Get default dashboards
 *DashboardsApi* | [**deleteDashboard**](docs/DashboardsApi.md#deleteDashboard) | **DELETE** /api/v1/{tenant}/dashboards/{id} | Delete a dashboard
-*DashboardsApi* | [**exportChartToCsv**](docs/DashboardsApi.md#exportChartToCsv) | **POST** /api/v1/{tenant}/dashboards/charts/export/to-csv | Export a table chart data to CSV
-*DashboardsApi* | [**exportDashboardChartDataToCSV**](docs/DashboardsApi.md#exportDashboardChartDataToCSV) | **POST** /api/v1/{tenant}/dashboards/{id}/charts/{chartId}/export/to-csv | Export a dashboard chart data to CSV
+*DashboardsApi* | [**exportChart**](docs/DashboardsApi.md#exportChart) | **POST** /api/v1/{tenant}/dashboards/charts/export | Export a chart data to CSV or ION
+*DashboardsApi* | [**exportDashboardChart**](docs/DashboardsApi.md#exportDashboardChart) | **POST** /api/v1/{tenant}/dashboards/{id}/charts/{chartId}/export | Export a dashboard chart data to CSV or ION
 *DashboardsApi* | [**previewChart**](docs/DashboardsApi.md#previewChart) | **POST** /api/v1/{tenant}/dashboards/charts/preview | Preview a chart data
 *DashboardsApi* | [**searchDashboards**](docs/DashboardsApi.md#searchDashboards) | **GET** /api/v1/{tenant}/dashboards | Search for dashboards
 *DashboardsApi* | [**updateDashboard**](docs/DashboardsApi.md#updateDashboard) | **PUT** /api/v1/{tenant}/dashboards/{id} | Update a dashboard

--- a/java/java-sdk/docs/DashboardsApi.md
+++ b/java/java-sdk/docs/DashboardsApi.md
@@ -9,8 +9,8 @@ All URIs are relative to *http://localhost*
 | [**dashboardChartData**](DashboardsApi.md#dashboardChartData) | **POST** /api/v1/{tenant}/dashboards/{id}/charts/{chartId} | Generate a dashboard chart data |
 | [**defaultDashboards1**](DashboardsApi.md#defaultDashboards1) | **GET** /api/v1/{tenant}/dashboards/settings/default-dashboards | Get default dashboards |
 | [**deleteDashboard**](DashboardsApi.md#deleteDashboard) | **DELETE** /api/v1/{tenant}/dashboards/{id} | Delete a dashboard |
-| [**exportChartToCsv**](DashboardsApi.md#exportChartToCsv) | **POST** /api/v1/{tenant}/dashboards/charts/export/to-csv | Export a table chart data to CSV |
-| [**exportDashboardChartDataToCSV**](DashboardsApi.md#exportDashboardChartDataToCSV) | **POST** /api/v1/{tenant}/dashboards/{id}/charts/{chartId}/export/to-csv | Export a dashboard chart data to CSV |
+| [**exportChart**](DashboardsApi.md#exportChart) | **POST** /api/v1/{tenant}/dashboards/charts/export | Export a chart data to CSV or ION |
+| [**exportDashboardChart**](DashboardsApi.md#exportDashboardChart) | **POST** /api/v1/{tenant}/dashboards/{id}/charts/{chartId}/export | Export a dashboard chart data to CSV or ION |
 | [**previewChart**](DashboardsApi.md#previewChart) | **POST** /api/v1/{tenant}/dashboards/charts/preview | Preview a chart data |
 | [**searchDashboards**](DashboardsApi.md#searchDashboards) | **GET** /api/v1/{tenant}/dashboards | Search for dashboards |
 | [**updateDashboard**](DashboardsApi.md#updateDashboard) | **PUT** /api/v1/{tenant}/dashboards/{id} | Update a dashboard |
@@ -370,11 +370,11 @@ null (empty response body)
 | **200** | deleteDashboard 200 response |  -  |
 
 
-## exportChartToCsv
+## exportChart
 
-> byte[] exportChartToCsv(tenant, dashboardControllerPreviewRequest)
+> byte[] exportChart(tenant, dashboardControllerPreviewRequest, format)
 
-Export a table chart data to CSV
+Export a chart data to CSV or ION
 
 ### Example
 
@@ -398,11 +398,12 @@ public class Example {
 
         String tenant = "tenant_example"; // String | 
         DashboardControllerPreviewRequest dashboardControllerPreviewRequest = new DashboardControllerPreviewRequest(); // DashboardControllerPreviewRequest | 
+        String format = "CSV"; // String | The export format, CSV or ION
         try {
-            byte[] result = kestraClient.DashboardsApi().exportChartToCsv(tenant, dashboardControllerPreviewRequest);
+            byte[] result = kestraClient.DashboardsApi().exportChart(tenant, dashboardControllerPreviewRequest, format);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling DashboardsApi#exportChartToCsv");
+            System.err.println("Exception when calling DashboardsApi#exportChart");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -419,6 +420,7 @@ public class Example {
 |------------- | ------------- | ------------- | -------------|
 | **tenant** | **String**|  | |
 | **dashboardControllerPreviewRequest** | [**DashboardControllerPreviewRequest**](DashboardControllerPreviewRequest.md)|  | |
+| **format** | **String**| The export format, CSV or ION | [optional] |
 
 ### Return type
 
@@ -437,14 +439,14 @@ public class Example {
 ### HTTP response details
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
-| **200** | exportChartToCsv 200 response |  -  |
+| **200** | exportChart 200 response |  -  |
 
 
-## exportDashboardChartDataToCSV
+## exportDashboardChart
 
-> byte[] exportDashboardChartDataToCSV(id, chartId, tenant, chartFiltersOverrides)
+> byte[] exportDashboardChart(id, chartId, tenant, chartFiltersOverrides, format)
 
-Export a dashboard chart data to CSV
+Export a dashboard chart data to CSV or ION
 
 ### Example
 
@@ -470,11 +472,12 @@ public class Example {
         String chartId = "chartId_example"; // String | The chart id
         String tenant = "tenant_example"; // String | 
         ChartFiltersOverrides chartFiltersOverrides = new ChartFiltersOverrides(); // ChartFiltersOverrides | The filters to apply, some can override chart definition like labels & namespace
+        String format = "CSV"; // String | The export format, CSV or ION
         try {
-            byte[] result = kestraClient.DashboardsApi().exportDashboardChartDataToCSV(id, chartId, tenant, chartFiltersOverrides);
+            byte[] result = kestraClient.DashboardsApi().exportDashboardChart(id, chartId, tenant, chartFiltersOverrides, format);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling DashboardsApi#exportDashboardChartDataToCSV");
+            System.err.println("Exception when calling DashboardsApi#exportDashboardChart");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -493,6 +496,7 @@ public class Example {
 | **chartId** | **String**| The chart id | |
 | **tenant** | **String**|  | |
 | **chartFiltersOverrides** | [**ChartFiltersOverrides**](ChartFiltersOverrides.md)| The filters to apply, some can override chart definition like labels &amp; namespace | |
+| **format** | **String**| The export format, CSV or ION | [optional] |
 
 ### Return type
 
@@ -511,7 +515,7 @@ public class Example {
 ### HTTP response details
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
-| **200** | exportDashboardChartDataToCSV 200 response |  -  |
+| **200** | exportDashboardChart 200 response |  -  |
 
 
 ## previewChart

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/DashboardsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/DashboardsApiTest.java
@@ -4,6 +4,10 @@ import io.kestra.sdk.internal.ApiException;
 import io.kestra.sdk.model.*;
 import org.junit.jupiter.api.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static io.kestra.TestUtils.*;
@@ -30,6 +34,95 @@ public class DashboardsApiTest {
                   max: P365D
                 charts: []
                 """.formatted(id, title);
+    }
+
+    // Dashboard with a single OSS-native Table chart over the Executions data
+    // type, scoped to namespace so its export content is deterministic even on
+    // a shared test instance with unrelated executions.
+    static String executionsTableDashboardYaml(String dashboardId, String title, String chartId, String namespace) {
+        return """
+                id: %s
+                title: %s
+                description: Test dashboard
+                timeWindow:
+                  default: P30D
+                  max: P365D
+                charts:
+                  - id: %s
+                    type: io.kestra.plugin.core.dashboard.chart.Table
+                    chartOptions:
+                      displayName: Executions
+                    data:
+                      type: io.kestra.plugin.core.dashboard.data.Executions
+                      where:
+                        - field: NAMESPACE
+                          type: EQUAL_TO
+                          value: %s
+                      columns:
+                        id:
+                          field: ID
+                          displayName: Execution ID
+                        namespace:
+                          field: NAMESPACE
+                          displayName: Namespace
+                        flow:
+                          field: FLOW_ID
+                          displayName: Flow
+                        state:
+                          field: STATE
+                          displayName: State
+                """.formatted(dashboardId, title, chartId, namespace);
+    }
+
+    // executionsTableDashboardYaml's chart block on its own, usable directly in
+    // an ad-hoc PreviewRequest (no dashboard wrapper).
+    static String executionsTableChartYaml(String chartId, String namespace) {
+        return """
+                id: %s
+                type: io.kestra.plugin.core.dashboard.chart.Table
+                chartOptions:
+                  displayName: Executions
+                data:
+                  type: io.kestra.plugin.core.dashboard.data.Executions
+                  where:
+                    - field: NAMESPACE
+                      type: EQUAL_TO
+                      value: %s
+                  columns:
+                    id:
+                      field: ID
+                      displayName: Execution ID
+                    namespace:
+                      field: NAMESPACE
+                      displayName: Namespace
+                    flow:
+                      field: FLOW_ID
+                      displayName: Flow
+                    state:
+                      field: STATE
+                      displayName: State
+                """.formatted(chartId, namespace);
+    }
+
+    // The CSV header uses the executionsTable*Yaml column keys (not their
+    // displayName), and the SQL layer does not guarantee they come back in
+    // declaration order, so this compares against a sorted copy of the header.
+    private static final List<String> EXPECTED_EXPORT_COLUMNS = List.of("flow", "id", "namespace", "state");
+
+    static void assertCsvHeader(String csv) {
+        String header = csv.split("\n", 2)[0].stripTrailing();
+        List<String> columns = new ArrayList<>(List.of(header.split(",")));
+        Collections.sort(columns);
+        assertThat(columns).isEqualTo(EXPECTED_EXPORT_COLUMNS);
+    }
+
+    // Every Amazon Ion 1.0 binary stream starts with this fixed 4-byte header;
+    // FileSerde writes ION exports in binary form.
+    private static final byte[] ION_BINARY_VERSION_MARKER = {(byte) 0xE0, 0x01, 0x00, (byte) 0xEA};
+
+    static void assertIonBinaryMarker(byte[] result) {
+        assertThat(result).hasSizeGreaterThanOrEqualTo(4);
+        assertThat(Arrays.copyOfRange(result, 0, 4)).isEqualTo(ION_BINARY_VERSION_MARKER);
     }
 
     // ========================================================================
@@ -234,33 +327,97 @@ public class DashboardsApiTest {
     }
 
     @Test
-    void exportChartToCsv_basic() throws ApiException {
-        DashboardControllerPreviewRequest request = new DashboardControllerPreviewRequest()
-                .chart("""
-                        id: csv-chart
-                        type: io.kestra.plugin.ee.core.dashboard.charts.TimeSeriesChart
-                        graphStyle: LINES
-                        columns:
-                          date:
-                            field: DATE
-                        """);
+    void exportChart_basic() throws ApiException {
+        String namespace = randomId();
+        String flowId = randomId();
 
-        try {
-            byte[] result = api().exportChartToCsv(TENANT, request);
-            assertThat(result).isNotNull();
-        } catch (ApiException e) {
-            assertThat(e.getCode()).isIn(400, 422);
-        }
+        createFlow(logFlowYaml(flowId, namespace));
+        ExecutionControllerExecutionResponse execution = client().executions()
+                .createExecution(TENANT, namespace, flowId, null, true, null, null, null, null);
+
+        DashboardControllerPreviewRequest request = new DashboardControllerPreviewRequest()
+                .chart(executionsTableChartYaml("adhoc-chart", namespace));
+
+        byte[] result = api().exportChart(TENANT, request, "CSV");
+        assertThat(result).isNotEmpty();
+
+        String csv = new String(result, StandardCharsets.UTF_8);
+        assertThat(csv).contains(namespace, flowId, execution.getId());
+        assertCsvHeader(csv);
     }
 
     @Test
-    void exportDashboardChartDataToCSV_notFound() throws ApiException {
+    void exportChart_ion() throws ApiException {
+        String namespace = randomId();
+        String flowId = randomId();
+
+        createFlow(logFlowYaml(flowId, namespace));
+        ExecutionControllerExecutionResponse execution = client().executions()
+                .createExecution(TENANT, namespace, flowId, null, true, null, null, null, null);
+
+        DashboardControllerPreviewRequest request = new DashboardControllerPreviewRequest()
+                .chart(executionsTableChartYaml("adhoc-chart", namespace));
+
+        byte[] result = api().exportChart(TENANT, request, "ION");
+        assertThat(result).isNotEmpty();
+
+        String ion = new String(result, StandardCharsets.UTF_8);
+        assertThat(ion).contains(namespace, flowId, execution.getId());
+        assertIonBinaryMarker(result);
+    }
+
+    @Test
+    void exportDashboardChart_csv() throws ApiException {
+        String namespace = randomId();
+        String flowId = randomId();
+        String chartId = "recent_executions";
+
+        createFlow(logFlowYaml(flowId, namespace));
+        ExecutionControllerExecutionResponse execution = client().executions()
+                .createExecution(TENANT, namespace, flowId, null, true, null, null, null, null);
+
+        DashboardControllerDashboardResponse created = api().createDashboard(TENANT,
+                executionsTableDashboardYaml(randomId(), "export-csv-" + randomId(), chartId, namespace));
+
+        ChartFiltersOverrides filters = new ChartFiltersOverrides();
+        byte[] result = api().exportDashboardChart(created.getId(), chartId, TENANT, filters, "CSV");
+        assertThat(result).isNotEmpty();
+
+        String csv = new String(result, StandardCharsets.UTF_8);
+        assertThat(csv).contains(namespace, flowId, execution.getId());
+        assertCsvHeader(csv);
+    }
+
+    @Test
+    void exportDashboardChart_ion() throws ApiException {
+        String namespace = randomId();
+        String flowId = randomId();
+        String chartId = "recent_executions";
+
+        createFlow(logFlowYaml(flowId, namespace));
+        ExecutionControllerExecutionResponse execution = client().executions()
+                .createExecution(TENANT, namespace, flowId, null, true, null, null, null, null);
+
+        DashboardControllerDashboardResponse created = api().createDashboard(TENANT,
+                executionsTableDashboardYaml(randomId(), "export-ion-" + randomId(), chartId, namespace));
+
+        ChartFiltersOverrides filters = new ChartFiltersOverrides();
+        byte[] result = api().exportDashboardChart(created.getId(), chartId, TENANT, filters, "ION");
+        assertThat(result).isNotEmpty();
+
+        String ion = new String(result, StandardCharsets.UTF_8);
+        assertThat(ion).contains(namespace, flowId, execution.getId());
+        assertIonBinaryMarker(result);
+    }
+
+    @Test
+    void exportDashboardChart_notFound() throws ApiException {
         String title = "csv-export-" + randomId();
         DashboardControllerDashboardResponse created = api().createDashboard(TENANT, dashboardYaml(title));
 
         ChartFiltersOverrides filters = new ChartFiltersOverrides();
 
-        assertThatThrownBy(() -> api().exportDashboardChartDataToCSV(created.getId(), "nonexistent", TENANT, filters))
+        assertThatThrownBy(() -> api().exportDashboardChart(created.getId(), "nonexistent", TENANT, filters, "CSV"))
                 .isInstanceOf(ApiException.class);
     }
 }

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/DashboardsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/DashboardsApi.java
@@ -118,24 +118,26 @@ public class DashboardsApi extends BaseApi {
                 new TypeReference<>() {});
     }
 
-    public byte[] exportChartToCsv(
+    public byte[] exportChart(
             @jakarta.annotation.Nonnull String tenant,
-            @jakarta.annotation.Nonnull DashboardControllerPreviewRequest request) throws ApiException {
+            @jakarta.annotation.Nonnull DashboardControllerPreviewRequest request,
+            @jakarta.annotation.Nullable String format) throws ApiException {
         return invoke("POST",
-                tenantPath(tenant, "dashboards", "charts", "export", "to-csv"),
-                request, null, null,
+                tenantPath(tenant, "dashboards", "charts", "export"),
+                request, queryParams("format", format), null,
                 OCTET_STREAM, JSON,
                 new TypeReference<>() {});
     }
 
-    public byte[] exportDashboardChartDataToCSV(
+    public byte[] exportDashboardChart(
             @jakarta.annotation.Nonnull String id,
             @jakarta.annotation.Nonnull String chartId,
             @jakarta.annotation.Nonnull String tenant,
-            @jakarta.annotation.Nonnull ChartFiltersOverrides filters) throws ApiException {
+            @jakarta.annotation.Nonnull ChartFiltersOverrides filters,
+            @jakarta.annotation.Nullable String format) throws ApiException {
         return invoke("POST",
-                tenantPath(tenant, "dashboards", id, "charts", chartId, "export", "to-csv"),
-                filters, null, null,
+                tenantPath(tenant, "dashboards", id, "charts", chartId, "export"),
+                filters, queryParams("format", format), null,
                 OCTET_STREAM, JSON,
                 new TypeReference<>() {});
     }

--- a/javascript/test_javascript_sdk/DashboardsApi.spec.ts
+++ b/javascript/test_javascript_sdk/DashboardsApi.spec.ts
@@ -264,7 +264,7 @@ describe('DashboardsApi', () => {
         const created = await createDashboard(`csv-export-${randomId()}`);
         const id = (created as any).id;
 
-        await expect(kestraClient.Dashboards.exportDashboardChart({
+        await expect(Dashboards.exportDashboardChart({
             id,
             chartId: 'nonexistent',
             format: 'CSV',

--- a/javascript/test_javascript_sdk/DashboardsApi.spec.ts
+++ b/javascript/test_javascript_sdk/DashboardsApi.spec.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { randomId } from './_utils.js';
+import { randomId, getSimpleFlowAndId } from './_utils.js';
 import * as Dashboards from '@kestra-io/kestra-sdk/dashboards';
 import * as DashboardsAdmin from '@kestra-io/kestra-sdk/dashboards-admin';
+import * as Executions from '@kestra-io/kestra-sdk/executions';
+import * as Flows from '@kestra-io/kestra-sdk/flows';
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 function dashboardYaml(title: string, id?: string): string {
     const dashId = id ?? randomId();
@@ -19,6 +23,110 @@ async function createDashboard(title?: string) {
     return Dashboards.createDashboard({
         body: dashboardYaml(title ?? `test-dash-${randomId()}`),
     });
+}
+
+// Dashboard with a single OSS-native Table chart over the Executions data
+// type, scoped to namespace so its export content is deterministic even on
+// a shared test instance with unrelated executions.
+function executionsTableDashboardYaml(dashboardId: string, title: string, chartId: string, namespace: string): string {
+    return `id: ${dashboardId}
+title: ${title}
+description: Test dashboard
+timeWindow:
+  default: P30D
+  max: P365D
+charts:
+  - id: ${chartId}
+    type: io.kestra.plugin.core.dashboard.chart.Table
+    chartOptions:
+      displayName: Executions
+    data:
+      type: io.kestra.plugin.core.dashboard.data.Executions
+      where:
+        - field: NAMESPACE
+          type: EQUAL_TO
+          value: ${namespace}
+      columns:
+        id:
+          field: ID
+          displayName: Execution ID
+        namespace:
+          field: NAMESPACE
+          displayName: Namespace
+        flow:
+          field: FLOW_ID
+          displayName: Flow
+        state:
+          field: STATE
+          displayName: State
+`;
+}
+
+// executionsTableDashboardYaml's chart block on its own, usable directly in
+// an ad-hoc PreviewRequest (no dashboard wrapper).
+function executionsTableChartYaml(chartId: string, namespace: string): string {
+    return `id: ${chartId}
+type: io.kestra.plugin.core.dashboard.chart.Table
+chartOptions:
+  displayName: Executions
+data:
+  type: io.kestra.plugin.core.dashboard.data.Executions
+  where:
+    - field: NAMESPACE
+      type: EQUAL_TO
+      value: ${namespace}
+  columns:
+    id:
+      field: ID
+      displayName: Execution ID
+    namespace:
+      field: NAMESPACE
+      displayName: Namespace
+    flow:
+      field: FLOW_ID
+      displayName: Flow
+    state:
+      field: STATE
+      displayName: State
+`;
+}
+
+async function createFlowAndWaitForExecution(): Promise<{ namespace: string; flowId: string; executionId: string }> {
+    const { flowId, flowNamespace, flowBody } = getSimpleFlowAndId();
+    await Flows.createFlow({ body: flowBody });
+
+    const exec = await Executions.createExecution({ namespace: flowNamespace, id: flowId, wait: true });
+    const executionId = (exec as any).id;
+
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+        try {
+            const e = await Executions.execution({ executionId });
+            const state = (e as any).state?.current;
+            if (state === 'SUCCESS' || state === 'FAILED') break;
+        } catch (_) { /* execution may not be in DB yet */ }
+        await sleep(500);
+    }
+    return { namespace: flowNamespace, flowId, executionId };
+}
+
+// The CSV header uses the executionsTable*Yaml column keys (not their
+// displayName), and the SQL layer does not guarantee they come back in
+// declaration order, so tests compare against a sorted copy of the header.
+const EXPECTED_EXPORT_COLUMNS = ['flow', 'id', 'namespace', 'state'];
+
+function assertCsvHeader(csv: string) {
+    const header = csv.split('\n', 1)[0].replace(/\r$/, '');
+    expect(header.split(',').sort()).toEqual(EXPECTED_EXPORT_COLUMNS);
+}
+
+// The Node/axios client used in this test suite doesn't support
+// `responseType: 'blob'` outside a browser, so both CSV and ION responses
+// surface here as plain strings decoded as UTF-8. Binary Ion's opcode bytes
+// aren't valid UTF-8, so that decode leaves U+FFFD replacement characters in
+// the result — a reliable signal the payload is binary, not CSV text.
+function assertIonLooksBinary(ion: string) {
+    expect(ion).toContain(String.fromCharCode(0xfffd));
 }
 
 describe('DashboardsApi', () => {
@@ -88,5 +196,78 @@ describe('DashboardsApi', () => {
             body: dashboardYaml(`validate-${randomId()}`),
         });
         expect(result).toBeDefined();
+    });
+
+    it('exportChart: exports an ad-hoc chart to CSV', async () => {
+        const { namespace, flowId, executionId } = await createFlowAndWaitForExecution();
+
+        const csv = await Dashboards.exportChart({
+            chart: executionsTableChartYaml('adhoc-chart', namespace),
+            format: 'CSV',
+        });
+
+        expect(csv).toContain(namespace);
+        expect(csv).toContain(flowId);
+        expect(csv).toContain(executionId);
+        assertCsvHeader(csv);
+    });
+
+    it('exportChart: exports an ad-hoc chart to ION', async () => {
+        const { namespace, flowId, executionId } = await createFlowAndWaitForExecution();
+
+        const ion = await Dashboards.exportChart({
+            chart: executionsTableChartYaml('adhoc-chart', namespace),
+            format: 'ION',
+        });
+
+        expect(ion).toContain(namespace);
+        expect(ion).toContain(flowId);
+        expect(ion).toContain(executionId);
+        assertIonLooksBinary(ion);
+    });
+
+    it('exportDashboardChart: exports a saved dashboard chart to CSV', async () => {
+        const { namespace, flowId, executionId } = await createFlowAndWaitForExecution();
+        const chartId = 'recent_executions';
+
+        const created = await Dashboards.createDashboard({
+            body: executionsTableDashboardYaml(randomId(), `export-csv-${randomId()}`, chartId, namespace),
+        });
+        const id = (created as any).id;
+
+        const csv = await Dashboards.exportDashboardChart({ id, chartId, format: 'CSV' });
+
+        expect(csv).toContain(namespace);
+        expect(csv).toContain(flowId);
+        expect(csv).toContain(executionId);
+        assertCsvHeader(csv);
+    });
+
+    it('exportDashboardChart: exports a saved dashboard chart to ION', async () => {
+        const { namespace, flowId, executionId } = await createFlowAndWaitForExecution();
+        const chartId = 'recent_executions';
+
+        const created = await Dashboards.createDashboard({
+            body: executionsTableDashboardYaml(randomId(), `export-ion-${randomId()}`, chartId, namespace),
+        });
+        const id = (created as any).id;
+
+        const ion = await Dashboards.exportDashboardChart({ id, chartId, format: 'ION' });
+
+        expect(ion).toContain(namespace);
+        expect(ion).toContain(flowId);
+        expect(ion).toContain(executionId);
+        assertIonLooksBinary(ion);
+    });
+
+    it('exportDashboardChart: returns error for non-existent chart id', async () => {
+        const created = await createDashboard(`csv-export-${randomId()}`);
+        const id = (created as any).id;
+
+        await expect(kestraClient.Dashboards.exportDashboardChart({
+            id,
+            chartId: 'nonexistent',
+            format: 'CSV',
+        })).rejects.toThrow();
     });
 });

--- a/python/python-sdk/kestrapy/api/dashboards_api.py
+++ b/python/python-sdk/kestrapy/api/dashboards_api.py
@@ -52,13 +52,15 @@ class DashboardsApi(BaseApi):
         path = self._tenant_path(tenant, "dashboards", "charts", "preview")
         return self._json_request("POST", path, PagedResultsMapStringObject, body=request)
 
-    def export_chart_to_csv(self, tenant: str, request: DashboardControllerPreviewRequest) -> bytes:
-        path = self._tenant_path(tenant, "dashboards", "charts", "export", "to-csv")
-        return self._download_request("POST", path, body=request, accept=self.OCTET)
+    def export_chart(self, tenant: str, request: DashboardControllerPreviewRequest, format: Optional[str] = None) -> bytes:
+        path = self._tenant_path(tenant, "dashboards", "charts", "export")
+        params = list(self._build_query_params(format=format).items())
+        return self._download_request("POST", path, body=request, params=params, accept=self.OCTET)
 
-    def export_dashboard_chart_data_to_csv(self, id: str, chart_id: str, tenant: str, filters: ChartFiltersOverrides) -> bytes:
-        path = self._tenant_path(tenant, "dashboards", id, "charts", chart_id, "export", "to-csv")
-        return self._download_request("POST", path, body=filters, accept=self.OCTET)
+    def export_dashboard_chart(self, id: str, chart_id: str, tenant: str, filters: ChartFiltersOverrides, format: Optional[str] = None) -> bytes:
+        path = self._tenant_path(tenant, "dashboards", id, "charts", chart_id, "export")
+        params = list(self._build_query_params(format=format).items())
+        return self._download_request("POST", path, body=filters, params=params, accept=self.OCTET)
 
     # ---- Settings ----
 

--- a/python/python-sdk/testApis/test_dashboards_api.py
+++ b/python/python-sdk/testApis/test_dashboards_api.py
@@ -4,6 +4,11 @@ import pytest
 from test_helpers import (
     TENANT,
     random_id,
+    random_namespace,
+    log_flow_yaml,
+    create_flow,
+    create_execution,
+    wait_for_execution,
 )
 from kestrapy import (
     ChartFiltersOverrides,
@@ -24,6 +29,93 @@ def dashboard_yaml(title, dashboard_id=None):
         "  max: P365D\n"
         "charts: []\n"
     )
+
+
+def executions_table_dashboard_yaml(dashboard_id, title, chart_id, namespace):
+    """Dashboard with a single OSS-native Table chart over the Executions data
+    type, scoped to namespace so its export content is deterministic even on
+    a shared test instance with unrelated executions."""
+    return (
+        f"id: {dashboard_id}\n"
+        f"title: {title}\n"
+        "description: Test dashboard\n"
+        "timeWindow:\n"
+        "  default: P30D\n"
+        "  max: P365D\n"
+        "charts:\n"
+        f"  - id: {chart_id}\n"
+        "    type: io.kestra.plugin.core.dashboard.chart.Table\n"
+        "    chartOptions:\n"
+        "      displayName: Executions\n"
+        "    data:\n"
+        "      type: io.kestra.plugin.core.dashboard.data.Executions\n"
+        "      where:\n"
+        "        - field: NAMESPACE\n"
+        "          type: EQUAL_TO\n"
+        f"          value: {namespace}\n"
+        "      columns:\n"
+        "        id:\n"
+        "          field: ID\n"
+        "          displayName: Execution ID\n"
+        "        namespace:\n"
+        "          field: NAMESPACE\n"
+        "          displayName: Namespace\n"
+        "        flow:\n"
+        "          field: FLOW_ID\n"
+        "          displayName: Flow\n"
+        "        state:\n"
+        "          field: STATE\n"
+        "          displayName: State\n"
+    )
+
+
+def executions_table_chart_yaml(chart_id, namespace):
+    """executions_table_dashboard_yaml's chart block on its own, usable
+    directly in an ad-hoc PreviewRequest (no dashboard wrapper)."""
+    return (
+        f"id: {chart_id}\n"
+        "type: io.kestra.plugin.core.dashboard.chart.Table\n"
+        "chartOptions:\n"
+        "  displayName: Executions\n"
+        "data:\n"
+        "  type: io.kestra.plugin.core.dashboard.data.Executions\n"
+        "  where:\n"
+        "    - field: NAMESPACE\n"
+        "      type: EQUAL_TO\n"
+        f"      value: {namespace}\n"
+        "  columns:\n"
+        "    id:\n"
+        "      field: ID\n"
+        "      displayName: Execution ID\n"
+        "    namespace:\n"
+        "      field: NAMESPACE\n"
+        "      displayName: Namespace\n"
+        "    flow:\n"
+        "      field: FLOW_ID\n"
+        "      displayName: Flow\n"
+        "    state:\n"
+        "      field: STATE\n"
+        "      displayName: State\n"
+    )
+
+
+# The CSV header uses the executions_table_*_yaml column keys (not their
+# displayName), and the SQL layer does not guarantee they come back in
+# declaration order, so tests compare against a sorted copy of the header.
+EXPECTED_EXPORT_COLUMNS = sorted(["flow", "id", "namespace", "state"])
+
+# Every Amazon Ion 1.0 binary stream starts with this fixed 4-byte header;
+# FileSerde writes ION exports in binary form.
+ION_BINARY_VERSION_MARKER = b"\xe0\x01\x00\xea"
+
+
+def assert_csv_header(csv):
+    header = csv.split("\n", 1)[0].rstrip("\r")
+    assert sorted(header.split(",")) == EXPECTED_EXPORT_COLUMNS
+
+
+def assert_ion_binary_marker(result):
+    assert result[:4] == ION_BINARY_VERSION_MARKER
 
 
 # ========================================================================
@@ -276,23 +368,118 @@ def test_preview_chart_basic(client):
         assert e.status in (400, 422)
 
 
-def test_export_chart_to_csv_basic(client):
+def test_export_chart_basic(client):
+    namespace = random_namespace()
+    flow_id = random_id()
+
+    create_flow(client, log_flow_yaml(flow_id, namespace))
+    execution = create_execution(client, namespace, flow_id)
+    execution = wait_for_execution(client, execution.id)
+
     request = DashboardControllerPreviewRequest(
-        chart=(
-            "id: csv-chart\n"
-            "type: io.kestra.plugin.ee.core.dashboard.charts.TimeSeriesChart\n"
-            "graphStyle: LINES\n"
-            "columns:\n"
-            "  date:\n"
-            "    field: DATE\n"
-        )
+        chart=executions_table_chart_yaml("adhoc-chart", namespace)
     )
 
-    try:
-        result = client.dashboards.export_chart_to_csv(tenant=TENANT, request=request)
-        assert result is not None
-    except ApiException as e:
-        assert e.status in (400, 422)
+    result = client.dashboards.export_chart(tenant=TENANT, request=request, format="CSV")
+    assert result
+
+    csv = result.decode()
+    assert namespace in csv
+    assert flow_id in csv
+    assert execution.id in csv
+    assert_csv_header(csv)
+
+
+def test_export_chart_ion(client):
+    namespace = random_namespace()
+    flow_id = random_id()
+
+    create_flow(client, log_flow_yaml(flow_id, namespace))
+    execution = create_execution(client, namespace, flow_id)
+    execution = wait_for_execution(client, execution.id)
+
+    request = DashboardControllerPreviewRequest(
+        chart=executions_table_chart_yaml("adhoc-chart", namespace)
+    )
+
+    result = client.dashboards.export_chart(tenant=TENANT, request=request, format="ION")
+    assert result
+
+    # Binary Ion: decode leniently just to assert the string values are
+    # present inline, same as the byte-level check below.
+    ion = result.decode("utf-8", errors="ignore")
+    assert namespace in ion
+    assert flow_id in ion
+    assert execution.id in ion
+    assert_ion_binary_marker(result)
+
+
+def test_export_dashboard_chart_csv(client):
+    namespace = random_namespace()
+    flow_id = random_id()
+    chart_id = "recent_executions"
+
+    create_flow(client, log_flow_yaml(flow_id, namespace))
+    execution = create_execution(client, namespace, flow_id)
+    execution = wait_for_execution(client, execution.id)
+
+    created = client.dashboards.create_dashboard(
+        tenant=TENANT,
+        yaml_body=executions_table_dashboard_yaml(
+            random_id(), f"export-csv-{random_id()}", chart_id, namespace
+        ),
+    )
+
+    filters = ChartFiltersOverrides()
+    result = client.dashboards.export_dashboard_chart(
+        id=created["id"],
+        chart_id=chart_id,
+        tenant=TENANT,
+        filters=filters,
+        format="CSV",
+    )
+    assert result
+
+    csv = result.decode()
+    assert namespace in csv
+    assert flow_id in csv
+    assert execution.id in csv
+    assert_csv_header(csv)
+
+
+def test_export_dashboard_chart_ion(client):
+    namespace = random_namespace()
+    flow_id = random_id()
+    chart_id = "recent_executions"
+
+    create_flow(client, log_flow_yaml(flow_id, namespace))
+    execution = create_execution(client, namespace, flow_id)
+    execution = wait_for_execution(client, execution.id)
+
+    created = client.dashboards.create_dashboard(
+        tenant=TENANT,
+        yaml_body=executions_table_dashboard_yaml(
+            random_id(), f"export-ion-{random_id()}", chart_id, namespace
+        ),
+    )
+
+    filters = ChartFiltersOverrides()
+    result = client.dashboards.export_dashboard_chart(
+        id=created["id"],
+        chart_id=chart_id,
+        tenant=TENANT,
+        filters=filters,
+        format="ION",
+    )
+    assert result
+
+    # Binary Ion: decode leniently just to assert the string values are
+    # present inline, same as the byte-level check below.
+    ion = result.decode("utf-8", errors="ignore")
+    assert namespace in ion
+    assert flow_id in ion
+    assert execution.id in ion
+    assert_ion_binary_marker(result)
 
 
 @pytest.mark.xfail(
@@ -302,7 +489,7 @@ def test_export_chart_to_csv_basic(client):
     "every other shard-8 test passed) — same hang as test_dashboard_chart_data_not_found",
     strict=False,
 )
-def test_export_dashboard_chart_data_to_csv_not_found(client):
+def test_export_dashboard_chart_not_found(client):
     title = f"csv-export-{random_id()}"
     created = client.dashboards.create_dashboard(
         tenant=TENANT, yaml_body=dashboard_yaml(title)
@@ -311,9 +498,10 @@ def test_export_dashboard_chart_data_to_csv_not_found(client):
     filters = ChartFiltersOverrides()
 
     with pytest.raises(ApiException):
-        client.dashboards.export_dashboard_chart_data_to_csv(
+        client.dashboards.export_dashboard_chart(
             id=created["id"],
             chart_id="nonexistent",
             tenant=TENANT,
             filters=filters,
+            format="CSV",
         )


### PR DESCRIPTION
- Renames the chart-export operations from CSV-only `*-to-csv` routes to a single `/export` route taking a `format` query param (`CSV` or `ION`)
- Updates the Java, Python, Go, and JavaScript SDKs plus their tests to match
- Breaking rename, not a deprecate-and-keep — old method names (`exportChartToCsv`, `exportDashboardChartDataToCSV`, etc.) are removed outright, matching the OSS route rename with no back-compat alias
- Hand-edits the EE OpenAPI spec (`kestra-ee.yml`) surgically — only the two export paths — rather than a full regen, to keep the diff scoped to this change
- Companion to kestra-io/kestra#17260 and kestra-io/plugin-kestra#157 (kestra-ee#9112); no SDK release until Kestra 2.0 ships — draft until then, tested locally via `publishToMavenLocal`/local builds only

### ⚠️ Signature change
- Java:   exportChartToCsv(tenant, request) → exportChart(tenant, request, format)
- Java:   exportDashboardChartDataToCSV(id, chartId, tenant, filters) → exportDashboardChart(id, chartId, tenant, filters, format)
- Python: export_chart_to_csv(tenant, request) → export_chart(tenant, request, format=None)
- Python: export_dashboard_chart_data_to_csv(id, chart_id, tenant, filters) → export_dashboard_chart(id, chart_id, tenant, filters, format=None)
- Go:     ExportChartToCsv(ctx, tenant, request) → ExportChart(ctx, tenant, request, format *string)
- Go:     ExportDashboardChartDataToCSV(ctx, id, chartId, tenant, filters) → ExportDashboardChart(ctx, id, chartId, tenant, filters, format *string)
- JS:     exportChartToCsv → exportChart, exportDashboardChartDataToCSV → exportDashboardChart (regenerated)
