### PR TITLE
fix: bring back inputs for resumeExecution method (cherry pick for 1.3)

### DIFF
--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -15,16 +15,28 @@ runs:
       run: |
         resolve_version() {
           local branch_version="$1"
-          if [[ "${branch_version}" == *.x ]]; then
-            local prefix="${branch_version%.x}"
-            curl -s "https://api.github.com/repos/kestra-io/kestra/releases?per_page=100" \
-              | grep '"tag_name"' \
-              | grep "\"${prefix}\." \
-              | head -1 \
-              | sed 's/.*"tag_name": "\(.*\)".*/\1/'
-          else
+          if [[ "${branch_version}" != *.x ]]; then
             echo "${branch_version}"
+            return
           fi
+          # Cap the resolved Kestra version to this branch's major.minor line
+          # (e.g. releases/v1.3.x -> v1.3). This is a hard ceiling: we always
+          # pick the newest v1.3.x patch but never v1.4/v2.0, so cutting a 2.0
+          # release upstream cannot silently move this branch off 1.3.
+          local prefix="${branch_version%.x}"     # v1.3.x -> v1.3
+          local prefix_re="${prefix//./\\.}"       # v1.3   -> v1\.3
+          local resolved
+          resolved=$(curl -s "https://api.github.com/repos/kestra-io/kestra/releases?per_page=100" \
+            | grep '"tag_name"' \
+            | sed 's/.*"tag_name": "\(.*\)".*/\1/' \
+            | grep -E "^${prefix_re}\.[0-9]+$" \
+            | sort -V \
+            | tail -1)
+          if [[ -z "${resolved}" ]]; then
+            echo "::error::compute-version: no ${prefix}.x release found in the latest 100 Kestra releases; bump per_page or the branch line" >&2
+            exit 1
+          fi
+          echo "${resolved}"
         }
         if [[ "${GITHUB_REF_NAME}" == releases/* ]]; then
           echo "kestra_version=$(resolve_version "${GITHUB_REF_NAME#releases/}")" >> $GITHUB_OUTPUT

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BindingsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BindingsApiTest.java
@@ -25,10 +25,12 @@ public class BindingsApiTest {
     }
 
     static IAMRoleControllerApiRoleDetail createTestRole() throws ApiException {
+        // Kestra requires a role to have at least one permission.
         IAMRoleControllerApiRoleCreateOrUpdateRequest req = new IAMRoleControllerApiRoleCreateOrUpdateRequest()
                 .name("binding-role-" + randomId())
                 .description("Role for binding tests")
-                .permissions(new IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions());
+                .permissions(new IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions()
+                        .FLOW(List.of("CREATE", "READ")));
         return rolesApi().createRole(TENANT, req);
     }
 

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ExecutionsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ExecutionsApiTest.java
@@ -621,7 +621,6 @@ public class ExecutionsApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: returns 404 'Requested Flow is not found' — execution action now requires the source flow to exist")
     void resumeExecution_withInputs() throws ApiException {
         String ns = randomId();
         String flowId = randomId();

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ExecutionsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ExecutionsApiTest.java
@@ -635,11 +635,16 @@ public class ExecutionsApiTest {
             return state == StateType.PAUSED;
         });
 
-        // onResume declares a required input, so resume succeeds only if inputs are forwarded
-        Execution resumed = api().resumeExecution(executionId, TENANT, Map.of("quorum_status", "TIMEOUT"));
+        // onResume declares a required input, so resume succeeds only if inputs are forwarded.
+        // Kestra 1.3 answers resume with 204 (no body), so a non-throwing call already proves the
+        // required input was accepted; confirm the execution actually left the PAUSED state.
+        api().resumeExecution(executionId, TENANT, Map.of("quorum_status", "TIMEOUT"));
 
-        assertThat(resumed).isNotNull();
-        assertThat(resumed.getId()).isEqualTo(executionId);
+        await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS).until(() -> {
+            ApiExecution exec = api().execution(executionId, TENANT);
+            StateType state = exec.getState() != null ? exec.getState().getCurrent() : null;
+            return state != null && state != StateType.PAUSED;
+        });
     }
 
     @Test

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ExecutionsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/ExecutionsApiTest.java
@@ -59,6 +59,20 @@ public class ExecutionsApiTest {
                 """.formatted(id, ns);
     }
 
+    static String pauseWithInputsFlowYaml(String id, String ns) {
+        return """
+                id: %s
+                namespace: %s
+                tasks:
+                  - id: pause
+                    type: io.kestra.plugin.core.flow.Pause
+                    onResume:
+                      - id: quorum_status
+                        type: STRING
+                        required: true
+                """.formatted(id, ns);
+    }
+
     static String webhookFlowYaml(String id, String ns, String key) {
         return """
                 id: %s
@@ -602,6 +616,29 @@ public class ExecutionsApiTest {
 
         // Resume
         Execution resumed = api().resumeExecution(executionId, TENANT);
+        assertThat(resumed).isNotNull();
+        assertThat(resumed.getId()).isEqualTo(executionId);
+    }
+
+    @Test
+    @Disabled("Kestra 2.0: returns 404 'Requested Flow is not found' — execution action now requires the source flow to exist")
+    void resumeExecution_withInputs() throws ApiException {
+        String ns = randomId();
+        String flowId = randomId();
+        createFlow(pauseWithInputsFlowYaml(flowId, ns));
+
+        ExecutionControllerExecutionResponse resp = executeFlow(ns, flowId);
+        String executionId = resp.getId();
+
+        await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS).until(() -> {
+            ApiExecution exec = api().execution(executionId, TENANT);
+            StateType state = exec.getState() != null ? exec.getState().getCurrent() : null;
+            return state == StateType.PAUSED;
+        });
+
+        // onResume declares a required input, so resume succeeds only if inputs are forwarded
+        Execution resumed = api().resumeExecution(executionId, TENANT, Map.of("quorum_status", "TIMEOUT"));
+
         assertThat(resumed).isNotNull();
         assertThat(resumed.getId()).isEqualTo(executionId);
     }

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/RolesApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/RolesApiTest.java
@@ -17,10 +17,12 @@ public class RolesApiTest {
     }
 
     static IAMRoleControllerApiRoleDetail createTestRole(String name) throws ApiException {
+        // Kestra requires a role to have at least one permission.
         IAMRoleControllerApiRoleCreateOrUpdateRequest request = new IAMRoleControllerApiRoleCreateOrUpdateRequest()
                 .name(name)
                 .description("Test role: " + name)
-                .permissions(new IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions());
+                .permissions(new IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions()
+                        .FLOW(List.of("CREATE", "READ")));
         return api().createRole(TENANT, request);
     }
 
@@ -65,7 +67,8 @@ public class RolesApiTest {
         IAMRoleControllerApiRoleCreateOrUpdateRequest update = new IAMRoleControllerApiRoleCreateOrUpdateRequest()
                 .name(newName)
                 .description("Updated description")
-                .permissions(new IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions());
+                .permissions(new IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions()
+                        .FLOW(List.of("CREATE", "READ")));
 
         IAMRoleControllerApiRoleDetail updated = api().updateRole(created.getId(), TENANT, update);
 

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/ExecutionsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/ExecutionsApi.java
@@ -35,7 +35,9 @@ import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ExecutionsApi extends BaseApi {
 
@@ -342,10 +344,18 @@ public class ExecutionsApi extends BaseApi {
     public Execution resumeExecution(
             @jakarta.annotation.Nonnull String executionId,
             @jakarta.annotation.Nonnull String tenant) throws ApiException {
+        return resumeExecution(executionId, tenant, null);
+    }
+
+    public Execution resumeExecution(
+            @jakarta.annotation.Nonnull String executionId,
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nullable Map<String, Object> inputs) throws ApiException {
         return invoke("POST",
                 tenantPath(tenant, "executions", executionId, "resume"),
                 null, null, null,
                 JSON, MULTIPART,
+                inputs != null ? inputs : new HashMap<>(),
                 new TypeReference<>() {});
     }
 

--- a/java/java-sdk/src/main/java/io/kestra/sdk/model/IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/model/IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions.java
@@ -56,6 +56,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions.JSON_PROPERTY_U_N_K_N_O_W_N
 })
 @JsonTypeName("IAMRoleController_ApiRoleCreateOrUpdateRequest_permissions")
+// Kestra rejects a role whose permissions map carries unknown/non-assignable
+// keys, so never serialize empty permission arrays (an unset permission).
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions {
   public static final String JSON_PROPERTY_F_L_O_W = "FLOW";


### PR DESCRIPTION
Follow up of https://github.com/kestra-io/client-sdk/pull/345

Also used this PR to:
- fix build because of Kestra update from 1.3.26 to 1.3.28
- cap Kestra version to 1.3.x so it won't fetch Kestra 2.0