### PR TITLE
feat: remove operationIdsToSkip from OpenAPI customizer

### DIFF
--- a/configurations/kestra-openapi-sdk-customizer.json
+++ b/configurations/kestra-openapi-sdk-customizer.json
@@ -1,41 +1,5 @@
 {
   "removeDeprecatedParameters": true,
   "removeDeprecatedOperations": false,
-  "operationIdsToSkip": [
-    "triggerExecutionByPostWebhook",
-    "validateNewExecutionInputs",
-    "validateResumeExecutionInputs",
-    "triggerExecutionByPutWebhook",
-    "triggerExecution",
-    "searchTaskRun",
-    "resumeExecutionFromBreakpoint",
-    "previewFileFromExecution",
-    "listFlowExecutionsByNamespace",
-    "listExecutableDistinctNamespaces",
-    "evalTaskRunExpression",
-    "previewAppTest",
-    "openAppTest",
-    "streamEventsFromApp",
-    "dispatchApp",
-    "downloadFileFromAppExecution",
-    "fileMetaFromAppExecution",
-    "filePreviewFromAppExecution",
-    "logsFromAppExecution",
-    "previewApp",
-    "openApp",
-    "logsFromAppExecutionlogsFromAppExecution",
-    "followLogsFromExecution",
-    "basicAuthConfigErrors", "# seems not useful",
-    "createBasicAuth", "# cannot be used",
-    "refreshLicense", "# seems not useful",
-    "setupKestra", "# seems not useful",
-    "tenantUsage", "# GO deserialization doesnt work",
-    "usages", "# GO deserialization doesnt work",
-    "listPermissions", "# GO deserialization enum clash with 1.1",
-    "exportFlows", "# csv export mainly aimed for UI not working yet in the SDK",
-    "exportExecutions", "# csv export mainly aimed for UI not working yet in the SDK"
-  ],
-  "tagsToSkip": [
-    "Credentials"
-  ]
+  "tagsToSkip": ["Credentials"]
 }


### PR DESCRIPTION
This pull request makes a change to the `kestra-openapi-sdk-customizer.json` configuration file, simplifying the configuration by removing the `operationIdsToSkip` list. The only remaining customization is to skip the `Credentials` tag.

Configuration simplification:

* Removed the `operationIdsToSkip` list, so no operations are explicitly skipped during SDK generation anymore.
* The `tagsToSkip` configuration remains, continuing to skip the `Credentials` tag.