### PR TITLE
feat(js-sdk): forward CSRF token from <meta> in the browser

### DIFF
--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -53,6 +53,21 @@ export function configureClient(clientConfig: Config<ClientOptions> = {}, axiosC
                 config.headers["Accept"] = "text/csv, text/plain, text/json, application/json"
             }
         }
+
+        // Kestra's CsrfTokenFilter rejects cookie-authenticated non-safe requests (POST/PUT/PATCH/
+        // DELETE) that lack a CSRF token with a 403. In the browser the Kestra UI exposes the token
+        // as <meta name="csrf-token">, so forward it as X-CSRF-TOKEN here — every browser consumer
+        // then gets it automatically instead of re-implementing the lookup. No-op outside the browser
+        // (Node, other projects) and when the caller already set the header or uses header auth.
+        const isUnsafe = method === "post" || method === "put" || method === "patch" || method === "delete"
+        if (isUnsafe && typeof document !== "undefined" && config.headers["X-CSRF-TOKEN"] == null) {
+            const token = Array.from(document.querySelectorAll('meta[name="csrf-token"]'))
+                .map((m) => m.getAttribute("content"))
+                .find((c): c is string => !!c)
+            if (token) {
+                config.headers["X-CSRF-TOKEN"] = token
+            }
+        }
         return config
     })
 

--- a/javascript/test_javascript_sdk/csrfInterceptor.spec.ts
+++ b/javascript/test_javascript_sdk/csrfInterceptor.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import { configureClient, useClient } from "@kestra-io/kestra-sdk";
+
+// Captures the outgoing request config so we can assert what the interceptor produced,
+// without hitting a backend.
+function stubAdapterCapturing(): { last: () => InternalAxiosRequestConfig } {
+    const instance = configureClient();
+    let captured: InternalAxiosRequestConfig;
+    instance.defaults.adapter = async (config) => {
+        captured = config;
+        return {
+            data: {},
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            config,
+        } as AxiosResponse;
+    };
+    return { last: () => captured };
+}
+
+function stubMetaToken(token: string) {
+    vi.stubGlobal("document", {
+        querySelectorAll: () => [{ getAttribute: () => token }],
+    });
+}
+
+describe("CSRF interceptor", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("sets X-CSRF-TOKEN from <meta> on unsafe methods", async () => {
+        stubMetaToken("tok-123");
+        const capture = stubAdapterCapturing();
+
+        for (const method of ["post", "put", "patch", "delete"] as const) {
+            await useClient().request({ url: "http://localhost/api/v1/x", method });
+            expect(capture.last().headers["X-CSRF-TOKEN"]).toBe("tok-123");
+        }
+    });
+
+    it("does not set X-CSRF-TOKEN on safe methods", async () => {
+        stubMetaToken("tok-123");
+        const capture = stubAdapterCapturing();
+
+        await useClient().get("http://localhost/api/v1/x");
+        expect(capture.last().headers["X-CSRF-TOKEN"]).toBeUndefined();
+    });
+
+    it("does not overwrite a caller-provided X-CSRF-TOKEN", async () => {
+        stubMetaToken("tok-123");
+        const capture = stubAdapterCapturing();
+
+        await useClient().post("http://localhost/api/v1/x", null, {
+            headers: { "X-CSRF-TOKEN": "caller-token" },
+        });
+        expect(capture.last().headers["X-CSRF-TOKEN"]).toBe("caller-token");
+    });
+
+    it("is a no-op outside the browser (no document)", async () => {
+        // vitest node env: `document` is undefined unless stubbed.
+        const capture = stubAdapterCapturing();
+
+        await useClient().post("http://localhost/api/v1/x", null);
+        expect(capture.last().headers["X-CSRF-TOKEN"]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## What

Forward the Kestra CSRF token as `X-CSRF-TOKEN` from the JS SDK's request interceptor.

Kestra's `CsrfTokenFilter` rejects cookie-authenticated non-safe requests (`POST`/`PUT`/`PATCH`/`DELETE`) that lack `X-CSRF-TOKEN` with a **403**. The Kestra UI exposes the token as `<meta name="csrf-token">`. Today every browser consumer (Kestra UI, plugin UIs) re-implements this lookup — the Kestra UI does it in `main.ts`, and plugins duplicate it in their composables. Moving it into `configureClient()` means every browser consumer gets it for free.

## Behaviour

- Only on unsafe methods (`POST`/`PUT`/`PATCH`/`DELETE`).
- **No-op** outside the browser (`typeof document === "undefined"` → Node, other projects).
- **Does not overwrite** a caller-provided `X-CSRF-TOKEN` (header auth stays untouched).

## Follow-ups (separate PRs)

- Kestra UI: drop the now-redundant manual CSRF interceptor in `main.ts` (removes the documented "do not call `configureClient` after this → 403" footgun).
- Plugin UIs (e.g. plugin-gcp): drop the per-call CSRF lookup from their composables.

## Tests

Added `csrfInterceptor.spec.ts`: sets the header from `<meta>` on unsafe methods, skips safe methods, preserves a caller-provided header, and is a no-op without `document`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)