### PR TITLE
test(go): fail instead of swallowing any error on the chart preview smoke test

### DIFF
--- a/go-sdk/test/api_dashboards_test.go
+++ b/go-sdk/test/api_dashboards_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -327,11 +328,14 @@ columns:
 `)
 		request := kestra_api_client.NewDashboardControllerPreviewRequest(chartYaml)
 
-		// May fail with 400/422 if chart type not available, verifies endpoint reachability
+		// This minimal chart definition may legitimately be refused with a 400/422. Any other
+		// status means the endpoint itself is gone rather than the chart being rejected — EE
+		// answers an unmatched /api path with 403 — so those must fail the test.
 		_, err := KestraTestClient().Dashboards().PreviewChart(ctx, MAIN_TENANT, request)
-		// We accept success or a controlled API error
 		if err != nil {
-			require.Contains(t, err.Error(), "")
+			var apiErr *kestra_api_client.ApiError
+			require.True(t, errors.As(err, &apiErr), "expected an *ApiError, got %v", err)
+			require.Contains(t, []int{400, 422}, apiErr.StatusCode, "unexpected status, body: %s", apiErr.Body)
 		}
 	})
 


### PR DESCRIPTION
`previewChart_basic` swallowed every error:

```go
if err != nil {
	require.Contains(t, err.Error(), "")   // can never fail
}
```

The empty substring is contained in every string, so the test passed no matter what came back — including the endpoint no longer existing. EE answers an unmatched `/api` path with `403`, not `404`, so a renamed or deleted route is reported as a pass by the [daily freshness check](https://github.com/kestra-io/client-sdk/actions/runs/30333124607) rather than a failure. This has already happened once on the neighbouring chart-export route (kestra-io/kestra#17260), where the Java and Python suites went red on the `403` while the Go leg stayed green for hours.

## Change

Assert the tolerated statuses through the typed `*ApiError`, using the `errors.As` idiom already used in `api_executions_test.go`:

```go
_, err := KestraTestClient().Dashboards().PreviewChart(ctx, MAIN_TENANT, request)
if err != nil {
	var apiErr *kestra_api_client.ApiError
	require.True(t, errors.As(err, &apiErr), "expected an *ApiError, got %v", err)
	require.Contains(t, []int{400, 422}, apiErr.StatusCode, "unexpected status, body: %s", apiErr.Body)
}
```

The minimal chart definition the test posts may legitimately be refused with a `400`/`422`, and that still passes. Anything else — a moved route, a transport error — now fails. This matches what the Java and Python tests already assert (`assert e.status in (400, 422)`).

This was the last remaining instance of the anti-pattern in `go-sdk`.

Test-only, no signature changes.