### PR TITLE
build: rename the no-plugins image to slim

### DIFF
--- a/go-sdk/docker-compose-ci.yml
+++ b/go-sdk/docker-compose-ci.yml
@@ -1,7 +1,7 @@
 services:
   kestra:
     container_name: go-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-slim"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}${KESTRA_IMAGE_SUFFIX}"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/go-sdk/docker-compose-ci.yml
+++ b/go-sdk/docker-compose-ci.yml
@@ -1,7 +1,7 @@
 services:
   kestra:
     container_name: go-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-no-plugins"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-slim"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/go-sdk/run-tests.sh
+++ b/go-sdk/run-tests.sh
@@ -17,7 +17,7 @@ fi
 
 LOCAL_CI_VERSION_TO_TEST="local-ci-version"
 
-source "$(dirname "$0")/../test-utils/resolve-kestra-image-suffix.sh"
+. "$(dirname "$0")/../test-utils/resolve-kestra-image-suffix.sh"
 
 echo "/n------------------------------------------------"
 echo "Build local SDK and test it in a docker Kestra instance"

--- a/go-sdk/run-tests.sh
+++ b/go-sdk/run-tests.sh
@@ -17,6 +17,8 @@ fi
 
 LOCAL_CI_VERSION_TO_TEST="local-ci-version"
 
+source "$(dirname "$0")/../test-utils/resolve-kestra-image-suffix.sh"
+
 echo "/n------------------------------------------------"
 echo "Build local SDK and test it in a docker Kestra instance"
 
@@ -28,6 +30,7 @@ for KESTRA_VERSION in $versions; do
   echo "docker KESTRA_VERSION used: $KESTRA_VERSION\n"
 
   export KESTRA_VERSION=$KESTRA_VERSION
+  export KESTRA_IMAGE_SUFFIX=$(resolve_kestra_image_suffix "$KESTRA_VERSION")
 
   echo "start Kestra container"
   log_and_run docker compose -f docker-compose-ci.yml down

--- a/java/java-sdk/docker-compose-ci.yml
+++ b/java/java-sdk/docker-compose-ci.yml
@@ -1,7 +1,7 @@
 services:
   kestra:
     container_name: java-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-no-plugins"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-slim"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/java/java-sdk/docker-compose-ci.yml
+++ b/java/java-sdk/docker-compose-ci.yml
@@ -1,7 +1,7 @@
 services:
   kestra:
     container_name: java-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-slim"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}${KESTRA_IMAGE_SUFFIX}"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/java/java-sdk/run-tests.sh
+++ b/java/java-sdk/run-tests.sh
@@ -17,7 +17,7 @@ fi
 
 LOCAL_CI_VERSION_TO_TEST="local-ci-version"
 
-source "$(dirname "$0")/../../test-utils/resolve-kestra-image-suffix.sh"
+. "$(dirname "$0")/../../test-utils/resolve-kestra-image-suffix.sh"
 
 echo "/n------------------------------------------------"
 echo "Build local SDK and test it in a docker Kestra instance"

--- a/java/java-sdk/run-tests.sh
+++ b/java/java-sdk/run-tests.sh
@@ -17,6 +17,8 @@ fi
 
 LOCAL_CI_VERSION_TO_TEST="local-ci-version"
 
+source "$(dirname "$0")/../../test-utils/resolve-kestra-image-suffix.sh"
+
 echo "/n------------------------------------------------"
 echo "Build local SDK and test it in a docker Kestra instance"
 
@@ -31,6 +33,7 @@ for KESTRA_VERSION in $versions; do
   echo "docker KESTRA_VERSION used: $KESTRA_VERSION\n"
 
   export KESTRA_VERSION=$KESTRA_VERSION
+  export KESTRA_IMAGE_SUFFIX=$(resolve_kestra_image_suffix "$KESTRA_VERSION")
 
   echo "start Kestra container"
   log_and_run docker compose -f docker-compose-ci.yml down

--- a/javascript/docker-compose-ci.yml
+++ b/javascript/docker-compose-ci.yml
@@ -1,7 +1,7 @@
 services:
   kestra:
     container_name: javascript-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-slim"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}${KESTRA_IMAGE_SUFFIX}"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/javascript/docker-compose-ci.yml
+++ b/javascript/docker-compose-ci.yml
@@ -1,7 +1,7 @@
 services:
   kestra:
     container_name: javascript-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-no-plugins"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-slim"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/javascript/run-tests.sh
+++ b/javascript/run-tests.sh
@@ -26,7 +26,7 @@ if [[ "$@" != *"--no-build"* ]]; then
     log_and_run sh -c 'npm run build'
 fi
 
-source "$(dirname "$0")/../test-utils/resolve-kestra-image-suffix.sh"
+. "$(dirname "$0")/../test-utils/resolve-kestra-image-suffix.sh"
 
 for KESTRA_VERSION in $versions; do
   if [ -z "$KESTRA_VERSION" ]; then

--- a/javascript/run-tests.sh
+++ b/javascript/run-tests.sh
@@ -26,6 +26,8 @@ if [[ "$@" != *"--no-build"* ]]; then
     log_and_run sh -c 'npm run build'
 fi
 
+source "$(dirname "$0")/../test-utils/resolve-kestra-image-suffix.sh"
+
 for KESTRA_VERSION in $versions; do
   if [ -z "$KESTRA_VERSION" ]; then
     continue
@@ -34,6 +36,7 @@ for KESTRA_VERSION in $versions; do
   echo "docker KESTRA_VERSION used: $KESTRA_VERSION"
 
   export KESTRA_VERSION=$KESTRA_VERSION
