### PR TITLE
ci: trigger pkg.go.dev indexing on go-sdk release

### DIFF
--- a/.github/workflows/go-sdk-release.yml
+++ b/.github/workflows/go-sdk-release.yml
@@ -13,6 +13,12 @@ jobs:
     name: Announce Go SDK release
     runs-on: ubuntu-latest
     steps:
+      - name: Trigger pkg.go.dev indexing
+        run: |
+          VERSION="${GITHUB_REF_NAME#go-sdk/}"
+          curl -sf "https://proxy.golang.org/github.com/kestra-io/client-sdk/go-sdk/@v/${VERSION}.info" > /dev/null
+          curl -sf "https://pkg.go.dev/github.com/kestra-io/client-sdk/go-sdk@${VERSION}" > /dev/null
+
       - name: Slack notification
         uses: kestra-io/actions/composite/slack-status@main
         with:


### PR DESCRIPTION
## Summary
- Same fix as kestra-io/kestractl#92: pkg.go.dev only crawls a module version once something requests its page, so new tags sit unindexed for days.
- After a `go-sdk/vX.Y.Z` tag is pushed, hit the Go module proxy and pkg.go.dev to force reindexing. Version is derived by stripping the `go-sdk/` tag prefix, since the module path (`github.com/kestra-io/client-sdk/go-sdk`) already includes the subdirectory.

## Test plan
- [ ] Cut a `go-sdk/vX.Y.Z` tag, confirm the new step runs before the Slack notification and pkg.go.dev shows the new version shortly after