### PR TITLE
fix(javascript): align the Policies and Quotas specs with the YAML-source policy API

### DIFF
--- a/javascript/test_javascript_sdk/PoliciesApi.spec.ts
+++ b/javascript/test_javascript_sdk/PoliciesApi.spec.ts
@@ -5,27 +5,30 @@ import { tenantId } from './_setup.js';
 import * as Policies from '@kestra-io/kestra-sdk/policies';
 import * as Namespaces from '@kestra-io/kestra-sdk/namespaces';
 import * as Flows from '@kestra-io/kestra-sdk/flows';
-import type { PolicyRequest, Rule } from '@kestra-io/kestra-sdk';
 
+// Policies are created and updated from their YAML source (`application/x-yaml`): the API
+// parses it, stamps the scope/tenant/namespace from the URL and stores the source alongside
+// the parsed model, so the body is a plain string rather than a structured request object.
+//
 // `io.kestra.plugin.ee.rules.Require` is a built-in FLOW-scoped governance rule: it reports
 // a violation when the listed properties are missing from a flow after mutation.
-function requireTimeoutRule(): Rule {
-    return {
-        type: 'io.kestra.plugin.ee.rules.Require',
-        on: 'FLOW',
-        action: 'WARN',
-        errorMessage: 'timeout is required',
-        properties: ['timeout'],
-    } as Rule;
-}
-
-function policyRequest(id: string): PolicyRequest {
-    return {
+function policySource(id: string, overrides: Record<string, string> = {}): string {
+    const fields: Record<string, string> = {
         id,
         displayName: `Test policy ${id}`,
         enforcement: 'EVALUATE',
-        rules: [requireTimeoutRule()],
+        ...overrides,
     };
+    return [
+        ...Object.entries(fields).map(([key, value]) => `${key}: ${value}`),
+        'rules:',
+        '  - type: io.kestra.plugin.ee.rules.Require',
+        '    on: FLOW',
+        '    action: WARN',
+        '    errorMessage: timeout is required',
+        '    properties:',
+        '      - timeout',
+    ].join('\n') + '\n';
 }
 
 async function createTestNamespace() {
@@ -58,7 +61,7 @@ async function waitForPolicyInSearch(
 describe('PoliciesApi (instance scope)', () => {
     it('createInstancePolicy + instancePolicy: creates and retrieves a policy', async () => {
         const id = `test-instance-policy-${randomId()}`;
-        const created = await Policies.createInstancePolicy(policyRequest(id));
+        const created = await Policies.createInstancePolicy({ body: policySource(id) });
         expect(created.id).toBe(id);
 
         const fetched = await Policies.instancePolicy({ id });
@@ -68,7 +71,7 @@ describe('PoliciesApi (instance scope)', () => {
 
     it('searchInstancePolicies: finds a created policy', async () => {
         const id = `test-search-instance-policy-${randomId()}`;
-        await Policies.createInstancePolicy(policyRequest(id));
+        await Policies.createInstancePolicy({ body: policySource(id) });
 
         const results = await waitForPolicyInSearch(
             () => Policies.searchInstancePolicies({ page: 1, size: 100 }),
@@ -79,12 +82,14 @@ describe('PoliciesApi (instance scope)', () => {
 
     it('updateInstancePolicy: updates displayName and enforcement', async () => {
         const id = `test-update-instance-policy-${randomId()}`;
-        await Policies.createInstancePolicy(policyRequest(id));
+        await Policies.createInstancePolicy({ body: policySource(id) });
 
         const updated = await Policies.updateInstancePolicy({
-            ...policyRequest(id),
-            displayName: 'Updated display name',
-            enforcement: 'ACTIVE',
+            id,
+            body: policySource(id, {
+                displayName: 'Updated display name',
+                enforcement: 'ACTIVE',
+            }),
         });
 
         expect(updated.displayName).toBe('Updated display name');
@@ -93,7 +98,7 @@ describe('PoliciesApi (instance scope)', () => {
 
     it('evaluateInstancePolicy: dry-runs the policy against flows in scope', async () => {
         const id = `test-evaluate-instance-policy-${randomId()}`;
-        await Policies.createInstancePolicy(policyRequest(id));
+        await Policies.createInstancePolicy({ body: policySource(id) });
 
         const result = await Policies.evaluateInstancePolicy({ id, page: 1, size: 10 });
         expect(result).toBeDefined();
@@ -102,7 +107,7 @@ describe('PoliciesApi (instance scope)', () => {
 
     it('deleteInstancePoliciesByIds: removes a policy', async () => {
         const id = `test-delete-instance-policy-${randomId()}`;
-        await Policies.createInstancePolicy(policyRequest(id));
+        await Policies.createInstancePolicy({ body: policySource(id) });
 
         await Policies.deleteInstancePoliciesByIds({ body: [id] });
 
@@ -116,8 +121,8 @@ describe('PoliciesApi (namespace scope)', () => {
         const id = `test-namespace-policy-${randomId()}`;
 
         const created = await Policies.createNamespacePolicy({
-            ...policyRequest(id),
             namespace: ns.id,
+            body: policySource(id),
         });
         expect(created.id).toBe(id);
 
@@ -128,7 +133,7 @@ describe('PoliciesApi (namespace scope)', () => {
     it('searchNamespacePolicies: resolves the scope chain for a namespace', async () => {
         const ns = await createTestNamespace();
         const id = `test-search-namespace-policy-${randomId()}`;
-        await Policies.createNamespacePolicy({ ...policyRequest(id), namespace: ns.id });
+        await Policies.createNamespacePolicy({ namespace: ns.id, body: policySource(id) });
 
         const results = await waitForPolicyInSearch(
             () => Policies.searchNamespacePolicies({ namespace: ns.id, page: 1, size: 100 }),
@@ -140,12 +145,12 @@ describe('PoliciesApi (namespace scope)', () => {
     it('updateNamespacePolicy: updates the policy description', async () => {
         const ns = await createTestNamespace();
         const id = `test-update-namespace-policy-${randomId()}`;
-        await Policies.createNamespacePolicy({ ...policyRequest(id), namespace: ns.id });
+        await Policies.createNamespacePolicy({ namespace: ns.id, body: policySource(id) });
 
         const updated = await Policies.updateNamespacePolicy({
-            ...policyRequest(id),
             namespace: ns.id,
-            description: 'now requires a timeout',
+            id,
+            body: policySource(id, { description: 'now requires a timeout' }),
         });
         expect(updated.description).toBe('now requires a timeout');
     });
@@ -153,7 +158,7 @@ describe('PoliciesApi (namespace scope)', () => {
     it('evaluateNamespacePolicy: dry-runs the policy against flows in the namespace', async () => {
         const ns = await createTestNamespace();
         const id = `test-evaluate-namespace-policy-${randomId()}`;
-        await Policies.createNamespacePolicy({ ...policyRequest(id), namespace: ns.id });
+        await Policies.createNamespacePolicy({ namespace: ns.id, body: policySource(id) });
 
         const result = await Policies.evaluateNamespacePolicy({ namespace: ns.id, id, page: 1, size: 10 });
         expect(result).toBeDefined();
@@ -162,7 +167,7 @@ describe('PoliciesApi (namespace scope)', () => {
     it('deleteNamespacePolicy: removes a policy', async () => {
         const ns = await createTestNamespace();
         const id = `test-delete-namespace-policy-${randomId()}`;
-        await Policies.createNamespacePolicy({ ...policyRequest(id), namespace: ns.id });
+        await Policies.createNamespacePolicy({ namespace: ns.id, body: policySource(id) });
 
         await Policies.deleteNamespacePolicy({ namespace: ns.id, id });
 
@@ -173,9 +178,8 @@ describe('PoliciesApi (namespace scope)', () => {
         const ns = await createTestNamespace();
         const policyId = `test-preview-policy-${randomId()}`;
         await Policies.createNamespacePolicy({
-            ...policyRequest(policyId),
             namespace: ns.id,
-            enforcement: 'ACTIVE',
+            body: policySource(policyId, { enforcement: 'ACTIVE' }),
         });
 
         const { flowBody } = getSimpleFlowAndId();
@@ -190,7 +194,7 @@ describe('PoliciesApi (namespace scope)', () => {
 describe('PoliciesApi (tenant scope)', () => {
     it('createTenantPolicy + tenantPolicy: creates and retrieves a policy', async () => {
         const id = `test-tenant-policy-${randomId()}`;
-        const created = await Policies.createTenantPolicy(policyRequest(id));
+        const created = await Policies.createTenantPolicy({ body: policySource(id) });
         expect(created.id).toBe(id);
 
         const fetched = await Policies.tenantPolicy({ id });
@@ -199,7 +203,7 @@ describe('PoliciesApi (tenant scope)', () => {
 
     it('searchPolicies: finds a tenant-scope policy across scopes', async () => {
         const id = `test-search-policies-${randomId()}`;
-        await Policies.createTenantPolicy(policyRequest(id));
+        await Policies.createTenantPolicy({ body: policySource(id) });
 
         const results = await waitForPolicyInSearch(
             () => Policies.searchPolicies({ page: 1, size: 100 }),
@@ -210,7 +214,7 @@ describe('PoliciesApi (tenant scope)', () => {
 
     it('exportTenantPolicies: exports every tenant-scope policy as YAML', async () => {
         const id = `test-export-policy-${randomId()}`;
-        await Policies.createTenantPolicy(policyRequest(id));
+        await Policies.createTenantPolicy({ body: policySource(id) });
 
         const exported = await Policies.exportTenantPolicies();
         expect(typeof exported).toBe('string');
@@ -230,7 +234,7 @@ describe('PoliciesApi (tenant scope)', () => {
 
     it('deleteTenantPoliciesByIds: removes tenant-scope policies', async () => {
         const id = `test-delete-tenant-policy-${randomId()}`;
-        await Policies.createTenantPolicy(policyRequest(id));
+        await Policies.createTenantPolicy({ body: policySource(id) });
 
         await Policies.deleteTenantPoliciesByIds({ body: [id] });
 

--- a/javascript/test_javascript_sdk/QuotasApi.spec.ts
+++ b/javascript/test_javascript_sdk/QuotasApi.spec.ts
@@ -5,11 +5,11 @@ import * as TenantsAdmin from '@kestra-io/kestra-sdk/tenants-admin';
 import type { Tenant } from '@kestra-io/kestra-sdk';
 
 describe('QuotasApi', () => {
-    it('search: lists quota limits for the tenant', async () => {
-        // `search` (GET /quota-limits) returns QuotaLimit usage counters, which are
-        // materialized lazily as quota-consuming activity occurs. A tenant with no
+    it('searchQuotaLimits: lists quota limits for the tenant', async () => {
+        // `searchQuotaLimits` (GET /quota-limits) returns QuotaLimit usage counters, which
+        // are materialized lazily as quota-consuming activity occurs. A tenant with no
         // recorded usage returns an empty array, so assert the response shape.
-        const result = await Quotas.search();
+        const result = await Quotas.searchQuotaLimits();
         expect(Array.isArray(result)).toBe(true);
     });
 

--- a/kestra-ee.yml
+++ b/kestra-ee.yml
@@ -563,13 +563,13 @@ paths:
     post:
       tags:
       - Policies
-      summary: Create an instance-scope policy
+      summary: Create an instance-scope policy from its YAML source
       operationId: createInstancePolicy
       requestBody:
         content:
-          application/json:
+          application/x-yaml:
             schema:
-              $ref: "#/components/schemas/PolicyRequest"
+              type: string
         required: true
       responses:
         "200":
@@ -705,6 +705,30 @@ paths:
       - basicAuth: []
       x-kestra:
         edition: ee
+  /api/v1/instance/policies/validate:
+    post:
+      tags:
+      - Policies
+      summary: Validate an instance-scope policy YAML source without persisting it
+      operationId: validateInstancePolicy
+      requestBody:
+        content:
+          application/x-yaml:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: validateInstancePolicy 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidateConstraintViolation"
+      security:
+      - bearerAuth: []
+      - basicAuth: []
+      x-kestra:
+        edition: ee
   /api/v1/instance/policies/{id}:
     get:
       tags:
@@ -738,7 +762,7 @@ paths:
     put:
       tags:
       - Policies
-      summary: Update an instance-scope policy
+      summary: Update an instance-scope policy from its YAML source
       operationId: updateInstancePolicy
       parameters:
       - name: id
@@ -748,9 +772,9 @@ paths:
           type: string
       requestBody:
         content:
-          application/json:
+          application/x-yaml:
             schema:
-              $ref: "#/components/schemas/PolicyRequest"
+              type: string
         required: true
       responses:
         "200":
@@ -15166,7 +15190,7 @@ paths:
     post:
       tags:
       - Policies
-      summary: Create a namespace-scope policy
+      summary: Create a namespace-scope policy from its YAML source
       operationId: createNamespacePolicy
       parameters:
       - name: tenant
@@ -15181,9 +15205,9 @@ paths:
           type: string
       requestBody:
         content:
-          application/json:
+          application/x-yaml:
             schema:
-              $ref: "#/components/schemas/PolicyRequest"
+              type: string
         required: true
       responses:
         "200":
@@ -15354,6 +15378,41 @@ paths:
       - basicAuth: []
       x-kestra:
         edition: ee
+  /api/v1/{tenant}/namespaces/{namespace}/policies/validate:
+    post:
+      tags:
+      - Policies
+      summary: Validate a namespace-scope policy YAML source without persisting it
+      operationId: validateNamespacePolicy
+      parameters:
+      - name: tenant
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/x-yaml:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: validateNamespacePolicy 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidateConstraintViolation"
+      security:
+      - bearerAuth: []
+      - basicAuth: []
+      x-kestra:
+        edition: ee
   /api/v1/{tenant}/namespaces/{namespace}/policies/{id}:
     get:
       tags:
@@ -15391,7 +15450,7 @@ paths:
     put:
       tags:
       - Policies
-      summary: Update a namespace-scope policy
+      summary: Update a namespace-scope policy from its YAML source
       operationId: updateNamespacePolicy
       parameters:
       - name: tenant
@@ -15411,9 +15470,9 @@ paths:
           type: string
       requestBody:
         content:
-          application/json:
+          application/x-yaml:
             schema:
-              $ref: "#/components/schemas/PolicyRequest"
+              type: string
         required: true
       responses:
         "200":
@@ -15891,7 +15950,7 @@ paths:
     post:
       tags:
       - Policies
-      summary: Create a tenant-scope policy
+      summary: Create a tenant-scope policy from its YAML source
       operationId: createTenantPolicy
       parameters:
       - name: tenant
@@ -15901,9 +15960,9 @@ paths:
           type: string
       requestBody:
         content:
-          application/json:
+          application/x-yaml:
             schema:
-              $ref: "#/components/schemas/PolicyRequest"
+              type: string
         required: true
       responses:
         "200":
@@ -16100,6 +16159,36 @@ paths:
       - basicAuth: []
       x-kestra:
         edition: ee
+  /api/v1/{tenant}/policies/validate:
+    post:
+      tags:
+      - Policies
+      summary: Validate a tenant-scope policy YAML source without persisting it
+      operationId: validateTenantPolicy
+      parameters:
+      - name: tenant
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/x-yaml:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: validateTenantPolicy 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidateConstraintViolation"
+      security:
+      - bearerAuth: []
+      - basicAuth: []
+      x-kestra:
+        edition: ee
   /api/v1/{tenant}/policies/{id}:
     get:
       tags:
@@ -16132,7 +16221,7 @@ paths:
     put:
       tags:
       - Policies
-      summary: Update a tenant-scope policy
+      summary: Update a tenant-scope policy from its YAML source
       operationId: updateTenantPolicy
       parameters:
       - name: tenant
@@ -16147,9 +16236,9 @@ paths:
           type: string
       requestBody:
         content:
-          application/json:
+          application/x-yaml:
             schema:
-              $ref: "#/components/schemas/PolicyRequest"
+              type: string
         required: true
       responses:
         "200":
@@ -25361,7 +25450,7 @@ components:
           items:
             $ref: "#/components/schemas/Rule"
         source:
-          title: "The original YAML source, preserved for round-trip editing; null when the policy was authored through the structured API."
+          title: "The YAML source, preserved for round-trip editing: the authored source for API/imported policies, or a canonical serialization for the config-declared and migrated ones."
           type: string
         deleted:
           type: boolean
@@ -25495,30 +25584,6 @@ components:
           items:
             $ref: "#/components/schemas/PolicyConflict"
       description: Result of dry-running the applicable policy chain against a flow source.
-    PolicyRequest:
-      required:
-      - id
-      - rules
-      type: object
-      properties:
-        id:
-          type: string
-        displayName:
-          type: string
-        description:
-          type: string
-        enforcement:
-          $ref: "#/components/schemas/Enforcement"
-        target:
-          title: "Optional application refinement within the scope's reach: tenants for INSTANCE, namespace subtrees for TENANT."
-          allOf:
-          - $ref: "#/components/schemas/Target"
-        rules:
-          minItems: 1
-          type: array
-          items:
-            $ref: "#/components/schemas/Rule"
-      description: "Create/update payload for a policy; scope, tenant and namespace are derived from the URL."
     PolicyRuleSummary:
       type: object
       properties:
@@ -26770,20 +26835,6 @@ components:
       - DOCKER
       - STANDALONE
       x-type: String
-    Target:
-      type: object
-      properties:
-        tenants:
-          title: The tenants the policy applies to; INSTANCE and STATIC scopes only. Absent = every tenant.
-          type: array
-          items:
-            type: string
-        namespaces:
-          title: The namespace subtrees the policy applies to; TENANT scope only. Absent = the whole tenant.
-          type: array
-          items:
-            type: string
-      description: "Narrows where the policy applies within its scope: tenants for INSTANCE/STATIC policies, namespace subtrees for TENANT policies."
     Task:
       required:
       - id

--- a/kestra-ee.yml
+++ b/kestra-ee.yml
@@ -21734,8 +21734,6 @@ components:
           type: string
         error:
           type: string
-        stackTrace:
-          type: string
     ExecutionController.ExecutionResponse:
       required:
       - deleted

--- a/kestra-ee.yml
+++ b/kestra-ee.yml
@@ -16324,7 +16324,7 @@ paths:
       tags:
       - Quotas
       summary: Search for quota limits
-      operationId: search
+      operationId: searchQuotaLimits
       parameters:
       - name: tenant
         in: path
@@ -16333,13 +16333,39 @@ paths:
           type: string
       responses:
         "200":
-          description: search 200 response
+          description: searchQuotaLimits 200 response
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/QuotaLimit"
+      security:
+      - bearerAuth: []
+      - basicAuth: []
+      x-kestra:
+        edition: ee
+  /api/v1/{tenant}/quota-limits/reset:
+    post:
+      tags:
+      - Quotas
+      summary: Reset a quota limit
+      operationId: resetQuotaLimit
+      parameters:
+      - name: tenant
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QuotaLimitController.ApiQuotaLimitResetRequest"
+        required: true
+      responses:
+        "200":
+          description: resetQuotaLimit 200 response
       security:
       - bearerAuth: []
       - basicAuth: []
@@ -25945,6 +25971,21 @@ components:
         count:
           type: integer
           format: int64
+    QuotaLimitController.ApiQuotaLimitResetRequest:
+      required:
+      - id
+      type: object
+      properties:
+        namespace:
+          type: string
+          nullable: true
+        flowId:
+          type: string
+          nullable: true
+        id:
+          minLength: 1
+          type: string
+      description: Request body for resetting a quota limit.
     RBACService.RoleAssignment.RoleOrigin:
       type: string
       enum:

--- a/kestra-ee.yml
+++ b/kestra-ee.yml
@@ -18702,6 +18702,13 @@ paths:
         schema:
           type: boolean
           default: true
+      - name: recoverMissedSchedules
+        in: query
+        description: "When true, missed schedules are recovered on enable according to the trigger's recoverMissedSchedules configuration; omitted or false, missed schedules are skipped"
+        explode: false
+        schema:
+          type: boolean
+          nullable: true
       - name: tenant
         in: path
         required: true
@@ -27369,6 +27376,9 @@ components:
           type: string
         disabled:
           type: boolean
+        recoverMissedSchedules:
+          type: boolean
+          nullable: true
     TriggerController.ApiTriggerId:
       type: object
       properties:
@@ -27391,6 +27401,9 @@ components:
             $ref: "#/components/schemas/TriggerController.ApiTriggerId"
         disabled:
           type: boolean
+        recoverMissedSchedules:
+          type: boolean
+          nullable: true
     TriggerFixture:
       required:
       - id

--- a/kestra-ee.yml
+++ b/kestra-ee.yml
@@ -7319,6 +7319,8 @@ paths:
               type: string
         required: true
       responses:
+        "422":
+          description: If the dashboard id is reserved ('_default')
         "200":
           description: createDashboard 200 response
           content:
@@ -7328,13 +7330,19 @@ paths:
       security:
       - bearerAuth: []
       - basicAuth: []
-  /api/v1/{tenant}/dashboards/charts/export/to-csv:
+  /api/v1/{tenant}/dashboards/charts/export:
     post:
       tags:
       - Dashboards
-      summary: Export a table chart data to CSV
-      operationId: exportChartToCsv
+      summary: Export a chart data
+      operationId: exportChart
       parameters:
+      - name: format
+        in: query
+        description: The export format
+        explode: false
+        schema:
+          $ref: "#/components/schemas/ExportFormat"
       - name: tenant
         in: path
         required: true
@@ -7348,7 +7356,7 @@ paths:
         required: true
       responses:
         "200":
-          description: exportChartToCsv 200 response
+          description: exportChart 200 response
           content:
             application/octet-stream:
               schema:
@@ -7382,6 +7390,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PagedResults_Map_String.Object__"
+      security:
+      - bearerAuth: []
+      - basicAuth: []
+  /api/v1/{tenant}/dashboards/defaults/definitions:
+    get:
+      tags:
+      - Dashboards
+      summary: Get the built-in default dashboard definitions
+      operationId: getDefaultDashboardDefinitions
+      parameters:
+      - name: tenant
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: getDefaultDashboardDefinitions 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
       security:
       - bearerAuth: []
       - basicAuth: []
@@ -7518,6 +7550,8 @@ paths:
               type: string
         required: true
       responses:
+        "422":
+          description: If the dashboard id is reserved ('_default')
         "200":
           description: updateDashboard 200 response
           content:
@@ -7591,12 +7625,12 @@ paths:
       security:
       - bearerAuth: []
       - basicAuth: []
-  /api/v1/{tenant}/dashboards/{id}/charts/{chartId}/export/to-csv:
+  /api/v1/{tenant}/dashboards/{id}/charts/{chartId}/export:
     post:
       tags:
       - Dashboards
-      summary: Export a dashboard chart data to CSV
-      operationId: exportDashboardChartDataToCSV
+      summary: Export a dashboard chart data
+      operationId: exportDashboardChart
       parameters:
       - name: id
         in: path
@@ -7610,6 +7644,12 @@ paths:
         required: true
         schema:
           type: string
+      - name: format
+        in: query
+        description: The export format
+        explode: false
+        schema:
+          $ref: "#/components/schemas/ExportFormat"
       - name: tenant
         in: path
         required: true
@@ -7624,7 +7664,7 @@ paths:
         required: true
       responses:
         "200":
-          description: exportDashboardChartDataToCSV 200 response
+          description: exportDashboardChart 200 response
           content:
             application/octet-stream:
               schema:
@@ -21993,6 +22033,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DailyExecutionStatistics"
+    ExportFormat:
+      type: string
+      enum:
+      - CSV
+      - ION
     ExpressionContext:
       type: object
       properties:


### PR DESCRIPTION
Fixes the `javascript SDK vs latest Kestra` leg of the daily freshness check, red since [run 30333124607](https://github.com/kestra-io/client-sdk/actions/runs/30333124607) (15 of 16 `PoliciesApi` tests failing with a bare `403 Forbidden`).

## Root cause

kestra-ee [`fe7140415`](https://github.com/kestra-io/kestra-ee/commit/fe7140415317aa690fbafe5a62e801ff55a220a9) (*feat(policies): populate and round-trip the policy source*) switched every policy create/update from a JSON body to a YAML source:

```java
- @Post(uri = "/{tenant}/policies")                              @Body @Valid ApiPolicyRequest request
+ @Post(uri = "/{tenant}/policies", consumes = APPLICATION_YAML) @Body @NotNull String source
```

`main`'s committed `kestra-ee.yml` predates that, so the regenerated SDK posts `application/json` to a route that only consumes `application/x-yaml`. No route matches, and EE's security filter rejects the unmatched `/api` path before routing — which is why it surfaces as `403` rather than `404`/`415`.

Every failure lands on a `create*Policy`/`update*Policy` call; `importPolicies` is the only test that stayed green because it is `multipart/form-data` and was left untouched. That pattern rules out a permission or license-gate cause.

## Changes

- `kestra-ee.yml` refreshed up to kestra-ee@`1e1d45ca` (the five `ci: auto-update` commits, same content as #369).
- `PoliciesApi.spec.ts` — policies are now created and updated from their YAML source; the spec builds the document with a `policySource()` helper instead of a structured `policyRequest()` object.
- `QuotasApi.spec.ts` — follows the `search` → `searchQuotaLimits` operationId rename.

## ⚠️ Signature change

Generated JS SDK, driven by the spec refresh — all breaking, no back-compat aliases (they mirror upstream route/operation renames):

```
Policies.createInstancePolicy({ ...PolicyRequest })   → Policies.createInstancePolicy({ body: string /* YAML */ })
Policies.updateInstancePolicy({ ...PolicyRequest })   → Policies.updateInstancePolicy({ id, body: string })
Policies.createTenantPolicy({ ...PolicyRequest })     → Policies.createTenantPolicy({ body: string })
Policies.updateTenantPolicy({ ...PolicyRequest })     → Policies.updateTenantPolicy({ id, body: string })
Policies.createNamespacePolicy({ ...PolicyRequest })  → Policies.createNamespacePolicy({ namespace, body: string })
Policies.updateNamespacePolicy({ ...PolicyRequest })  → Policies.updateNamespacePolicy({ namespace, id, body: string })
Quotas.search(...)                                    → Quotas.searchQuotaLimits(...)
Dashboards.exportChartToCsv(...)                       → Dashboards.exportChart({ ..., format?: 'CSV' | 'ION' })
Dashboards.exportDashboardChartDataToCSV(...)          → Dashboards.exportDashboardChart({ ..., format?: 'CSV' | 'ION' })
```

New operations added by the same refresh: `validateInstancePolicy`, `validateTenantPolicy`, `validateNamespacePolicy`, `getDefaultDashboardDefinitions`, `resetQuotaLimit`.

Downstream consumers (plugin-kestra) should note the `Policies.*` and `Quotas.search` renames.

## Relationship to other PRs

- Supersedes #369 — same `kestra-ee.yml` content, plus the test realignment that #369 alone would leave red.
- Overlaps #323 on the two dashboards export paths in `kestra-ee.yml`: #323 hand-edits them, this PR picks them up from the full spec regen. Whichever lands second will need the other's hunk dropped. No JS test exercises the dashboards export, so the JS leg is unaffected either way; #323 still owns the Java/Python/Go method renames.
