### PR TITLE
fix: address post-merge review follow-ups on JS SDK test comment (#376)

### DIFF
--- a/.github/scripts/coverage-comment.mjs
+++ b/.github/scripts/coverage-comment.mjs
@@ -72,7 +72,7 @@ const sha = COMMIT_SHA || GITHUB_SHA;
 /** Escape the characters that would break a markdown table cell or inline text. */
 const escapeMd = (s) => s.replace(/([|`*_[\]<>])/g, "\\$1");
 
-const stripAnsi = (s) => s.replace(/\[[0-9;]*m/g, "");
+const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
 
 /**
  * Permalink to a spec file (optionally a given line) on GitHub. Returns null
@@ -303,7 +303,13 @@ ${items}
 </details>`;
 }
 
-function buildFailingSection() {
+/**
+ * @param dropTrailingGroups How many file groups to additionally drop from
+ *   the tail, beyond the `MAX_FAILURES_SHOWN` cap. Used to shrink the section
+ *   by whole groups when the assembled body is still over the size limit,
+ *   instead of slicing the final markdown at an arbitrary byte offset.
+ */
+function buildFailingSection(dropTrailingGroups = 0) {
     if (failingTests.length === 0 && unhandledErrors.length > 0) {
         return `### ❌ JavaScript SDK — tests failed
 
@@ -326,17 +332,29 @@ ${reason}.${RUN_URL ? ` See the [workflow logs](${RUN_URL}).` : ""}`;
         return "";
     }
 
-    const shown = failingTests.slice(0, MAX_FAILURES_SHOWN);
-    const shownFiles = new Set(shown.map((t) => t.file));
-    const hidden = failingTests.length - shown.length;
+    // Slice whole file groups (not individual tests) so a group's displayed
+    // "N failing" count always matches the number of entries under it. At
+    // least one group is always shown, even if it alone exceeds the cap.
+    const countCappedGroups = [];
+    let countCappedTotal = 0;
+    for (const group of failingByFile) {
+        if (countCappedTotal > 0 && countCappedTotal + group.tests.length > MAX_FAILURES_SHOWN) {
+            break;
+        }
+        countCappedGroups.push(group);
+        countCappedTotal += group.tests.length;
+    }
+    const shownGroups = dropTrailingGroups > 0
+        ? countCappedGroups.slice(0, Math.max(0, countCappedGroups.length - dropTrailingGroups))
+        : countCappedGroups;
+    const shownCount = shownGroups.reduce((n, g) => n + g.tests.length, 0);
+    const hidden = failingTests.length - shownCount;
     // Expand automatically while the list is still short enough to skim.
     const open = failingTests.length <= 20 ? " open" : "";
 
-    const groups = failingByFile
-        .filter(({ file }) => shownFiles.has(file))
+    const groups = shownGroups
         .map(({ file, tests }) => {
             const items = tests
-                .filter((t) => shown.includes(t))
                 .map((t) => {
                     const link = specLink(file, t.line);
                     const label = escapeMd(t.title);
@@ -423,18 +441,41 @@ ${rows}
 // ---------------------------------------------------------------------------
 
 // Failures first: they are what a dev opening the PR needs to act on.
-const sections = [buildFailingSection(), buildCoverageSection()].filter(Boolean);
+function assembleBody(dropTrailingGroups) {
+    const sections = [buildFailingSection(dropTrailingGroups), buildCoverageSection()].filter(
+        Boolean,
+    );
+    return sections.length === 0 ? null : `${MARKER}\n${sections.join("\n\n---\n\n")}`;
+}
 
-if (sections.length === 0) {
+let body = assembleBody(0);
+
+if (body === null) {
     console.log("Nothing to report (no coverage data, no test results) — skipping comment.");
     process.exit(0);
 }
 
-let body = `${MARKER}\n${sections.join("\n\n---\n\n")}`;
+// If the body is still over GitHub's limit, drop whole failing-test file
+// groups from the tail instead of slicing the final markdown at an arbitrary
+// byte offset — a raw slice regularly lands inside a fenced code block or an
+// open <details>, swallowing the truncation notice and rendering the tail as
+// code.
+for (
+    let dropTrailingGroups = 1;
+    body.length > MAX_BODY_CHARS && dropTrailingGroups <= failingByFile.length;
+    dropTrailingGroups++
+) {
+    body = assembleBody(dropTrailingGroups);
+}
 
 if (body.length > MAX_BODY_CHARS) {
-    body = `${body.slice(0, MAX_BODY_CHARS)}\n\n_…comment truncated._${
-        RUN_URL ? ` [Full logs](${RUN_URL})` : ""
+    // Even with every failing-test group dropped, the report (mostly
+    // coverage data) is still too big. Fall back to a minimal, self-contained
+    // notice rather than truncate mid-markdown.
+    body = `${MARKER}\n### ⚠️ JavaScript SDK report truncated
+
+The generated report exceeded GitHub's comment size limit even after dropping all failing-test detail groups.${
+        RUN_URL ? ` See the [workflow logs](${RUN_URL}) for the full result.` : ""
     }`;
 }
 

--- a/.github/scripts/coverage-comment.mjs
+++ b/.github/scripts/coverage-comment.mjs
@@ -303,12 +303,8 @@ ${items}
 </details>`;
 }
 
-/**
- * @param dropTrailingGroups How many file groups to additionally drop from
- *   the tail, beyond the `MAX_FAILURES_SHOWN` cap. Used to shrink the section
- *   by whole groups when the assembled body is still over the size limit,
- *   instead of slicing the final markdown at an arbitrary byte offset.
- */
+/** @param dropTrailingGroups Extra file groups to drop from the tail, beyond
+ *   the MAX_FAILURES_SHOWN cap, to shrink the section under MAX_BODY_CHARS. */
 function buildFailingSection(dropTrailingGroups = 0) {
     if (failingTests.length === 0 && unhandledErrors.length > 0) {
         return `### ❌ JavaScript SDK — tests failed
@@ -332,9 +328,8 @@ ${reason}.${RUN_URL ? ` See the [workflow logs](${RUN_URL}).` : ""}`;
         return "";
     }
 
-    // Slice whole file groups (not individual tests) so a group's displayed
-    // "N failing" count always matches the number of entries under it. At
-    // least one group is always shown, even if it alone exceeds the cap.
+    // Slice whole file groups, not individual tests, so each group's
+    // "N failing" header always matches what's listed beneath it.
     const countCappedGroups = [];
     let countCappedTotal = 0;
     for (const group of failingByFile) {
@@ -455,11 +450,8 @@ if (body === null) {
     process.exit(0);
 }
 
-// If the body is still over GitHub's limit, drop whole failing-test file
-// groups from the tail instead of slicing the final markdown at an arbitrary
-// byte offset — a raw slice regularly lands inside a fenced code block or an
-// open <details>, swallowing the truncation notice and rendering the tail as
-// code.
+// Drop whole failing-test groups from the tail to fit the size limit — a
+// raw byte-offset slice can land inside a fence or an open <details>.
 for (
     let dropTrailingGroups = 1;
     body.length > MAX_BODY_CHARS && dropTrailingGroups <= failingByFile.length;
@@ -469,9 +461,8 @@ for (
 }
 
 if (body.length > MAX_BODY_CHARS) {
-    // Even with every failing-test group dropped, the report (mostly
-    // coverage data) is still too big. Fall back to a minimal, self-contained
-    // notice rather than truncate mid-markdown.
+    // Still too big with every group dropped (huge coverage data) — fall
+    // back to a minimal notice instead of truncating mid-markdown.
     body = `${MARKER}\n### ⚠️ JavaScript SDK report truncated
 
 The generated report exceeded GitHub's comment size limit even after dropping all failing-test detail groups.${

--- a/javascript/test_javascript_sdk/failureReporter.ts
+++ b/javascript/test_javascript_sdk/failureReporter.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import type { Reporter, SerializedError, TestCase, TestModule } from "vitest/node";
 
 /**
  * Writes `coverage/test-failures.json`, consumed by
@@ -48,7 +49,7 @@ function relativeSpec(moduleId: string | undefined): string {
 }
 
 /** `AssertionError: expected 1 to be 2`, without duplicating the name. */
-function describeError(error: { name?: string; message?: string }): string {
+function describeError(error: SerializedError): string {
     const message = (error.message ?? "").trim();
     const name = (error.name ?? "").trim();
     if (!message) return name || "Unknown error (no message recorded)";
@@ -60,7 +61,7 @@ function describeError(error: { name?: string; message?: string }): string {
  * With `retry`, vitest keeps one error per attempt — almost always the same
  * message repeated. Show each distinct one once.
  */
-function collectErrors(errors: { name?: string; message?: string }[]): string {
+function collectErrors(errors: ReadonlyArray<SerializedError>): string {
     const seen: string[] = [];
     for (const error of errors ?? []) {
         const described = describeError(error);
@@ -69,7 +70,7 @@ function collectErrors(errors: { name?: string; message?: string }[]): string {
     return seen.join("\n\n") || "Test failed with no recorded error.";
 }
 
-export default class FailureReporter {
+export default class FailureReporter implements Reporter {
     private report: FailureReport = {
         failures: [],
         moduleErrors: [],
@@ -80,9 +81,9 @@ export default class FailureReporter {
      * Fires once per test with its final result, so a flaky test that passes on
      * a retry is never recorded as a failure.
      */
-    onTestCaseResult(testCase: any) {
+    onTestCaseResult(testCase: TestCase) {
         const result = testCase.result();
-        if (result?.state !== "failed") return;
+        if (result.state !== "failed") return;
 
         const name = testCase.name ?? "<unnamed test>";
         const fullName: string = testCase.fullName ?? name;
@@ -100,11 +101,9 @@ export default class FailureReporter {
         });
     }
 
-    onTestRunEnd(testModules: any[], unhandledErrors: unknown[]) {
+    onTestRunEnd(testModules: ReadonlyArray<TestModule>, unhandledErrors: ReadonlyArray<SerializedError>) {
         for (const module of testModules ?? []) {
-            const errors =
-                typeof module.errors === "function" ? module.errors() : [];
-            for (const error of errors) {
+            for (const error of module.errors()) {
                 this.report.moduleErrors.push({
                     file: relativeSpec(module.moduleId),
                     error: describeError(error),
@@ -113,9 +112,7 @@ export default class FailureReporter {
         }
 
         for (const error of unhandledErrors ?? []) {
-            this.report.unhandledErrors.push(
-                describeError(error as { name?: string; message?: string }),
-            );
+            this.report.unhandledErrors.push(describeError(error));
         }
 
         // Always write the file, even for a green run: an empty report tells the


### PR DESCRIPTION
### What changes are being made and why?

Follow-up to #376, addressing [jymaire's post-merge review](https://github.com/kestra-io/client-sdk/pull/376#issuecomment-5129179718). Four issues, all in the code introduced by that PR:

1. **`stripAnsi` embedded a literal ESC control byte in the regex source** (`.github/scripts/coverage-comment.mjs`) instead of the visible `\x1b` escape sequence. It happened to strip ANSI codes correctly at runtime, but the invisible byte is a footgun: GitHub (and some editors) render it as nothing, which is exactly why it read as broken in review. Replaced with the explicit `\x1b\[[0-9;]*m` pattern — same behavior, now visible and safe against tools that don't preserve raw control characters.
2. **Truncation sliced individual tests in completion order** while each file group's header printed the *full* per-file failing count — so under truncation, a group's `— N failing` header could disagree with the entries actually listed beneath it. Truncation now slices whole file groups (at least one group is always shown, even if it alone exceeds the cap), so headers and content always agree.
3. **The final `MAX_BODY_CHARS` cut sliced raw markdown at a byte offset**, which could land inside a fenced code block or an open `<details>`, swallowing the truncation notice and rendering the tail as code. Truncation now drops whole failing-test file groups from the tail until the body fits, falling back to a minimal self-contained notice if it's still too big even with every group dropped.
4. **`failureReporter.ts` typed the vitest reporter-API callbacks as `any`.** `vitest/node` exports `Reporter`, `TestCase`, `TestModule`, and `SerializedError`, so the class now implements `Reporter` with real types. This file exists specifically to depend on reporter-API internals, so it's the one place where drift on a future vitest major should fail at type-check rather than silently produce an empty report — the `typeof module.errors === "function"` guard is gone since `errors()` is no longer optional once properly typed.

### How the changes have been QAed?

- `node --check` on the modified script, plus a standalone `tsc --noEmit` pass against `failureReporter.ts` using the project's compiler options (via `vitest/node`'s shipped `.d.ts`) — no type errors.
- Manually exercised `coverage-comment.mjs` against synthetic failure reports:
  - Normal case (a few failures, no truncation) — output unchanged.
  - Count-truncation case (100 failures across 5 files, `MAX_FAILURES_SHOWN = 60`) — now shows exactly 3 complete file groups (60/60 tests) with an accurate "40 more" note, instead of partial groups with mismatched headers.
  - Size-truncation case (temporarily lowering `MAX_BODY_CHARS` to exercise the path) — confirmed whole groups are dropped from the tail and every `<details>`/code fence in the output stays balanced, with a "report truncated" fallback when even zero groups still don't fit.
  - Verified `stripAnsi` now strips real ANSI sequences (`\x1b[31m...\x1b[39m`) while no longer eating legitimate bracketed text like `[1;2m]`.

No behavior change outside these four fixes; the workflow invocation and vitest reporter registration are untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_013twU1RFPrfYmvrLk2TZiWv)_