### PR TITLE
fix(javascript): send application/x-yaml Content-Type for YAML-source request bodies

### DIFF
--- a/javascript/javascript-sdk/heyapi-sdk-plugin/index.ts
+++ b/javascript/javascript-sdk/heyapi-sdk-plugin/index.ts
@@ -1,2 +1,3 @@
 export { defineConfigKestraHeyOptionalTenant } from "./config";
+export { fixYamlSourceRequestBodyContentType } from "./patch";
 export type { KestraSdkPlugin } from "./types";

--- a/javascript/javascript-sdk/heyapi-sdk-plugin/patch.ts
+++ b/javascript/javascript-sdk/heyapi-sdk-plugin/patch.ts
@@ -1,22 +1,6 @@
 /**
- * `parser.patch.operations` callback that forces the generator to emit
- * `Content-Type: application/x-yaml` for YAML-source request bodies.
- *
- * Some endpoints (e.g. `PUT .../reusable-inputs/{id}`) accept a raw YAML document and declare
- * `application/x-yaml`, `text/plain` AND `application/json` request-body variants, all with a
- * plain `type: string` schema. hey-api resolves a request body to the JSON variant whenever one
- * is declared (`contents.find(json) || contents[0]` in its requestBody parser), so the generated
- * operation hardcodes `Content-Type: application/json` and the server fails to deserialize the
- * raw YAML string (HTTP 500 — kestra-io/client-sdk#340).
- *
- * For these string-schema YAML bodies, drop the `application/json` variant and reorder the
- * remaining content so `application/x-yaml` comes first — the parser then resolves the body to
- * the YAML variant regardless of spec ordering, and both `sdk.gen.ts` operations and the
- * generated wrappers send the correct content type.
- *
- * Bodies whose JSON variant carries a structured (non-string) schema (e.g. `validateTask`,
- * whose variants are all `type: object`) are left untouched: JSON is a legitimate
- * representation there and the SDK serializes those bodies as JSON objects.
+ * hey-api prefers a declared `application/json` request-body variant, mislabeling raw YAML source bodies (#340).
+ * For string-schema YAML bodies, drop the JSON variant and put `application/x-yaml` first so the parser picks it.
  */
 const YAML_MEDIA_TYPE = "application/x-yaml";
 const JSON_MEDIA_TYPE = "application/json";

--- a/javascript/javascript-sdk/heyapi-sdk-plugin/patch.ts
+++ b/javascript/javascript-sdk/heyapi-sdk-plugin/patch.ts
@@ -1,0 +1,45 @@
+/**
+ * `parser.patch.operations` callback that forces the generator to emit
+ * `Content-Type: application/x-yaml` for YAML-source request bodies.
+ *
+ * Some endpoints (e.g. `PUT .../reusable-inputs/{id}`) accept a raw YAML document and declare
+ * `application/x-yaml`, `text/plain` AND `application/json` request-body variants, all with a
+ * plain `type: string` schema. hey-api resolves a request body to the JSON variant whenever one
+ * is declared (`contents.find(json) || contents[0]` in its requestBody parser), so the generated
+ * operation hardcodes `Content-Type: application/json` and the server fails to deserialize the
+ * raw YAML string (HTTP 500 — kestra-io/client-sdk#340).
+ *
+ * For these string-schema YAML bodies, drop the `application/json` variant and reorder the
+ * remaining content so `application/x-yaml` comes first — the parser then resolves the body to
+ * the YAML variant regardless of spec ordering, and both `sdk.gen.ts` operations and the
+ * generated wrappers send the correct content type.
+ *
+ * Bodies whose JSON variant carries a structured (non-string) schema (e.g. `validateTask`,
+ * whose variants are all `type: object`) are left untouched: JSON is a legitimate
+ * representation there and the SDK serializes those bodies as JSON objects.
+ */
+const YAML_MEDIA_TYPE = "application/x-yaml";
+const JSON_MEDIA_TYPE = "application/json";
+
+function isPlainString(schema: any): boolean {
+    return !!schema && schema.type === "string" && schema.format !== "binary";
+}
+
+export function fixYamlSourceRequestBodyContentType(method: string, path: string, operation: any): void {
+    const requestBody = operation?.requestBody;
+    const content = requestBody?.content;
+    if (!content || typeof content !== "object") return;
+
+    if (!isPlainString(content[YAML_MEDIA_TYPE]?.schema)) return;
+    if (!isPlainString(content[JSON_MEDIA_TYPE]?.schema)) return;
+
+    delete content[JSON_MEDIA_TYPE];
+
+    const reordered: Record<string, unknown> = { [YAML_MEDIA_TYPE]: content[YAML_MEDIA_TYPE] };
+    for (const [mediaType, value] of Object.entries(content)) {
+        if (mediaType !== YAML_MEDIA_TYPE) reordered[mediaType] = value;
+    }
+    requestBody.content = reordered;
+
+    console.debug(`fixYamlSourceRequestBodyContentType: ${method.toUpperCase()} ${path} (${operation.operationId}) now prefers ${YAML_MEDIA_TYPE}`);
+}

--- a/javascript/javascript-sdk/openapi-ts.config.ts
+++ b/javascript/javascript-sdk/openapi-ts.config.ts
@@ -1,7 +1,7 @@
 import type { UserConfig } from "@hey-api/openapi-ts";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import { defineConfigKestraHeyOptionalTenant } from "./heyapi-sdk-plugin";
+import { defineConfigKestraHeyOptionalTenant, fixYamlSourceRequestBodyContentType } from "./heyapi-sdk-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,6 +17,13 @@ const generateHash = (str: string) => {
 
 export default {
     input: path.resolve(__dirname, "../../kestra-ee.sanitized.yml"),
+    parser: {
+        patch: {
+            // hey-api prefers the application/json variant when resolving a request
+            // body; force application/x-yaml for YAML-source bodies (issue #340).
+            operations: fixYamlSourceRequestBodyContentType,
+        },
+    },
     output: {
         path: path.resolve(__dirname, "./src/openapi"),
         postProcess: [


### PR DESCRIPTION
Closes #340.

- **Root cause:** hey-api resolves a request body to the `application/json` variant whenever one is declared, so `ReusableInputs.createOrUpdate` — whose spec declares `application/x-yaml`, `text/plain` and a string-schema `application/json` (mirroring the controller's `@Consumes`) — was generated with a hardcoded `Content-Type: application/json`, and the server rejected the raw YAML body with HTTP 500.
- **Fix:** a `parser.patch.operations` callback (`heyapi-sdk-plugin/patch.ts`, wired in `openapi-ts.config.ts`) drops the JSON variant and puts `application/x-yaml` first for request bodies whose YAML and JSON variants are both plain strings — so `sdk.gen.ts` and the wrappers emit `Content-Type: application/x-yaml`; structured-schema bodies like `validateTask` (all `type: object`) are untouched, and the shared `kestra-ee.sanitized.yml` used by the Go generator is not modified.
- **QA:** regenerated the SDK (exactly one operation affected), `npm run check:types` passes, and a mocked-`fetch` run confirms `createOrUpdate` now sends raw YAML as `application/x-yaml`, `createFlow`/`validateTask` are unchanged, and caller-supplied `Content-Type` overrides still win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bZdkgLe3pk2cpmUguLG2Y