### PR TITLE
test(javascript): keep page sizes within the API maximum

### DIFF
--- a/javascript/test_javascript_sdk/FlowsApi.spec.ts
+++ b/javascript/test_javascript_sdk/FlowsApi.spec.ts
@@ -252,7 +252,6 @@ describe('FlowsApi', () => {
         const flow = await createSimpleFlow();
         const resp = await Flows.searchFlowsBySourceCode({
             page: 1,
-            size: 10000,
             q: flow.id,
             namespace: flow.namespace,
         });

--- a/javascript/test_javascript_sdk/RolesApi.spec.ts
+++ b/javascript/test_javascript_sdk/RolesApi.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { randomId } from './_utils.js';
+import { MAX_PAGE_SIZE, randomId } from './_utils.js';
 import * as Roles from '@kestra-io/kestra-sdk/roles';
 
 describe('RolesApi', () => {
@@ -98,7 +98,7 @@ describe('RolesApi', () => {
 
         const results = await Roles.searchRoles({
             page: 1,
-            size: 10000,
+            size: MAX_PAGE_SIZE,
             filters: [],
         });
 

--- a/javascript/test_javascript_sdk/ServiceAccountApi.spec.ts
+++ b/javascript/test_javascript_sdk/ServiceAccountApi.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { randomIdWith } from './_utils.js';
+import { MAX_PAGE_SIZE, randomIdWith } from './_utils.js';
 import { tenantId } from './_setup.js';
 import * as ServiceAccount from '@kestra-io/kestra-sdk/service-account';
 
@@ -81,7 +81,7 @@ describe('ServiceAccountApi', () => {
         const created = await ServiceAccount.createServiceAccount({ name });
 
         // Many SDKs use {page, size}; some use {page: 1, size: 50}, others 0-based.
-        const results = await ServiceAccount.listServiceAccounts({ page: 1, size: 10000, filters: [] });
+        const results = await ServiceAccount.listServiceAccounts({ page: 1, size: MAX_PAGE_SIZE, filters: [] });
 
         // tolerate different result shapes: {results: []} or direct array
         const items = Array.isArray(results) ? results : results?.results ?? [];
@@ -180,7 +180,7 @@ describe('ServiceAccountApi', () => {
         const name = randomIdWith('test-list-service-accounts-for-tenant');
         const created = await ServiceAccount.createServiceAccountForTenant({ name });
 
-        const results = await ServiceAccount.listServiceAccountsForTenant({ page: 1, size: 10000, filters: [] });
+        const results = await ServiceAccount.listServiceAccountsForTenant({ page: 1, size: MAX_PAGE_SIZE, filters: [] });
         const items = Array.isArray(results) ? results : (results as any)?.results ?? [];
         expect(items.map((r: any) => r?.id)).toContain(created.id);
     });

--- a/javascript/test_javascript_sdk/_utils.ts
+++ b/javascript/test_javascript_sdk/_utils.ts
@@ -15,6 +15,13 @@ export function randomEmail() {
 
 export const TEST_DATA_PATH = "../../test-utils";
 
+/**
+ * Largest page size the API accepts (`PageableUtils.MAX_PAGE_SIZE`); anything above is rejected with
+ * a 422. Use it only where a test genuinely needs "every row" — otherwise omit `size` and let the
+ * endpoint's own default apply.
+ */
+export const MAX_PAGE_SIZE = 1000;
+
 export function get(filePath: string) {
     const absolute = path.isAbsolute(filePath)
         ? filePath


### PR DESCRIPTION
### What changes are being made and why?

The API caps page sizes at 1000 (`PageableUtils.MAX_PAGE_SIZE`) and rejects anything above it with a `422`. Four specs passed `size: 10000` to mean *"every row"* and now fail:

```
422 Invalid entity: searchFlowsBySourceCode.size: must be less than or equal to 1000
422 Invalid entity: searchRoles.size: must be less than or equal to 1000
422 Invalid entity: listServiceAccounts.size: must be less than or equal to 1000
422 Invalid entity: listServiceAccountsForTenant.size: must be less than or equal to 1000
```

- `FlowsApi > search_flows_by_source_code` drops `size` entirely — the search is already narrowed by `q` + `namespace`, so the endpoint's own default is plenty.
- `RolesApi > search_roles` and both `ServiceAccountApi` listings genuinely do want every row, so they ask for `MAX_PAGE_SIZE` — a new constant in `_utils.ts` — rather than an arbitrary large number that drifts out of range the next time the cap changes.

**No SDK behaviour change.** An earlier revision of this PR added a client-side default page size to `configureClient()`; it was dropped. `size` is optional on all 49 paginated endpoints and each carries its own deliberate default — 10 on 41 of them, but 1000 on `listPlugins`, 100 on `listAllMcpServers` / `findDistinctFieldValues`, 1 on the blueprint searches, 25 on the policy-evaluate endpoints. A blanket SDK default would have silently truncated `listPlugins` from 1000 rows to 25. The test edits above are the whole fix.

---

### How the changes have been QAed?

`npm run check:types` is clean after `./generate-sdks.sh javascript`.

CI is the real check here, and `main` is currently red on its own: the run on `6d52efc` ([30527428457](https://github.com/kestra-io/client-sdk/actions/runs/30527428457/job/90821519597)) has 8 failures. This branch removes the four page-size `422`s above. Three failures remain and reproduce on `main` unchanged, unrelated to pagination:

- `ExecutionsApi > pause_executions_by_ids` and `pause_executions_by_query` — `400 invalid bulk pause`, deterministic on both branches, likely a server-side bulk-pause regression deserving its own issue.
- `TestSuitesApi > searchTestSuitesResultsTest` — timeout at 5000ms, also fails on `main`.