### PR TITLE
fix(python/1.3): restore flow inputs on create/resume/replay execution

### DIFF
--- a/python/python-sdk/kestrapy/api/executions_api.py
+++ b/python/python-sdk/kestrapy/api/executions_api.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, Generator, List, Optional
 
 from kestrapy.base_api import BaseApi
@@ -36,7 +37,21 @@ class ExecutionsApi(BaseApi):
         schedule_date: Optional[str] = None,
         breakpoints: Optional[str] = None,
         kind: Optional[ExecutionKind] = None,
+        inputs: Optional[Dict[str, Any]] = None,
     ) -> ExecutionControllerExecutionResponse:
+        """Create a new execution for a flow.
+
+        Flow inputs are passed via ``inputs`` as a mapping of input id to value.
+        They are sent as ``multipart/form-data``, one form part per input:
+
+        - ``str`` values are sent verbatim.
+        - ``bytes``/``bytearray`` values are sent as a file part (for ``FILE`` inputs).
+        - a ``(filename, content)`` or ``(filename, content, content_type)`` tuple is
+          sent as a file part with that filename/content type (for ``FILE`` inputs).
+        - any other value (``int``, ``float``, ``bool``, ``dict``, ``list``, ...) is
+          JSON-encoded, so e.g. ``True`` becomes ``"true"`` and ``[1, 2]`` becomes
+          ``"[1, 2]"`` (for ``JSON``/``ARRAY``/... inputs).
+        """
         path = self._tenant_path(tenant, "executions", namespace, id)
         kind_val = kind.value if kind is not None and hasattr(kind, 'value') else kind
         params = list(self._build_query_params(
@@ -44,7 +59,26 @@ class ExecutionsApi(BaseApi):
             breakpoints=breakpoints, kind=kind_val,
         ).items())
         self._append_repeated_param(params, "labels", labels)
-        return self._json_request("POST", path, ExecutionControllerExecutionResponse, params=params)
+        files = self._build_inputs_multipart(inputs)
+        resp = self._request("POST", path, params=params, files=files)
+        return self._deserialize(resp.json(), ExecutionControllerExecutionResponse)
+
+    @staticmethod
+    def _build_inputs_multipart(inputs: Optional[Dict[str, Any]]):
+        """Turn a flow-inputs mapping into ``requests``-style multipart file parts."""
+        if not inputs:
+            return None
+        parts = []
+        for key, value in inputs.items():
+            if isinstance(value, (bytes, bytearray)):
+                parts.append((key, (key, value)))
+            elif isinstance(value, tuple):
+                parts.append((key, value))
+            elif isinstance(value, str):
+                parts.append((key, (None, value)))
+            else:
+                parts.append((key, (None, json.dumps(value))))
+        return parts
 
     # ========================================================================
     # Get execution
@@ -247,9 +281,18 @@ class ExecutionsApi(BaseApi):
         self._append_filter_params(params, filters)
         return self._raw_json_request("POST", path, params=params)
 
