### PR TITLE
fix(javascript): default useClient() generics to any, matching axios

### DIFF
--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -150,11 +150,11 @@ async function axiosLikeRequest<T>(
 
 const axiosLikeClient = {
     defaults: { headers: { common: commonHeaders } },
-    get: <T>(url: string, config?: AxiosLikeConfig) => axiosLikeRequest<T>("GET", url, undefined, config),
-    post: <T>(url: string, data?: any, config?: AxiosLikeConfig) => axiosLikeRequest<T>("POST", url, data, config),
-    put: <T>(url: string, data?: any, config?: AxiosLikeConfig) => axiosLikeRequest<T>("PUT", url, data, config),
-    delete: <T>(url: string, config?: AxiosLikeConfig) => axiosLikeRequest<T>("DELETE", url, undefined, config),
-    patch: <T>(url: string, data?: any, config?: AxiosLikeConfig) => axiosLikeRequest<T>("PATCH", url, data, config),
+    get: <T = any>(url: string, config?: AxiosLikeConfig) => axiosLikeRequest<T>("GET", url, undefined, config),
+    post: <T = any>(url: string, data?: any, config?: AxiosLikeConfig) => axiosLikeRequest<T>("POST", url, data, config),
+    put: <T = any>(url: string, data?: any, config?: AxiosLikeConfig) => axiosLikeRequest<T>("PUT", url, data, config),
+    delete: <T = any>(url: string, config?: AxiosLikeConfig) => axiosLikeRequest<T>("DELETE", url, undefined, config),
+    patch: <T = any>(url: string, data?: any, config?: AxiosLikeConfig) => axiosLikeRequest<T>("PATCH", url, data, config),
 } as const
 
 export function configureClient(clientConfig: Config<ClientOptions> = {}): Client {


### PR DESCRIPTION
### What changes are being made and why?

Follow-up to #342. `useClient()`'s `get`/`post`/`put`/`patch`/`delete` had no default for their type parameter (`<T>` instead of `<T = any>`), so a call without an explicit generic inferred to `unknown` instead of `any` - unlike the axios instance they replace, where `AxiosInstance.get<T = any>` always defaulted.

This is the actual source of most `unknown`-propagation type errors surfacing across `kestra`/`kestra-ee` after the axios removal: dozens of call sites read `response.data` straight into loosely-typed locals without ever needing an explicit generic before, because axios already gave them `any`.

### How the changes have been QAed?

- `tsc --noEmit` + `npm run build`: clean.

### Setup Instructions

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RUCozmbCVE3Sw6GUdQCQTo)_