### PR TITLE
docs(agents): notify on suspicious signature/BC changes without blocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Tests require a running Kestra instance at `http://localhost:9903` with credenti
 
 ## Signature Changes — Notify, Don't Block
 
-Java, and now parts of Python (`executions_api.py`), are **hand-written**, not generated — a manual rewrite can silently drop a parameter with no generator to catch it. This already happened to `resumeExecution`'s `inputs` param in Java, and independently to `create_execution` / `resume_execution` / `replay_execution_with_inputs` in Python.
+Java, Python and Go are **hand-written**, not generated — a manual rewrite can silently drop a parameter with no generator to catch it. This already happened to `resumeExecution`'s `inputs` param in Java, and independently to `create_execution` / `resume_execution` / `replay_execution_with_inputs` in Python.
 
 When touching a hand-written or generated API class, for every public method you change:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,15 @@ Tests require a running Kestra instance at `http://localhost:9903` with credenti
 ./generate-sdks.sh python       # Python only
 ./generate-sdks.sh go           # Go only
 ```
+
+## Signature Changes — Notify, Don't Block
+
+Java, and now parts of Python (`executions_api.py`), are **hand-written**, not generated — a manual rewrite can silently drop a parameter with no generator to catch it. This already happened to `resumeExecution`'s `inputs` param in Java, and independently to `create_execution` / `resume_execution` / `replay_execution_with_inputs` in Python.
+
+When touching a hand-written or generated API class, for every public method you change:
+
+1. Diff the method's previous signature (params, types, arity) against the new one.
+2. If it changed, add a line to the PR description under a `### ⚠️ Signature change` heading: `old signature → new signature`.
+3. **Never block the change or revert it just because a signature changed** — a deliberate change is fine. The note exists so the reviewer and downstream SDK consumers (e.g. plugin-kestra) can catch an *unintended* drop before merge, not to gate the PR.
+
+Unit tests alone won't catch this — they only fail if a test explicitly exercises the changed parameter. Plugin repos consuming this SDK run an analogous non-blocking check on their side (`kestra-plugin-developer` in `engineering-ai-hub`); a note here lets them catch a break sooner too.


### PR DESCRIPTION
## Summary

- AGENTS.md now instructs contributors to diff and note public-method signature changes on hand-written/generated API classes (`### ⚠️ Signature change`, old → new) in the PR description — non-blocking, doesn't gate deliberate changes.

Context: `resumeExecution`'s `inputs` param was silently dropped during a hand-written Java rewrite (unit tests stayed green since nothing exercised it), then propagated to plugin-kestra on its next SDK bump. Companion check added to plugin repos in kestra-io/engineering-ai-hub#85. See https://kestra-io.slack.com/archives/C08LERML509/p1784281489868259.

## Test plan

- [ ] Docs-only change, no build/test impact