-    def resume_execution(self, execution_id: str, tenant: str) -> None:
-        path = self._tenant_path(tenant, "executions", execution_id,"resume")
-        self._void_request("POST", path)
+    def resume_execution(
+        self, execution_id: str, tenant: str, inputs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Resume a paused execution.
+
+        ``inputs`` supplies the ``onResume`` inputs declared by the ``Pause`` task,
+        encoded as ``multipart/form-data`` (see ``create_execution`` for the value
+        conventions).
+        """
+        path = self._tenant_path(tenant, "executions", execution_id, "resume")
+        files = self._build_inputs_multipart(inputs)
+        self._request("POST", path, files=files)
 
     def resume_executions_by_ids(self, tenant: str, ids: List[str]) -> Any:
         path = self._tenant_path(tenant, "executions", "resume", "by-ids")
@@ -311,12 +354,21 @@ class ExecutionsApi(BaseApi):
         task_run_id: Optional[str] = None,
         revision: Optional[int] = None,
         breakpoints: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
     ) -> Execution:
-        path = self._tenant_path(tenant, "executions", execution_id,"replay-with-inputs")
+        """Replay an execution, overriding its inputs.
+
+        ``inputs`` is the new set of flow inputs, encoded as ``multipart/form-data``
+        (see ``create_execution`` for the value conventions). Without it this behaves
+        like ``replay_execution``.
+        """
+        path = self._tenant_path(tenant, "executions", execution_id, "replay-with-inputs")
         params = self._build_query_params(
             taskRunId=task_run_id, revision=revision, breakpoints=breakpoints,
         )
-        return self._json_request("POST", path, Execution, params=params)
+        files = self._build_inputs_multipart(inputs)
+        resp = self._request("POST", path, params=params, files=files)
+        return self._deserialize(resp.json(), Execution)
 
     def replay_executions_by_ids(
         self, tenant: str, ids: List[str], latest_revision: Optional[bool] = None,

--- a/python/python-sdk/testApis/test_executions_api.py
+++ b/python/python-sdk/testApis/test_executions_api.py
@@ -54,6 +54,36 @@ tasks:
 """
 
 
+def _input_flow_yaml(flow_id, ns):
+    return f"""\
+id: {flow_id}
+namespace: {ns}
+inputs:
+  - id: greeting
+    type: STRING
+tasks:
+  - id: echo
+    type: io.kestra.plugin.core.log.Log
+    message: "{{{{ inputs.greeting }}}}"
+"""
+
+
+def _pause_flow_yaml(flow_id, ns):
+    return f"""\
+id: {flow_id}
+namespace: {ns}
+tasks:
+  - id: pause
+    type: io.kestra.plugin.core.flow.Pause
+    onResume:
+      - id: reason
+        type: STRING
+  - id: after
+    type: io.kestra.plugin.core.log.Log
+    message: "{{{{ outputs.pause.onResume.reason }}}}"
+"""
+
+
 def _webhook_flow_yaml(flow_id, ns, key):
     return f"""\
 id: {flow_id}
@@ -132,6 +162,19 @@ class TestCreateAndGet:
         result = _execute_flow(client, ns, flow_id)
         assert result is not None
         assert result.id is not None and result.id != ""
+
+    def test_create_execution_with_inputs(self, client, shared_flow):
+        ns, _ = shared_flow
+        flow_id = random_id()
+        create_flow(client, _input_flow_yaml(flow_id, ns))
+
+        result = _execute_flow(
+            client, ns, flow_id, wait=True, inputs={"greeting": "hello"},
+        )
+        assert result is not None
+        assert result.state.current == StateType.SUCCESS
+        assert result.inputs is not None
+        assert result.inputs.get("greeting") == "hello"
 
     def test_execution_get_by_id(self, client, succeeded_execution):
         execution_id, _, _ = succeeded_execution
@@ -422,6 +465,23 @@ class TestReplay:
         result = client.executions.replay_execution_with_inputs(execution_id, TENANT)
         assert result is not None
         assert result.id is not None and result.id != ""
+
+    def test_replay_execution_with_inputs_overrides_inputs(self, client, shared_flow):
+        ns, _ = shared_flow
+        flow_id = random_id()
+        create_flow(client, _input_flow_yaml(flow_id, ns))
+
+        original = _execute_flow(
+            client, ns, flow_id, wait=True, inputs={"greeting": "hello"},
+        )
+        assert original.inputs.get("greeting") == "hello"
+
+        replayed = client.executions.replay_execution_with_inputs(
+            original.id, TENANT, inputs={"greeting": "world"},
+        )
+        assert replayed.id != original.id
+        final = wait_for_execution(client, replayed.id)
+        assert final.inputs.get("greeting") == "world"
 
     def test_replay_executions_by_ids_basic(self, client, succeeded_execution):
         execution_id, _, _ = succeeded_execution
@@ -788,6 +848,23 @@ class TestPauseResume:
 
         client.executions.resume_execution(execution_id, TENANT)
         _wait_for_state(client, execution_id, [StateType.RUNNING, StateType.SUCCESS])
+
+    def test_resume_execution_with_inputs(self, client, shared_flow):
+        ns, _ = shared_flow
+        flow_id = random_id()
+        create_flow(client, _pause_flow_yaml(flow_id, ns))
+
+        resp = _execute_flow(client, ns, flow_id)
+        execution_id = resp.id
+        _wait_for_state(client, execution_id, [StateType.PAUSED])
+
+        # A required onResume input must be supplied at resume time; without the
+        # multipart body this raises 422 (the regression this guards against).
+        client.executions.resume_execution(
+            execution_id, TENANT, inputs={"reason": "go"},
+        )
+        final = wait_for_execution(client, execution_id)
+        assert final.state.current == StateType.SUCCESS
 
     def test_pause_executions_by_ids_basic(self, client):
         with pytest.raises(Exception):


### PR DESCRIPTION
## Problem

kestrapy **1.3.x** dropped the ability to pass **flow inputs** to executions. Reported in #203 and Pylon #2038 (HeartFlow): after upgrading `kestrapy` 1.0.10 → 1.3.0, `create_execution` lost its `additional_form_datas` parameter and gained no replacement — there was no way to start a flow with inputs.

The hand-written SDK rewrite reimplemented three `multipart/form-data` endpoints as bodyless requests. All three are fixed here.

> This is the **1.3 line** fix (the branch 1.3.x is released from). The equivalent fix for `main`/2.0 is #335 — the two differ only in the endpoint paths (1.3 has no `/actions/` segment).

## Fixes

An `inputs` mapping, sent as `multipart/form-data` via a shared `_build_inputs_multipart` helper:

| method | 1.3 path |
|---|---|
| `create_execution` | `POST executions/{namespace}/{id}` |
| `resume_execution` | `POST executions/{executionId}/resume` |
| `replay_execution_with_inputs` | `POST executions/{executionId}/replay-with-inputs` |

Value conventions: `str` sent verbatim; `bytes` / `(filename, content[, content_type])` tuple → file part (FILE inputs); anything else JSON-encoded (`True`→`"true"`, `[1,2]`→`"[1, 2]"`).

## Backward compatibility

`inputs` is appended at the **end** of every signature, so the change is purely additive — all existing 1.3.x positional arguments keep their position, `inputs` is opt-in. `resume_execution` keeps its `None` return.

## Tests

- `test_create_execution_with_inputs` — flow with a `STRING` input, asserts echoed `inputs.greeting`
- `test_resume_execution_with_inputs` — pauses on a `Pause` task with a **required** `onResume` input, resumes with it, asserts SUCCESS
- `test_replay_execution_with_inputs_overrides_inputs` — replays overriding an input, asserts the new value

Ref Pylon #2038. Ships to customers in the next 1.3 patch (1.3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)