### PR TITLE
fix(javascript): share client interceptors and axios-parity gaps with useClient()

### DIFF
--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -30,9 +30,7 @@ function serializeQueryValue(val: unknown) {
 interface AxiosLikeConfig {
     params?: Record<string, unknown>
     headers?: Record<string, string>
-    /** Defaults to auto-detecting from the response Content-Type (json, else text). */
     responseType?: "json" | "text" | "blob"
-    /** Aborts the request after this many ms. */
     timeout?: number
     validateStatus?: (status: number) => boolean
     [key: string]: any
@@ -42,9 +40,7 @@ interface AxiosLikeResponse<T = any> {
     data: T
     status: number
     headers: Record<string, string>
-    // response.url after following redirects - useful for endpoints that respond with a
-    // redirect to a signed download URL instead of streaming the file themselves. Optional
-    // so hand-written mocks (setMockClient, tests) aren't forced to fabricate one.
+    // Optional so existing setMockClient()/test mocks aren't forced to fabricate one.
     request?: { responseURL: string }
 }
 
@@ -66,13 +62,7 @@ function withQuery(url: string, params?: Record<string, unknown>): string {
     return url.includes("?") ? `${url}&${query}` : `${url}?${query}`
 }
 
-/**
- * Runs a request through the SAME interceptor pipeline `configureClient()` wires up on
- * `client` (its own content-type/accept normalization, error status/message enrichment, and
- * anything a consumer app registered afterwards via `client.interceptors.*.use()`, e.g. a
- * CSRF header or 401 handling) - so ad-hoc calls made through `useClient()` behave exactly
- * like the generated endpoint functions instead of silently bypassing that configuration.
- */
+/** Shares client.interceptors.* with configureClient() so ad-hoc useClient() calls get the same behavior as generated endpoint calls. */
 async function axiosLikeRequest<T>(
     method: string,
     url: string,
@@ -100,9 +90,7 @@ async function axiosLikeRequest<T>(
     const requestInit: RequestInit = { method, headers, body, credentials: "include", redirect: "follow" }
     if (config.timeout) requestInit.signal = AbortSignal.timeout(config.timeout)
 
-    // Mirrors the ResolvedRequestOptions fields configureClient()'s own request interceptor
-    // reads: bodySerializer identity marks a multipart endpoint (skip forcing JSON content-type
-    // so the browser can set its own boundary), parseAs drives the Accept header for blob/text.
+    // bodySerializer identity marks a multipart endpoint for the shared request interceptor.
     const interceptorOptions = {
         ...config,
         bodySerializer: isFormData ? formDataBodySerializer.bodySerializer : undefined,

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -28,7 +28,12 @@ function serializeQueryValue(val: unknown) {
 }
 
 interface AxiosLikeConfig {
+    params?: Record<string, unknown>
     headers?: Record<string, string>
+    /** Defaults to auto-detecting from the response Content-Type (json, else text). */
+    responseType?: "json" | "text" | "blob"
+    /** Aborts the request after this many ms. */
+    timeout?: number
     validateStatus?: (status: number) => boolean
     [key: string]: any
 }
@@ -37,20 +42,51 @@ interface AxiosLikeResponse<T = any> {
     data: T
     status: number
     headers: Record<string, string>
+    // response.url after following redirects - useful for endpoints that respond with a
+    // redirect to a signed download URL instead of streaming the file themselves. Optional
+    // so hand-written mocks (setMockClient, tests) aren't forced to fabricate one.
+    request?: { responseURL: string }
 }
 
 const commonHeaders: Record<string, string> = {}
 
+function withQuery(url: string, params?: Record<string, unknown>): string {
+    if (!params) return url
+    const search = new URLSearchParams()
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null) continue
+        if (Array.isArray(value)) {
+            value.forEach(v => search.append(key, String(v)))
+        } else {
+            search.append(key, typeof value === "object" ? JSON.stringify(value) : String(value))
+        }
+    }
+    const query = search.toString()
+    if (!query) return url
+    return url.includes("?") ? `${url}&${query}` : `${url}?${query}`
+}
+
+/**
+ * Runs a request through the SAME interceptor pipeline `configureClient()` wires up on
+ * `client` (its own content-type/accept normalization, error status/message enrichment, and
+ * anything a consumer app registered afterwards via `client.interceptors.*.use()`, e.g. a
+ * CSRF header or 401 handling) - so ad-hoc calls made through `useClient()` behave exactly
+ * like the generated endpoint functions instead of silently bypassing that configuration.
+ */
 async function axiosLikeRequest<T>(
     method: string,
     url: string,
     data?: any,
     config: AxiosLikeConfig = {}
 ): Promise<AxiosLikeResponse<T>> {
+    const fullUrl = withQuery(url, config.params)
     const headers = new Headers({ ...commonHeaders, ...(config.headers ?? {}) })
+    const isFormData = data instanceof FormData
 
     let body: BodyInit | undefined
-    if (data !== undefined) {
+    if (isFormData || data instanceof Blob) {
+        body = data
+    } else if (data !== undefined) {
         if (typeof data === "string") {
             body = data
         } else {
@@ -61,33 +97,67 @@ async function axiosLikeRequest<T>(
         }
     }
 
-    const response = await fetch(url, { method, headers, body, credentials: "include" })
+    const requestInit: RequestInit = { method, headers, body, credentials: "include", redirect: "follow" }
+    if (config.timeout) requestInit.signal = AbortSignal.timeout(config.timeout)
+
+    // Mirrors the ResolvedRequestOptions fields configureClient()'s own request interceptor
+    // reads: bodySerializer identity marks a multipart endpoint (skip forcing JSON content-type
+    // so the browser can set its own boundary), parseAs drives the Accept header for blob/text.
+    const interceptorOptions = {
+        ...config,
+        bodySerializer: isFormData ? formDataBodySerializer.bodySerializer : undefined,
+        parseAs: config.responseType,
+    } as unknown as ResolvedRequestOptions
+
+    let request = new Request(fullUrl, requestInit)
+    for (const fn of client.interceptors.request.fns) {
+        if (fn) request = await fn(request, interceptorOptions)
+    }
+
+    let response = await fetch(request)
+    for (const fn of client.interceptors.response.fns) {
+        if (fn) response = await fn(response, request, interceptorOptions)
+    }
 
     const { validateStatus } = config
     const isSuccess = validateStatus ? validateStatus(response.status) : response.status < 400
 
+    const headersObj: Record<string, string> = {}
+    response.headers.forEach((value, key) => { headersObj[key] = value })
+
+    if (!isSuccess) {
+        const textError = await response.text()
+        let parsedError: unknown
+        try {
+            parsedError = JSON.parse(textError)
+        } catch {
+            parsedError = textError
+        }
+
+        let finalError: unknown = parsedError
+        for (const fn of client.interceptors.error.fns) {
+            if (fn) finalError = await fn(finalError, response, request, interceptorOptions)
+        }
+        if (finalError && typeof finalError === "object") {
+            (finalError as Record<string, unknown>).response = {
+                data: parsedError, status: response.status, headers: headersObj, request: { responseURL: response.url },
+            }
+        }
+        throw finalError
+    }
+
     let responseData: T
-    const contentType = response.headers.get("content-type") ?? ""
-    if (response.status === 204 || response.headers.get("content-length") === "0") {
+    if (config.responseType === "blob") {
+        responseData = await response.blob() as T
+    } else if (response.status === 204 || response.headers.get("content-length") === "0") {
         responseData = null as T
-    } else if (contentType.includes("application/json")) {
+    } else if (config.responseType !== "text" && (response.headers.get("content-type") ?? "").includes("application/json")) {
         responseData = await response.json() as T
     } else {
         responseData = await response.text() as unknown as T
     }
 
-    const headersObj: Record<string, string> = {}
-    response.headers.forEach((value, key) => { headersObj[key] = value })
-
-    const result: AxiosLikeResponse<T> = { data: responseData, status: response.status, headers: headersObj }
-
-    if (!isSuccess) {
-        const error = new Error(`Request failed with status ${response.status}`) as Error & { response: AxiosLikeResponse<T> }
-        error.response = result
-        throw error
-    }
-
-    return result
+    return { data: responseData, status: response.status, headers: headersObj, request: { responseURL: response.url } }
 }
 
 const axiosLikeClient = {

--- a/javascript/test_javascript_sdk/useClientErrorHandling.spec.ts
+++ b/javascript/test_javascript_sdk/useClientErrorHandling.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { configureClient, useClient } from "@kestra-io/kestra-sdk";
+
+// Unit tests, no live backend needed: fetch is stubbed directly.
+describe("useClient error handling", () => {
+    beforeEach(() => {
+        configureClient({ baseUrl: "http://localhost:8080" });
+    });
+
+    it("normalizes a JSON error body: status, message, and response.data", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () =>
+            new Response(JSON.stringify({ message: "Invalid flow", constraints: "bad input" }), {
+                status: 400,
+                headers: { "content-type": "application/json" },
+            })
+        ));
+
+        const client = useClient();
+        await expect(client.get("http://localhost:8080/api/v1/flows/x/y")).rejects.toMatchObject({
+            status: 400,
+            message: "400 Invalid flow",
+            response: {
+                status: 400,
+                data: { message: "Invalid flow", constraints: "bad input" },
+            },
+            constraints: "bad input",
+        });
+
+        vi.unstubAllGlobals();
+    });
+
+    it("shares a client.interceptors.error.use() registration with generated endpoint calls", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () =>
+            new Response(JSON.stringify({ message: "nope" }), {
+                status: 403,
+                headers: { "content-type": "application/json" },
+            })
+        ));
+
+        const client = useClient();
+        const seenStatuses: unknown[] = [];
+        configureClient({ baseUrl: "http://localhost:8080" }).interceptors.error.use((error) => {
+            seenStatuses.push((error as { status?: number }).status);
+            return error;
+        });
+
+        await expect(client.get("http://localhost:8080/api/v1/flows/x/y")).rejects.toBeDefined();
+        expect(seenStatuses).toEqual([403]);
+
+        vi.unstubAllGlobals();
+    });
+});

--- a/javascript/test_javascript_sdk/useClientInterceptors.spec.ts
+++ b/javascript/test_javascript_sdk/useClientInterceptors.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { configureClient, useClient } from "@kestra-io/kestra-sdk";
+
+// Unit tests, no live backend needed: fetch is stubbed directly.
+describe("useClient shares client.interceptors with configureClient()", () => {
+    beforeEach(() => {
+        configureClient({ baseUrl: "http://localhost:8080" });
+    });
+
+    it("applies a request interceptor registered on the client returned by configureClient()", async () => {
+        let capturedRequest: Request | undefined;
+        vi.stubGlobal("fetch", vi.fn(async (request: Request) => {
+            capturedRequest = request;
+            return new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            });
+        }));
+
+        const client = configureClient({ baseUrl: "http://localhost:8080" });
+        client.interceptors.request.use((request) => {
+            request.headers.set("X-CSRF-TOKEN", "abc123");
+            return request;
+        });
+
+        await useClient().get("http://localhost:8080/api/v1/foo");
+
+        expect(capturedRequest?.headers.get("X-CSRF-TOKEN")).toBe("abc123");
+
+        vi.unstubAllGlobals();
+    });
+
+    it("serializes params on useClient() calls the same way generated endpoints do", async () => {
+        let capturedUrl = "";
+        vi.stubGlobal("fetch", vi.fn(async (request: Request) => {
+            capturedUrl = request.url;
+            return new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            });
+        }));
+
+        await useClient().get("http://localhost:8080/api/v1/foo", { params: { q: "bar", tags: ["a", "b"] } });
+
+        expect(capturedUrl).toBe("http://localhost:8080/api/v1/foo?q=bar&tags=a&tags=b");
+
+        vi.unstubAllGlobals();
+    });
+});


### PR DESCRIPTION
### What changes are being made and why?

`useClient()`'s ad-hoc HTTP methods bypassed `configureClient()`'s interceptor pipeline entirely — a `client.interceptors.*.use()` registered by an app (CSRF header, 401 handling) silently never applied to `useClient()` calls, even though pre-#225 both paths shared one axios instance. `useClient()` also lost `params`, `responseType: "blob"`, `timeout`, and `request.responseURL` versus axios.

`axiosLikeRequest` now builds a real `Request`, runs it through the same `client.interceptors.request/response/error` arrays `configureClient()` populates, then fetches. Errors get the same status/message normalization as generated calls, plus a `.response` for backward compat with `err.response.data` call sites.

### How the changes have been QAed?

- `tsc --noEmit` + `npm run build`: clean, including `test_javascript_sdk`'s typecheck against the rebuilt package.
- Manual runtime check against the built `dist/index.js` with a mocked `fetch`: confirms interceptor sharing, `params` serialization, error normalization, and FormData content-type handling all work. (Full `npm test` needs a live Kestra instance, not available here.)

### Setup Instructions

None.
