### PR TITLE
test(javascript): address PR #339 review comments on Plugins/ReusableInputs

### DIFF
--- a/javascript/test_javascript_sdk/PluginsApi.spec.ts
+++ b/javascript/test_javascript_sdk/PluginsApi.spec.ts
@@ -59,7 +59,7 @@ describe('PluginsApi', () => {
     });
 
     it('propertiesFromType: returns the JSON-schema properties for a type', async () => {
-        const result = await kestraClient.Plugins.propertiesFromType({ type: 'TASK' });
+        const result = await Plugins.propertiesFromType({ type: 'TASK' });
         // A JSON Schema document: a `$schema` dialect marker plus the
         // `properties`/`required` describing every task property.
         expect(result).toMatchObject({ $schema: expect.stringContaining('json-schema.org') });
@@ -67,7 +67,7 @@ describe('PluginsApi', () => {
     });
 
     it('schemasFromType: returns the JSON schema for a type', async () => {
-        const result = await kestraClient.Plugins.schemasFromType({ type: 'FLOW' });
+        const result = await Plugins.schemasFromType({ type: 'FLOW' });
         // A JSON Schema document: a `$schema` dialect marker, a top-level `$ref`,
         // and the `definitions` it resolves into.
         expect(result).toMatchObject({ $schema: expect.stringContaining('json-schema.org') });
@@ -75,14 +75,14 @@ describe('PluginsApi', () => {
     });
 
     it('pluginIcon: returns the icon for a plugin class', async () => {
-        const result = await kestraClient.Plugins.pluginIcon({ cls: 'io.kestra.plugin.core.log.Log' });
+        const result = await Plugins.pluginIcon({ cls: 'io.kestra.plugin.core.log.Log' });
         // A core plugin always ships an icon, so the wrapped icon is non-null.
         expect(result.icon).toBeTruthy();
     });
 
     it('pluginVersions: lists the versions of a plugin class', async () => {
         const cls = 'io.kestra.plugin.core.log.Log';
-        const result = await kestraClient.Plugins.pluginVersions({ cls });
+        const result = await Plugins.pluginVersions({ cls });
         // The endpoint echoes the requested plugin class back in `type`.
         expect(result.type).toBe(cls);
     });
@@ -90,18 +90,18 @@ describe('PluginsApi', () => {
     it('pluginDocumentationFromVersion: gets documentation for a specific plugin version', async () => {
         const cls = 'io.kestra.plugin.core.log.Log';
         // Source a real version from pluginVersions rather than hard-coding one.
-        const { versions } = await kestraClient.Plugins.pluginVersions({ cls });
+        const { versions } = await Plugins.pluginVersions({ cls });
         const version = versions?.[0];
         // A semver-style version, optionally with a pre-release suffix (e.g. -SNAPSHOT).
         expect(version).toMatch(/^\d+\.\d+\.\d+/);
 
-        const result = await kestraClient.Plugins.pluginDocumentationFromVersion({ cls, version: version! });
+        const result = await Plugins.pluginDocumentationFromVersion({ cls, version: version! });
         // The rendered markdown documents the Log task.
         expect(result.markdown).toContain('Log');
     });
 
     it('pluginUiManifest: returns the UI manifest for the given tasks', async () => {
-        const result = await kestraClient.Plugins.pluginUiManifest({
+        const result = await Plugins.pluginUiManifest({
             body: [{ cls: 'io.kestra.plugin.core.log.Log' }],
         });
         // Shape is { manifest: { [key]: PluginUiModuleWithGroup[] } }. Core Log

--- a/javascript/test_javascript_sdk/QuotasApi.spec.ts
+++ b/javascript/test_javascript_sdk/QuotasApi.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { kestraClient, randomId } from './CommonTestSetup.js';
+import { randomId } from './_utils.js';
 import * as Quotas from '@kestra-io/kestra-sdk/quotas';
+import * as TenantsAdmin from '@kestra-io/kestra-sdk/tenants-admin';
 import type { Tenant } from '@kestra-io/kestra-sdk';
 
 describe('QuotasApi', () => {
@@ -26,9 +27,9 @@ describe('QuotasApi', () => {
             deleted: false,
             quotas: [quota],
         };
-        await kestraClient.TenantsAdmin.create(tenant);
+        await TenantsAdmin.create(tenant);
 
-        const result = await kestraClient.TenantsAdmin.get({ id });
+        const result = await TenantsAdmin.get({ id });
         expect((result as any).quotas).toEqual([quota]);
     });
 });

--- a/javascript/test_javascript_sdk/ReusableInputsApi.spec.ts
+++ b/javascript/test_javascript_sdk/ReusableInputsApi.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import './CommonTestSetup.js';
+import { randomId } from './_utils.js';
 import * as ReusableInputs from '@kestra-io/kestra-sdk/reusable-inputs';
 
 describe('ReusableInputsApi', () => {
@@ -11,9 +11,28 @@ describe('ReusableInputsApi', () => {
         expect(Array.isArray(result)).toBe(true);
     });
 
-    // `createOrUpdate` (and `revisions`, which needs a block to exist) are not
-    // covered: the endpoint consumes application/x-yaml, but the generated SDK
-    // wrapper hardcodes Content-Type: application/json, so the YAML body is
-    // rejected (HTTP 500). Tracked in #340 — re-enable once the generator emits
-    // the correct content type for YAML request bodies.
+    it('createOrUpdate: creates reusable inputs from YAML source', async () => {
+        const namespace = randomId();
+        const id = randomId();
+        const body = `id: ${id}\nnamespace: ${namespace}\ninputs:\n  - id: in\n    type: STRING\n`;
+
+        const result = await ReusableInputs.createOrUpdate({ namespace, id, body });
+
+        expect(result.id).toBe(id);
+        expect(result.namespace).toBe(namespace);
+        expect(result.inputs).toEqual([expect.objectContaining({ id: 'in', type: 'STRING' })]);
+    });
+
+    it('revisions: lists revision history for reusable inputs', async () => {
+        const namespace = randomId();
+        const id = randomId();
+        const body = `id: ${id}\nnamespace: ${namespace}\ninputs:\n  - id: in\n    type: STRING\n`;
+        await ReusableInputs.createOrUpdate({ namespace, id, body });
+
+        const result = await ReusableInputs.revisions({ namespace, id });
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({ id, namespace });
+    });
 });

--- a/javascript/test_javascript_sdk/WorkerQueuesApi.spec.ts
+++ b/javascript/test_javascript_sdk/WorkerQueuesApi.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { randomId } from './CommonTestSetup.js';
+import { randomId } from './_utils.js';
 import * as WorkerQueues from '@kestra-io/kestra-sdk/worker-queues';
 import * as WorkerQueuesAdmin from '@kestra-io/kestra-sdk/worker-queues-admin';
 


### PR DESCRIPTION
## What

Addresses the two outstanding review threads on #339:

- **`PluginsApi.spec.ts`** ([comment](https://github.com/kestra-io/client-sdk/pull/339#discussion_r3614911537)): 6 test bodies still called `kestraClient.Plugins.*`, but the file only imports the `Plugins` namespace (no `kestraClient`) — a `ReferenceError` at runtime. Switched all 6 to call `Plugins.*` directly, as suggested.
- **`ReusableInputsApi.spec.ts`** ([comment](https://github.com/kestra-io/client-sdk/pull/339#discussion_r3614918353)): #340 (YAML-body endpoints sending `Content-Type: application/json`) is now fixed on `main` (#354), so the `createOrUpdate`/`revisions` tests are no longer blocked. Added real coverage: creating a reusable-inputs block from YAML source and asserting the echoed `id`/`namespace`/`inputs`, then listing its revision history.

## Also fixed

While regenerating the SDK and type-checking, found `QuotasApi.spec.ts` and `WorkerQueuesApi.spec.ts` still importing the now-deleted `./CommonTestSetup.js` (removed repo-wide by the per-API-import refactor in #353), which broke `tsc --noEmit` for the entire test suite. Updated both to the current `./_utils.js` / per-domain-import convention so the whole suite type-checks again.

## Test plan

- [x] `./generate-sdks.sh javascript` — regenerated SDK, confirms `ReusableInputs.createOrUpdate` now emits `Content-Type: application/x-yaml`
- [x] `npm run check:types` — passes clean
- [ ] `npm test` — requires a live Kestra instance (`localhost:9903`); not available in this sandbox, so integration tests could not be executed here. Please confirm in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QiQt7Wjvb8W6VTUfbU4XuR)_