### PR TITLE
fix(javascript): export AxiosLikeConfig and AxiosLikeResponse

### DIFF
--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -27,7 +27,7 @@ function serializeQueryValue(val: unknown) {
     return val?.toString()
 }
 
-interface AxiosLikeConfig {
+export interface AxiosLikeConfig {
     params?: Record<string, unknown>
     headers?: Record<string, string>
     responseType?: "json" | "text" | "blob"
@@ -36,7 +36,7 @@ interface AxiosLikeConfig {
     [key: string]: any
 }
 
-interface AxiosLikeResponse<T = any> {
+export interface AxiosLikeResponse<T = any> {
     data: T
     status: number
     headers: Record<string, string>


### PR DESCRIPTION
### What changes are being made and why?

Follow-up to #342/#343. `AxiosLikeConfig` and `AxiosLikeResponse` were internal (unexported) types. Any consumer function whose return type is inferred from `useClient()`'s `get`/`post`/`put`/`patch`/`delete` - directly, or indirectly through something like a Pinia store action - fails typechecking as soon as that function is itself exported:

```
error TS4023: Exported variable 'useFooStore' has or is using name 'AxiosLikeResponse' from external module ".../@kestra-io/kestra-sdk/dist/index" but cannot be named.
```

This has shown up repeatedly across `kestra`/`kestra-ee` call sites migrated off axios, forcing each one to either unwrap to `.data`, add an explicit `Promise<any>` return-type annotation, or hand-roll a structurally-identical local `RawHttpResponse<T>` stand-in just to give TS something nameable. Exporting both types lets consumers reference the real type directly and removes the need for any of those workarounds.

### How the changes have been QAed?

- `tsc --noEmit`: clean.
- `tsdown` build: `AxiosLikeConfig`/`AxiosLikeResponse` now appear in the built `dist/index.d.ts`'s export list.
- Existing `useClientErrorHandling.spec.ts` / `useClientInterceptors.spec.ts`: pass.
- Verified against `kestra-ee`: overlaid the locally-built SDK into `ui-ee`'s `node_modules`, removed the local `RawHttpResponse<T>` stand-ins and explicit `Promise<any>` annotations from `stores/assets.ts` and `override/stores/auth.ts`, and `npm run check:types` (which also typechecks the OSS `ui` workspace) stayed fully clean with plain inferred return types.

### Setup Instructions

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RUCozmbCVE3Sw6GUdQCQTo)_