### PR TITLE
fix(javascript): poll for policy search results instead of asserting on a single read

### DIFF
--- a/javascript/test_javascript_sdk/PoliciesApi.spec.ts
+++ b/javascript/test_javascript_sdk/PoliciesApi.spec.ts
@@ -33,6 +33,28 @@ async function createTestNamespace() {
     return Namespaces.createNamespace({ id: nsId, deleted: false, tenant: tenantId });
 }
 
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Policy search reads from an index that's updated asynchronously after a create,
+// so a search issued immediately afterwards can miss a just-created policy. Poll
+// until it shows up (or give up after timeoutMs) instead of asserting on a single read.
+async function waitForPolicyInSearch(
+    search: () => Promise<{ results?: any[] } | undefined>,
+    id: string,
+    timeoutMs = 5000,
+    pollMs = 200,
+) {
+    const start = Date.now();
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const result = await search();
+        const results = result?.results ?? [];
+        if (results.some((p: any) => p.id === id)) return results;
+        if (Date.now() - start > timeoutMs) return results;
+        await sleep(pollMs);
+    }
+}
+
 describe('PoliciesApi (instance scope)', () => {
     it('createInstancePolicy + instancePolicy: creates and retrieves a policy', async () => {
         const id = `test-instance-policy-${randomId()}`;
@@ -48,8 +70,10 @@ describe('PoliciesApi (instance scope)', () => {
         const id = `test-search-instance-policy-${randomId()}`;
         await Policies.createInstancePolicy(policyRequest(id));
 
-        const result = await Policies.searchInstancePolicies({ page: 1, size: 100 });
-        const results = result?.results ?? [];
+        const results = await waitForPolicyInSearch(
+            () => Policies.searchInstancePolicies({ page: 1, size: 100 }),
+            id,
+        );
         expect(results.some((p: any) => p.id === id)).toBeTruthy();
     });
 
@@ -106,8 +130,10 @@ describe('PoliciesApi (namespace scope)', () => {
         const id = `test-search-namespace-policy-${randomId()}`;
         await Policies.createNamespacePolicy({ ...policyRequest(id), namespace: ns.id });
 
-        const result = await Policies.searchNamespacePolicies({ namespace: ns.id, page: 1, size: 100 });
-        const results = result?.results ?? [];
+        const results = await waitForPolicyInSearch(
+            () => Policies.searchNamespacePolicies({ namespace: ns.id, page: 1, size: 100 }),
+            id,
+        );
         expect(results.some((p: any) => p.id === id)).toBeTruthy();
     });
 
@@ -175,8 +201,10 @@ describe('PoliciesApi (tenant scope)', () => {
         const id = `test-search-policies-${randomId()}`;
         await Policies.createTenantPolicy(policyRequest(id));
 
-        const result = await Policies.searchPolicies({ page: 1, size: 100 });
-        const results = result?.results ?? [];
+        const results = await waitForPolicyInSearch(
+            () => Policies.searchPolicies({ page: 1, size: 100 }),
+            id,
+        );
         expect(results.some((p: any) => p.id === id)).toBeTruthy();
     });
 


### PR DESCRIPTION
## Summary

Fixes the CI failure on `main` in [this run](https://github.com/kestra-io/client-sdk/actions/runs/30014398045/job/89230468688):

```
FAIL test_javascript_sdk/PoliciesApi.spec.ts > PoliciesApi (namespace scope) > searchNamespacePolicies: resolves the scope chain for a namespace
AssertionError: expected false to be truthy
```

The test creates a namespace-scoped policy and immediately searches for it. Policy search reads from an index that's updated asynchronously after a create, so a search issued right after a create can race the index update and miss it. This is why all 4 attempts failed (vitest's global `retry: 3` immediately retries with no delay between attempts, so it never gave the index time to catch up), while `searchInstancePolicies`/`searchPolicies` — same pattern — happened to pass in this run.

This suite already has a precedent for this exact class of flake: `ExecutionsApi.spec.ts` sleeps/polls after creating a flow before relying on it elsewhere. This PR applies the same poll-until-found approach to `PoliciesApi.spec.ts`'s three create-then-search assertions (instance/namespace/tenant scope), replacing the single-shot read with a bounded poll (5s timeout, 200ms interval).

## Test plan

- [x] `npm run check:types` passes
- [x] Ran `PoliciesApi.spec.ts` against a local Kestra instance — all 16 tests pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)