### PR TITLE
feat(js): detect EE-only routes via a generated registry, throw EnterpriseFeatureError on 404

### DIFF
--- a/README_JAVASCRIPT_SDK.md
+++ b/README_JAVASCRIPT_SDK.md
@@ -90,6 +90,13 @@ import * as WorkerAuthAPI           from "@kestra-io/kestra-sdk/worker-auth";
 import * as WorkerGroupsAPI         from "@kestra-io/kestra-sdk/worker-groups";
 ```
 
+### Enterprise-only routes
+
+A 404 on a route that only exists in Kestra EE throws `EnterpriseFeatureError`
+(feature unavailable on this server) or `SdkVersionMismatchError` (server is EE
+but doesn't have this route — likely an SDK/server version mismatch), both
+exported from `@kestra-io/kestra-sdk`.
+
 ### Example: a flow lifecycle
 
 Configure the client once (see [Configure the client](#configure-the-client)), pick a tenant, then

--- a/README_JAVASCRIPT_SDK.md
+++ b/README_JAVASCRIPT_SDK.md
@@ -97,6 +97,12 @@ A 404 on a route that only exists in Kestra EE throws `EnterpriseFeatureError`
 but doesn't have this route — likely an SDK/server version mismatch), both
 exported from `@kestra-io/kestra-sdk`.
 
+`EnterpriseFeatureError` carries `feature`, `docsUrl` and `contactSalesUrl` so
+you can render your own "upgrade to unlock X" message. The two URLs are
+UTM-tagged (`utm_source=sdk&utm_medium=referral&utm_campaign=ee-feature-error`,
+with the feature key in `utm_content`); strip the query string if you'd rather
+not pass it through.
+
 ### Example: a flow lifecycle
 
 Configure the client once (see [Configure the client](#configure-the-client)), pick a tenant, then

--- a/javascript/javascript-sdk/enterprise-only-routes-plugin.ts
+++ b/javascript/javascript-sdk/enterprise-only-routes-plugin.ts
@@ -1,0 +1,53 @@
+import { $, definePluginConfig, type DefinePlugin } from "@hey-api/openapi-ts"
+
+// Local (client-sdk-only) hey-api codegen plugin: reads the `x-kestra: {edition: ee}` vendor
+// extension that kestra-ee's update-openapi-spec.yml workflow stamps onto EE-only operations
+// before the merged spec reaches this repo, and bakes a route registry into the generated SDK.
+// Consumed by src/index.ts to build the `enterpriseFeature` config passed to
+// createConfigureClient (see @kestra-io/hey-api-plugin/runtime's EnterpriseFeatureError /
+// SdkVersionMismatchError).
+//
+// This lives here, not in @kestra-io/hey-api-plugin: only client-sdk (the one SDK spanning both
+// editions) needs to tell an EE-only route apart from a genuinely-missing resource — ui/ and
+// ui-ee/ each generate from their own locally-accurate spec and never hit this case.
+
+type UserConfig = { name: "enterprise-only-routes" }
+type EnterpriseOnlyRoutesPlugin = DefinePlugin<UserConfig>
+
+function kebabCase(tag: string): string {
+    return tag
+        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+        .replace(/[\s_]+/g, "-")
+        .toLowerCase()
+}
+
+const handler: EnterpriseOnlyRoutesPlugin["Handler"] = ({ plugin }) => {
+    const routes: Record<string, { feature: string }> = {}
+
+    plugin.forEach(
+        "operation",
+        ({ operation }: { operation: any }) => {
+            const extension = (operation as { "x-kestra"?: { edition?: string } })["x-kestra"]
+            if (extension?.edition !== "ee") return
+
+            const method = String(operation.method).toUpperCase()
+            const path = String(operation.path)
+            const feature = kebabCase(operation.tags?.[0] ?? "enterprise")
+            routes[`${method} ${path}`] = { feature }
+        },
+        { order: "declarations" },
+    )
+
+    const routesSymbol = plugin.symbol("ENTERPRISE_ONLY_ROUTES_JSON", {
+        getFilePath: () => "sdk/enterpriseOnlyRoutes",
+    })
+
+    plugin.node($.const(routesSymbol).export().assign($.literal(JSON.stringify(routes))))
+}
+
+export const defineEnterpriseOnlyRoutesPlugin = definePluginConfig({
+    config: {},
+    dependencies: [],
+    handler,
+    name: "enterprise-only-routes",
+})

--- a/javascript/javascript-sdk/enterprise-only-routes-plugin.ts
+++ b/javascript/javascript-sdk/enterprise-only-routes-plugin.ts
@@ -1,15 +1,7 @@
 import { $, definePluginConfig, type DefinePlugin } from "@hey-api/openapi-ts"
 
-// Local (client-sdk-only) hey-api codegen plugin: reads the `x-kestra: {edition: ee}` vendor
-// extension that kestra-ee's update-openapi-spec.yml workflow stamps onto EE-only operations
-// before the merged spec reaches this repo, and bakes a route registry into the generated SDK.
-// Consumed by src/index.ts to build the `enterpriseFeature` config passed to
-// createConfigureClient (see @kestra-io/hey-api-plugin/runtime's EnterpriseFeatureError /
-// SdkVersionMismatchError).
-//
-// This lives here, not in @kestra-io/hey-api-plugin: only client-sdk (the one SDK spanning both
-// editions) needs to tell an EE-only route apart from a genuinely-missing resource — ui/ and
-// ui-ee/ each generate from their own locally-accurate spec and never hit this case.
+// Local (client-sdk-only): reads the `x-kestra: {edition: ee}` tag off each operation and bakes a
+// route registry into the generated SDK, consumed by src/index.ts's enterpriseFeature config.
 
 type UserConfig = { name: "enterprise-only-routes" }
 type EnterpriseOnlyRoutesPlugin = DefinePlugin<UserConfig>

--- a/javascript/javascript-sdk/enterprise-only-routes-plugin.ts
+++ b/javascript/javascript-sdk/enterprise-only-routes-plugin.ts
@@ -18,8 +18,8 @@ const handler: EnterpriseOnlyRoutesPlugin["Handler"] = ({ plugin }) => {
 
     plugin.forEach(
         "operation",
-        ({ operation }: { operation: any }) => {
-            const extension = (operation as { "x-kestra"?: { edition?: string } })["x-kestra"]
+        ({ operation }) => {
+            const extension = (operation as unknown as { "x-kestra"?: { edition?: string } })["x-kestra"]
             if (extension?.edition !== "ee") return
 
             const method = String(operation.method).toUpperCase()
@@ -29,6 +29,12 @@ const handler: EnterpriseOnlyRoutesPlugin["Handler"] = ({ plugin }) => {
         },
         { order: "declarations" },
     )
+
+    // Cheap guard against silent drift: if the x-kestra tag is ever renamed or dropped upstream,
+    // generation would otherwise succeed with an empty registry and no signal that anything broke.
+    if (Object.keys(routes).length === 0) {
+        console.warn("[enterprise-only-routes-plugin] Collected zero EE-only routes from the spec — check the x-kestra tag is still present.")
+    }
 
     const routesSymbol = plugin.symbol("ENTERPRISE_ONLY_ROUTES_JSON", {
         getFilePath: () => "sdk/enterpriseOnlyRoutes",

--- a/javascript/javascript-sdk/openapi-ts.config.ts
+++ b/javascript/javascript-sdk/openapi-ts.config.ts
@@ -2,6 +2,7 @@ import type { UserConfig } from "@hey-api/openapi-ts";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { defineConfigKestraHeyOptionalTenant, fixYamlSourceRequestBodyContentType } from "@kestra-io/hey-api-plugin";
+import { defineEnterpriseOnlyRoutesPlugin } from "./enterprise-only-routes-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,6 +49,7 @@ export default {
                 },
             }
         },
-        defineConfigKestraHeyOptionalTenant()
+        defineConfigKestraHeyOptionalTenant(),
+        defineEnterpriseOnlyRoutesPlugin(),
     ],
 } satisfies UserConfig

--- a/javascript/javascript-sdk/package.json
+++ b/javascript/javascript-sdk/package.json
@@ -23,6 +23,7 @@
     "./cluster": "./dist/cluster.js",
     "./dashboards": "./dist/dashboards.js",
     "./dashboards-admin": "./dist/dashboards-admin.js",
+    "./enterprise-only-routes": "./dist/enterprise-only-routes.js",
     "./executions": "./dist/executions.js",
     "./expressions": "./dist/expressions.js",
     "./files": "./dist/files.js",
@@ -80,7 +81,7 @@
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.99.0",
-    "@kestra-io/hey-api-plugin": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.1.0/kestra-io-hey-api-plugin-0.1.0.tgz",
+    "@kestra-io/hey-api-plugin": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.2.0/kestra-io-hey-api-plugin-0.2.0.tgz",
     "@types/node": "^25.9.1",
     "@types/nprogress": "^0.2.3",
     "tsdown": "^0.22.0",
@@ -91,6 +92,6 @@
     "dist/**/*.d.ts"
   ],
   "inlinedDependencies": {
-    "@kestra-io/hey-api-plugin": "0.1.0"
+    "@kestra-io/hey-api-plugin": "0.2.0"
   }
 }

--- a/javascript/javascript-sdk/package.json
+++ b/javascript/javascript-sdk/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.99.0",
-    "@kestra-io/hey-api-plugin": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.2.0/kestra-io-hey-api-plugin-0.2.0.tgz",
+    "@kestra-io/hey-api-plugin": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.3.0/kestra-io-hey-api-plugin-0.3.0.tgz",
     "@types/node": "^25.9.1",
     "@types/nprogress": "^0.2.3",
     "tsdown": "^0.22.0",
@@ -92,6 +92,6 @@
     "dist/**/*.d.ts"
   ],
   "inlinedDependencies": {
-    "@kestra-io/hey-api-plugin": "0.2.0"
+    "@kestra-io/hey-api-plugin": "0.3.0"
   }
 }

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -1,9 +1,12 @@
 import { client } from "./openapi/client.gen"
 import { formDataBodySerializer } from "./openapi/client"
 import type { ResolvedRequestOptions } from "./openapi/client"
-import { createConfigureClient } from "@kestra-io/hey-api-plugin/runtime"
+import { createConfigureClient, EnterpriseFeatureError } from "@kestra-io/hey-api-plugin/runtime"
+import type { EnterpriseFeatureConfig } from "@kestra-io/hey-api-plugin/runtime"
+import { ENTERPRISE_ONLY_ROUTES_JSON } from "./openapi/sdk/enterpriseOnlyRoutes.gen"
 
 export * from "./openapi/index"
+export { EnterpriseFeatureError }
 
 declare global {
     interface Window {
@@ -141,7 +144,28 @@ const axiosLikeClient = {
     patch: <T = any>(url: string, data?: any, config?: AxiosLikeConfig) => axiosLikeRequest<T>("PATCH", url, data, config),
 } as const
 
-export const configureClient = createConfigureClient(client, formDataBodySerializer)
+// Route registry baked in at generation time from the EE spec's `x-kestra: {edition: ee}` tags
+// (see enterprise-only-routes-plugin.ts) — lets the shared error interceptor tell a 404 on an
+// EE-only route (e.g. listAuditLogs on an OSS server) apart from a genuinely-missing resource.
+const enterpriseOnlyRoutes: Record<string, { feature: string }> = JSON.parse(ENTERPRISE_ONLY_ROUTES_JSON)
+
+// docsUrl/contactSalesUrl are intentionally generic (not a per-feature marketing URL table) —
+// pending the real per-feature marketing links, a generic destination is more honest than a
+// guessed one.
+//
+// NOTE: matchRoute + 404 alone can misfire on a real EE server (a genuine not-found on an
+// EE-only route with a path param, or an SDK/server version mismatch) — see kestra's
+// ErrorController/EditionHeaderFilter (X-Kestra-Entity / X-Kestra-Edition response headers) and
+// @kestra-io/hey-api-plugin's runtime.ts, which reads them to disambiguate. That header-reading
+// logic ships in @kestra-io/hey-api-plugin >= 0.3.0 (not yet released as of this pin at 0.2.0) —
+// re-pin the devDependency above once it is, no other change needed here.
+const enterpriseFeature: EnterpriseFeatureConfig = {
+    matchRoute: (method, path) => enterpriseOnlyRoutes[`${method} ${path}`],
+    docsUrl: (feature) => `https://kestra.io/docs/enterprise-edition/${feature}`,
+    contactSalesUrl: () => "https://kestra.io/demo",
+}
+
+export const configureClient = createConfigureClient(client, formDataBodySerializer, enterpriseFeature)
 
 /**
  * Set a mock client instance controlled in tests

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -144,21 +144,11 @@ const axiosLikeClient = {
     patch: <T = any>(url: string, data?: any, config?: AxiosLikeConfig) => axiosLikeRequest<T>("PATCH", url, data, config),
 } as const
 
-// Route registry baked in at generation time from the EE spec's `x-kestra: {edition: ee}` tags
-// (see enterprise-only-routes-plugin.ts) — lets the shared error interceptor tell a 404 on an
-// EE-only route (e.g. listAuditLogs on an OSS server) apart from a genuinely-missing resource.
+// Route registry baked in at generation time from the EE spec's x-kestra tags; see
+// enterprise-only-routes-plugin.ts. docsUrl/contactSalesUrl are generic pending real links.
 const enterpriseOnlyRoutes: Record<string, { feature: string }> = JSON.parse(ENTERPRISE_ONLY_ROUTES_JSON)
 
-// docsUrl/contactSalesUrl are intentionally generic (not a per-feature marketing URL table) —
-// pending the real per-feature marketing links, a generic destination is more honest than a
-// guessed one.
-//
-// NOTE: matchRoute + 404 alone can misfire on a real EE server (a genuine not-found on an
-// EE-only route with a path param, or an SDK/server version mismatch) — see kestra's
-// ErrorController/EditionHeaderFilter (X-Kestra-Entity / X-Kestra-Edition response headers) and
-// @kestra-io/hey-api-plugin's runtime.ts, which reads them to disambiguate. That header-reading
-// logic ships in @kestra-io/hey-api-plugin >= 0.3.0 (not yet released as of this pin at 0.2.0) —
-// re-pin the devDependency above once it is, no other change needed here.
+// TODO: re-pin @kestra-io/hey-api-plugin to >= 0.3.0 once released, for header-based disambiguation.
 const enterpriseFeature: EnterpriseFeatureConfig = {
     matchRoute: (method, path) => enterpriseOnlyRoutes[`${method} ${path}`],
     docsUrl: (feature) => `https://kestra.io/docs/enterprise-edition/${feature}`,

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -1,12 +1,12 @@
 import { client } from "./openapi/client.gen"
 import { formDataBodySerializer } from "./openapi/client"
 import type { ResolvedRequestOptions } from "./openapi/client"
-import { createConfigureClient, EnterpriseFeatureError } from "@kestra-io/hey-api-plugin/runtime"
+import { createConfigureClient, EnterpriseFeatureError, SdkVersionMismatchError } from "@kestra-io/hey-api-plugin/runtime"
 import type { EnterpriseFeatureConfig } from "@kestra-io/hey-api-plugin/runtime"
 import { ENTERPRISE_ONLY_ROUTES_JSON } from "./openapi/sdk/enterpriseOnlyRoutes.gen"
 
 export * from "./openapi/index"
-export { EnterpriseFeatureError }
+export { EnterpriseFeatureError, SdkVersionMismatchError }
 
 declare global {
     interface Window {
@@ -188,7 +188,6 @@ const featureToSlugMap: Record<string, string> = {
     "login": "/auth/authentication",
 }
 
-// TODO: re-pin @kestra-io/hey-api-plugin to >= 0.3.0 once released, for header-based disambiguation.
 const enterpriseFeature: EnterpriseFeatureConfig = {
     matchRoute: (method, path) => enterpriseOnlyRoutes[`${method} ${path}`],
     docsUrl: (feature) => `https://kestra.io/docs/enterprise${featureToSlugMap[feature] ?? ""}`,

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -145,13 +145,53 @@ const axiosLikeClient = {
 } as const
 
 // Route registry baked in at generation time from the EE spec's x-kestra tags; see
-// enterprise-only-routes-plugin.ts. docsUrl/contactSalesUrl are generic pending real links.
+// enterprise-only-routes-plugin.ts.
 const enterpriseOnlyRoutes: Record<string, { feature: string }> = JSON.parse(ENTERPRISE_ONLY_ROUTES_JSON)
+
+const featureToSlugMap: Record<string, string> = {
+    "audit-logs": "/governance/audit-logs",
+    "bindings": "/auth/rbac",
+    "auths": "/auth/authentication",
+    "banners": "/instance/announcements",
+    "cluster": "/instance/maintenance-mode",
+    "mcp": "",
+    "services": "",
+    "policies": "/governance",
+    "plugins": "/instance/versioned-plugins",
+    "worker-groups": "/scalability/worker-group",
+    "worker-queues": "",
+    "worker-auth": "/auth/credentials",
+    "kill-switches": "/instance/kill-switch",
+    "misc": "",
+    "invitations": "/auth/invitations",
+    "users": "/auth/rbac",
+    "notifications": "",
+    "service-account": "/auth/service-accounts",
+    "tenants": "/governance/tenants",
+    "ai": "",
+    "apps": "/scalability/apps",
+    "assets": "/governance/assets",
+    "blueprints": "/governance/custom-blueprints",
+    "blueprint-tags": "/governance/custom-blueprints",
+    "flows": "/governance",
+    "groups": "/auth/rbac",
+    "scim-groups": "/auth/scim",
+    "scim-configuration": "/auth/scim",
+    "scim-users": "/auth/scim",
+    "namespaces": "/governance/namespace-management",
+    "reusable-inputs": "",
+    "quotas": "",
+    "roles": "/auth/rbac",
+    "security-integrations": "/auth/sso",
+    "tenant-access": "/auth/rbac",
+    "test-suites": "/governance/unit-tests",
+    "login": "/auth/authentication",
+}
 
 // TODO: re-pin @kestra-io/hey-api-plugin to >= 0.3.0 once released, for header-based disambiguation.
 const enterpriseFeature: EnterpriseFeatureConfig = {
     matchRoute: (method, path) => enterpriseOnlyRoutes[`${method} ${path}`],
-    docsUrl: (feature) => `https://kestra.io/docs/enterprise-edition/${feature}`,
+    docsUrl: (feature) => `https://kestra.io/docs/enterprise${featureToSlugMap[feature] ?? ""}`,
     contactSalesUrl: () => "https://kestra.io/demo",
 }
 

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -189,10 +189,21 @@ export const featureToSlugMap: Record<string, string> = {
     "login": "/auth/authentication",
 }
 
+// Same UTM convention the app already uses on its own kestra.io links, with utm_source=sdk. An
+// EnterpriseFeatureError is the only thing we get to say to someone at the moment they hit an
+// Enterprise boundary, so the links are tagged to tell whether they lead anywhere. utm_content
+// carries the feature key, which is what keeps the features falling back to the bare
+// /docs/enterprise page distinguishable from one another.
+const UTM_CAMPAIGN = "utm_source=sdk&utm_medium=referral&utm_campaign=ee-feature-error"
+
+function withUtm(url: string, feature: string): string {
+    return `${url}?${UTM_CAMPAIGN}&utm_content=${encodeURIComponent(feature)}`
+}
+
 const enterpriseFeature: EnterpriseFeatureConfig = {
     matchRoute: (method, path) => enterpriseOnlyRoutes[`${method} ${path}`],
-    docsUrl: (feature) => `https://kestra.io/docs/enterprise${featureToSlugMap[feature] ?? ""}`,
-    contactSalesUrl: () => "https://kestra.io/demo",
+    docsUrl: (feature) => withUtm(`https://kestra.io/docs/enterprise${featureToSlugMap[feature] ?? ""}`, feature),
+    contactSalesUrl: (feature) => withUtm("https://kestra.io/demo", feature),
 }
 
 export const configureClient = createConfigureClient(client, formDataBodySerializer, enterpriseFeature)

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -148,7 +148,8 @@ const axiosLikeClient = {
 // enterprise-only-routes-plugin.ts.
 const enterpriseOnlyRoutes: Record<string, { feature: string }> = JSON.parse(ENTERPRISE_ONLY_ROUTES_JSON)
 
-const featureToSlugMap: Record<string, string> = {
+// Exported for the exhaustiveness test (registry features ⊆ this map's keys), not for consumer use.
+export const featureToSlugMap: Record<string, string> = {
     "audit-logs": "/governance/audit-logs",
     "bindings": "/auth/rbac",
     "auths": "/auth/authentication",

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.99.0",
-        "@kestra-io/hey-api-plugin": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.1.0/kestra-io-hey-api-plugin-0.1.0.tgz",
+        "@kestra-io/hey-api-plugin": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.2.0/kestra-io-hey-api-plugin-0.2.0.tgz",
         "@types/node": "^25.9.1",
         "@types/nprogress": "^0.2.3",
         "tsdown": "^0.22.0",
@@ -335,9 +335,9 @@
       "license": "MIT"
     },
     "node_modules/@kestra-io/hey-api-plugin": {
-      "version": "0.1.0",
-      "resolved": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.1.0/kestra-io-hey-api-plugin-0.1.0.tgz",
-      "integrity": "sha512-GiHFwEqONceFKT+aWIqLBKOhgsNnLCAZC01tDuVHwVtBvuNFgn7srPzeGNq+G3I0jYVgAW3AJTMsTrS6d2tpTQ==",
+      "version": "0.2.0",
+      "resolved": "https://github.com/kestra-io/hey-api-plugin/releases/download/v0.2.0/kestra-io-hey-api-plugin-0.2.0.tgz",
+      "integrity": "sha512-xpBz84NMNW9KYNhitTzwhsmgOLsuH9hJhuxCOa1lhgnDEBqkyxCCCXWwGTr6XY+/vQm+8G2lZt1iAHvDoMB56w==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/javascript/test_javascript_sdk/featureToSlugMap.spec.ts
+++ b/javascript/test_javascript_sdk/featureToSlugMap.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { featureToSlugMap } from "@kestra-io/kestra-sdk";
+import { ENTERPRISE_ONLY_ROUTES_JSON } from "@kestra-io/kestra-sdk/enterprise-only-routes";
+
+// Guards against the featureToSlugMap silently drifting out of sync with the generated registry.
+describe("featureToSlugMap exhaustiveness", () => {
+    it("has a key for every feature present in the generated EE-only route registry", () => {
+        const registry: Record<string, { feature: string }> = JSON.parse(ENTERPRISE_ONLY_ROUTES_JSON);
+        const registryFeatures = new Set(Object.values(registry).map(route => route.feature));
+
+        const missing = [...registryFeatures].filter(feature => !(feature in featureToSlugMap));
+
+        expect(missing).toEqual([]);
+    });
+});

--- a/javascript/test_javascript_sdk/useClientEnterpriseFeature.spec.ts
+++ b/javascript/test_javascript_sdk/useClientEnterpriseFeature.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { configureClient, EnterpriseFeatureError } from "@kestra-io/kestra-sdk";
+import { searchAuditLogsForAllTenants } from "@kestra-io/kestra-sdk/audit-logs";
+
+// Unit tests, no live backend needed: fetch is stubbed directly.
+//
+// searchAuditLogsForAllTenants calls "GET /api/v1/auditlogs/search", a real EE-only route from
+// the generated registry (see enterprise-only-routes-plugin.ts /
+// src/openapi/sdk/enterpriseOnlyRoutes.gen.ts) — unlike the axios-like useClient() facade, the
+// generated SDK functions pass the templated OpenAPI path that matchRoute needs.
+describe("EE-only-route 404 disambiguation", () => {
+    beforeEach(() => {
+        configureClient({ baseUrl: "http://localhost:8080" });
+    });
+
+    it("throws EnterpriseFeatureError for a 404 on a known EE-only route", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () =>
+            new Response(JSON.stringify({ message: "Not Found" }), {
+                status: 404,
+                headers: { "content-type": "application/json" },
+            })
+        ));
+
+        const error = await searchAuditLogsForAllTenants().catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(EnterpriseFeatureError);
+        expect((error as EnterpriseFeatureError).feature).toBe("audit-logs");
+
+        vi.unstubAllGlobals();
+    });
+});

--- a/javascript/test_javascript_sdk/useClientEnterpriseFeature.spec.ts
+++ b/javascript/test_javascript_sdk/useClientEnterpriseFeature.spec.ts
@@ -2,12 +2,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { configureClient, EnterpriseFeatureError } from "@kestra-io/kestra-sdk";
 import { searchAuditLogsForAllTenants } from "@kestra-io/kestra-sdk/audit-logs";
 
-// Unit tests, no live backend needed: fetch is stubbed directly.
-//
-// searchAuditLogsForAllTenants calls "GET /api/v1/auditlogs/search", a real EE-only route from
-// the generated registry (see enterprise-only-routes-plugin.ts /
-// src/openapi/sdk/enterpriseOnlyRoutes.gen.ts) — unlike the axios-like useClient() facade, the
-// generated SDK functions pass the templated OpenAPI path that matchRoute needs.
+// Unit test, no live backend needed: fetch is stubbed. Uses a real EE-only route
+// (GET /api/v1/auditlogs/search) via a generated SDK function so matchRoute gets a templated path.
 describe("EE-only-route 404 disambiguation", () => {
     beforeEach(() => {
         configureClient({ baseUrl: "http://localhost:8080" });

--- a/javascript/test_javascript_sdk/useClientEnterpriseFeature.spec.ts
+++ b/javascript/test_javascript_sdk/useClientEnterpriseFeature.spec.ts
@@ -1,12 +1,16 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { configureClient, EnterpriseFeatureError } from "@kestra-io/kestra-sdk";
 import { searchAuditLogsForAllTenants } from "@kestra-io/kestra-sdk/audit-logs";
+import { invitation } from "@kestra-io/kestra-sdk/invitations";
 
-// Unit test, no live backend needed: fetch is stubbed. Uses a real EE-only route
-// (GET /api/v1/auditlogs/search) via a generated SDK function so matchRoute gets a templated path.
+// Unit tests, no live backend needed: fetch is stubbed.
 describe("EE-only-route 404 disambiguation", () => {
     beforeEach(() => {
         configureClient({ baseUrl: "http://localhost:8080" });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
     });
 
     it("throws EnterpriseFeatureError for a 404 on a known EE-only route", async () => {
@@ -17,11 +21,26 @@ describe("EE-only-route 404 disambiguation", () => {
             })
         ));
 
+        // GET /api/v1/auditlogs/search has no path params - exercises the non-templated case.
         const error = await searchAuditLogsForAllTenants().catch((e: unknown) => e);
 
         expect(error).toBeInstanceOf(EnterpriseFeatureError);
         expect((error as EnterpriseFeatureError).feature).toBe("audit-logs");
+    });
 
-        vi.unstubAllGlobals();
+    it("throws EnterpriseFeatureError for a 404 on a templated {tenant}-scoped EE-only route", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () =>
+            new Response(JSON.stringify({ message: "Not Found" }), {
+                status: 404,
+                headers: { "content-type": "application/json" },
+            })
+        ));
+
+        // GET /api/v1/{tenant}/invitations/{id} has two path params - proves matchRoute still
+        // sees the templated path (not the resolved URL with real tenant/id values substituted in).
+        const error = await invitation({ id: "missing-id", tenant: "main" }).catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(EnterpriseFeatureError);
+        expect((error as EnterpriseFeatureError).feature).toBe("invitations");
     });
 });

--- a/javascript/test_javascript_sdk/useClientEnterpriseFeature.spec.ts
+++ b/javascript/test_javascript_sdk/useClientEnterpriseFeature.spec.ts
@@ -26,6 +26,14 @@ describe("EE-only-route 404 disambiguation", () => {
 
         expect(error).toBeInstanceOf(EnterpriseFeatureError);
         expect((error as EnterpriseFeatureError).feature).toBe("audit-logs");
+        // Links are UTM-tagged so growth can tell whether an Enterprise-boundary error leads
+        // anywhere, and utm_content keeps the features distinguishable.
+        expect((error as EnterpriseFeatureError).docsUrl).toBe(
+            "https://kestra.io/docs/enterprise/governance/audit-logs?utm_source=sdk&utm_medium=referral&utm_campaign=ee-feature-error&utm_content=audit-logs"
+        );
+        expect((error as EnterpriseFeatureError).contactSalesUrl).toBe(
+            "https://kestra.io/demo?utm_source=sdk&utm_medium=referral&utm_campaign=ee-feature-error&utm_content=audit-logs"
+        );
     });
 
     it("throws EnterpriseFeatureError for a 404 on a templated {tenant}-scoped EE-only route", async () => {
@@ -42,5 +50,8 @@ describe("EE-only-route 404 disambiguation", () => {
 
         expect(error).toBeInstanceOf(EnterpriseFeatureError);
         expect((error as EnterpriseFeatureError).feature).toBe("invitations");
+        expect((error as EnterpriseFeatureError).docsUrl).toBe(
+            "https://kestra.io/docs/enterprise/auth/invitations?utm_source=sdk&utm_medium=referral&utm_campaign=ee-feature-error&utm_content=invitations"
+        );
     });
 });


### PR DESCRIPTION
### What changes are being made and why?

Companion PR: kestra-io/kestra#17622 (edition + route-matched 404 headers, `SdkVersionMismatchError`), merged as `2d151f6` and released as `@kestra-io/hey-api-plugin@0.4.0`.

Replaces the abandoned `client-sdk#365`.

- New `enterprise-only-routes-plugin.ts`: local hey-api codegen plugin reading the `x-kestra: {edition: ee}` tag off each operation, baking a route registry into the generated SDK.
- `src/index.ts`: builds the `enterpriseFeature` config (with real per-feature docs slugs) and passes it to `createConfigureClient`, so a 404 on a known EE-only route throws `EnterpriseFeatureError`. Also re-exports `SdkVersionMismatchError`.
- Pins `@kestra-io/hey-api-plugin` to `0.4.0`, carrying the `X-Kestra-Route-Matched`/`X-Kestra-Edition` header disambiguation and `SdkVersionMismatchError`. The pin was written as `0.3.0` while that PR was open; `develop` shipped its own `0.3.0` in the meantime (kestra-io/kestra#19632), so the version moved up.
- `EnterpriseFeatureError`'s `docsUrl` and `contactSalesUrl` are UTM-tagged (`utm_source=sdk&utm_medium=referral&utm_campaign=ee-feature-error`, feature key in `utm_content`), following the same convention the app uses on its own kestra.io links.

Tests added: `useClientEnterpriseFeature.spec.ts`, `featureToSlugMap.spec.ts`. Verified after the `0.4.0` release: `npm install` resolves the pinned tarball, the full generation pipeline (customizer → `openapi-ts` → `tsdown` build) runs end to end against the real spec, and `check:types` is clean.