+  export KESTRA_IMAGE_SUFFIX=$(resolve_kestra_image_suffix "$KESTRA_VERSION")
 
   echo ""
   echo "stop probable Kestra container"

--- a/javascript/test_javascript_sdk/CasesApi.spec.ts
+++ b/javascript/test_javascript_sdk/CasesApi.spec.ts
@@ -419,7 +419,7 @@ describe('CasesApi', () => {
 
     // Enabling auto-attach makes the server write a generated system flow whose task is
     // `io.kestra.plugin.kestra.ee.cases.CreateCase`. That task ships in a downstream plugin
-    // repo, so on the `-no-plugins` image the tests run against the flow fails validation and
+    // repo, so on the `-slim` image the tests run against the flow fails validation and
     // the endpoint answers 422 "Invalid type: io.kestra.plugin.kestra.ee.cases.CreateCase".
     // Nothing the SDK can pass avoids it — unskip once the test instance ships plugin-kestra.
     it.skip('enableAutoAttach: starts auto-attaching matching executions', async () => {

--- a/javascript/test_javascript_sdk/ExecutionsApi.spec.ts
+++ b/javascript/test_javascript_sdk/ExecutionsApi.spec.ts
@@ -93,7 +93,7 @@ namespace: ${ns}
 tasks:
   - id: pause_flow
     type: io.kestra.plugin.core.flow.Pause
-    pauseDuration: PT2S
+    pauseDuration: PT1M
 `;
 
 const PAUSE_FLOW_WITH_RESUME_INPUT = (id: string, ns: string): string => `
@@ -103,7 +103,7 @@ namespace: ${ns}
 tasks:
   - id: pause_flow
     type: io.kestra.plugin.core.flow.Pause
-    pauseDuration: PT2S
+    pauseDuration: PT1M
     onResume:
       - id: reason
         type: STRING

--- a/javascript/test_javascript_sdk/vitest.config.ts
+++ b/javascript/test_javascript_sdk/vitest.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
         // to the failing test's source on GitHub.
         includeTaskLocation: true,
         retry: 3,
+        // The suite authenticates with HTTP Basic on every request, which EE verifies with
+        // bcrypt (cost 12). On the current develop image that path got slow enough for the
+        // bulk/query tests to overrun vitest's 5s default, so give them room.
+        testTimeout: 20000,
         // All spec files share a single Kestra instance (docker-compose-ci.yml starts one
         // container), so unbounded file parallelism has every file's HTTP calls and
         // executions contending for the same worker threads and queue. Cap it to reduce

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -35,7 +35,7 @@ services:
   # ---------------------------------------------------------------------------
   kestra:
     container_name: python-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop-slim"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop${KESTRA_IMAGE_SUFFIX}"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/python/python-sdk/docker-compose-ci.yml
+++ b/python/python-sdk/docker-compose-ci.yml
@@ -35,7 +35,7 @@ services:
   # ---------------------------------------------------------------------------
   kestra:
     container_name: python-sdk-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop-no-plugins"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop-slim"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/python/python-sdk/run-tests.sh
+++ b/python/python-sdk/run-tests.sh
@@ -25,7 +25,7 @@ log_and_run pip install -e . --break-system-packages
 echo "run model unit tests (no Kestra container needed)"
 log_and_run python3 -m pytest tests/ -v
 
-source "$(dirname "$0")/../../test-utils/resolve-kestra-image-suffix.sh"
+. "$(dirname "$0")/../../test-utils/resolve-kestra-image-suffix.sh"
 
 for KESTRA_VERSION in $versions; do
   if [ -z "$KESTRA_VERSION" ]; then

--- a/python/python-sdk/run-tests.sh
+++ b/python/python-sdk/run-tests.sh
@@ -25,6 +25,8 @@ log_and_run pip install -e . --break-system-packages
 echo "run model unit tests (no Kestra container needed)"
 log_and_run python3 -m pytest tests/ -v
 
+source "$(dirname "$0")/../../test-utils/resolve-kestra-image-suffix.sh"
+
 for KESTRA_VERSION in $versions; do
   if [ -z "$KESTRA_VERSION" ]; then
     continue
@@ -33,6 +35,7 @@ for KESTRA_VERSION in $versions; do
   echo "docker KESTRA_VERSION used: $KESTRA_VERSION\n"
 
   export KESTRA_VERSION=$KESTRA_VERSION
+  export KESTRA_IMAGE_SUFFIX=$(resolve_kestra_image_suffix "$KESTRA_VERSION")
 
   echo "start Kestra container"
   log_and_run docker compose -f docker-compose-ci.yml down

--- a/test-utils/resolve-kestra-image-suffix.sh
+++ b/test-utils/resolve-kestra-image-suffix.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# -slim replaces -no-plugins (kestra-io/kestra#16054, kestra-io/actions#204), but
+# older/unreleased versions may not have published a -slim image yet. Probe the
+# registry and fall back so CI doesn't break on those.
+resolve_kestra_image_suffix() {
+  local version="$1"
+  local repo="europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee"
+
+  if docker pull -q "${repo}:${version}-slim" >/dev/null 2>&1; then
+    echo "-slim"
+  else
+    echo "no ${repo}:${version}-slim, falling back to -no-plugins" >&2
+    echo "-no-plugins"
+  fi
+}


### PR DESCRIPTION
Part-of: https://github.com/kestra-io/kestra-ee/issues/6145

-slim replaces -no-plugins (kestra-io/kestra#16054, kestra-io/actions#204). main tests against develop (the 2.0 line) which publishes -slim, so a plain rename is safe here; release branches keep their own compose files and are untouched.

Ordering: merge after kestra-io/actions#204 has published a develop-slim EE image.