### PR TITLE
fix(deps): point hey-api-plugin devDependency at its dedicated release repo

### DIFF
--- a/javascript/javascript-sdk/package.json
+++ b/javascript/javascript-sdk/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.99.0",
-    "@kestra-io/hey-api-plugin": "https://github.com/kestra-io/kestra/releases/download/hey-api-plugin-v0.1.0/kestra-io-hey-api-plugin-0.1.0.tgz",
+    "@kestra-io/hey-api-plugin": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.1.0/kestra-io-hey-api-plugin-0.1.0.tgz",
     "@types/node": "^25.9.1",
     "@types/nprogress": "^0.2.3",
     "tsdown": "^0.22.0",


### PR DESCRIPTION
### ✨ Description

Follow-up to #359. That PR pins `@kestra-io/hey-api-plugin` to a `kestra-io/kestra` release tarball URL (`hey-api-plugin-v0.1.0` tag). Dispatching the OSS *Release hey-api-plugin* workflow to actually produce that tag failed: `kestra-io/kestra`'s tag-creation ruleset only allows `vX.Y.Z` semver tags (matching real product releases), and its Releases page is watched by clients and the website for "latest release per branch" — so a non-semver `hey-api-plugin-v0.1.0` tag either violates the ruleset or would pollute that page.

Fix: publish the release to a new, dedicated repo — [kestra-io/hey-api-plugin](https://github.com/kestra-io/hey-api-plugin) — that exists solely to host these tarballs (the plugin source stays in `kestra-io/kestra` as the single source of truth; only the publish destination changed). See kestra-io/kestra#17590 for that workflow change. This PR just updates the devDependency URL here to match.

### 🔗 Related Issue

Depends on kestra-io/kestra#17590 landing and the *Release hey-api-plugin* workflow being re-dispatched from `kestra-io/kestra`'s `develop` before `npm install` here will actually resolve this URL.

### 🎨 Frontend Checklist

_N/A — no frontend, package.json only._

### 📝 Additional Notes

Based on top of #359's branch (`claude/js-ts-sdk-oss-ee`) so it merges together with it. Once kestra-io/kestra#17590 is merged and the release workflow successfully dispatched, `npm install` here will populate `package-lock.json` for the new URL.

### 🤖 AI Authors

The devDependency URL just moved apartments — same tarball, new address, no forwarding mail needed. 🐱


---
_Generated by [Claude Code](https://claude.ai/code/session_01TP4Ak86CNvR1k3PuyZoUPT)_