### PR TITLE
fix(go): add /v2 module suffix required for the v2.0.0-rc1 tag

### DIFF
--- a/.github/workflows/go-sdk-release.yml
+++ b/.github/workflows/go-sdk-release.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Trigger pkg.go.dev indexing
         run: |
           VERSION="${GITHUB_REF_NAME#go-sdk/}"
-          curl -sf "https://proxy.golang.org/github.com/kestra-io/client-sdk/go-sdk/@v/${VERSION}.info" > /dev/null
-          curl -sf "https://pkg.go.dev/github.com/kestra-io/client-sdk/go-sdk@${VERSION}" > /dev/null
+          curl -sf "https://proxy.golang.org/github.com/kestra-io/client-sdk/go-sdk/v2/@v/${VERSION}.info" > /dev/null
+          curl -sf "https://pkg.go.dev/github.com/kestra-io/client-sdk/go-sdk/v2@${VERSION}" > /dev/null
 
       - name: Slack notification
         uses: kestra-io/actions/composite/slack-status@main

--- a/.github/workflows/go-sdk-release.yml
+++ b/.github/workflows/go-sdk-release.yml
@@ -16,8 +16,18 @@ jobs:
       - name: Trigger pkg.go.dev indexing
         run: |
           VERSION="${GITHUB_REF_NAME#go-sdk/}"
-          curl -sf "https://proxy.golang.org/github.com/kestra-io/client-sdk/go-sdk/v2/@v/${VERSION}.info" > /dev/null
-          curl -sf "https://pkg.go.dev/github.com/kestra-io/client-sdk/go-sdk/v2@${VERSION}" > /dev/null
+          MAJOR="${VERSION%%.*}"
+          MAJOR="${MAJOR#v}"
+          MODULE="github.com/kestra-io/client-sdk/go-sdk"
+          # v2+ carries the major version in the module path; v0/v1 do not, so
+          # tags cut from the releases/v1.3.x maintenance branch still resolve.
+          if [ "$MAJOR" -ge 2 ]; then
+            MODULE="$MODULE/v$MAJOR"
+          fi
+          curl -sf "https://proxy.golang.org/${MODULE}/@v/${VERSION}.info" > /dev/null
+          # Best effort: a brand-new version may not be indexed yet, and that
+          # must not swallow the Slack announcement below.
+          curl -sf "https://pkg.go.dev/${MODULE}@${VERSION}" > /dev/null || true
 
       - name: Slack notification
         uses: kestra-io/actions/composite/slack-status@main

--- a/README.md
+++ b/README.md
@@ -251,9 +251,9 @@ await new Promise((resolve, reject) =>
 );
 ```
 
-### Go (`github.com/kestra-io/client-sdk/go-sdk`)
+### Go (`github.com/kestra-io/client-sdk/go-sdk/v2`)
 
-- Pull the module into your project with `go get github.com/kestra-io/client-sdk/go-sdk@latest`.
+- Pull the module into your project with `go get github.com/kestra-io/client-sdk/go-sdk/v2@latest`.
 - Build a `KestraClient` with `NewClient`, pointing it at your Kestra host.
 - Authenticate with Basic credentials via `WithBasicAuth`, or with a service-account token via `WithTokenAuth`.
 
@@ -267,7 +267,7 @@ import (
 	"fmt"
 	"log"
 
-	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 )
 
 func main() {

--- a/README_GO_SDK.md
+++ b/README_GO_SDK.md
@@ -63,6 +63,14 @@ Consumers then pull that exact version with:
 go get github.com/kestra-io/client-sdk/go-sdk@v1.1.0
 ```
 
+For a `v2.0.0` and later tag, Go modules require the module path itself to carry
+the major version suffix (`go.mod`'s `module` line becomes
+`github.com/kestra-io/client-sdk/go-sdk/v2`), so the pull command becomes:
+
+```bash
+go get github.com/kestra-io/client-sdk/go-sdk/v2@v2.0.0
+```
+
 On the first request for a new version, `proxy.golang.org` fetches this repo,
 finds the matching tag, zips the source, and caches it immutably (its checksum is
 also recorded in `sum.golang.org`). Nothing is published by CI — the tag *is* the

--- a/go-sdk/go.mod
+++ b/go-sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/kestra-io/client-sdk/go-sdk
+module github.com/kestra-io/client-sdk/go-sdk/v2
 
 go 1.24
 

--- a/go-sdk/kestra_api_client/README.md
+++ b/go-sdk/kestra_api_client/README.md
@@ -23,7 +23,7 @@ go get golang.org/x/net/context
 Put the package under your project folder and add the following in import:
 
 ```go
-import kestra_api_client "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+import kestra_api_client "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 ```
 
 To use a proxy, set the environment variable `HTTP_PROXY`:

--- a/go-sdk/test/api_apps_test.go
+++ b/go-sdk/test/api_apps_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_assets_test.go
+++ b/go-sdk/test/api_assets_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_bindings_test.go
+++ b/go-sdk/test/api_bindings_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_blueprints_test.go
+++ b/go-sdk/test/api_blueprints_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_dashboards_test.go
+++ b/go-sdk/test/api_dashboards_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_executions_test.go
+++ b/go-sdk/test/api_executions_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_files_test.go
+++ b/go-sdk/test/api_files_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_flows_test.go
+++ b/go-sdk/test/api_flows_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_groups_test.go
+++ b/go-sdk/test/api_groups_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_invitations_test.go
+++ b/go-sdk/test/api_invitations_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_kv_test.go
+++ b/go-sdk/test/api_kv_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_logs_test.go
+++ b/go-sdk/test/api_logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_namespaces_test.go
+++ b/go-sdk/test/api_namespaces_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_roles_test.go
+++ b/go-sdk/test/api_roles_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_service_account_test.go
+++ b/go-sdk/test/api_service_account_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_testsuites_test.go
+++ b/go-sdk/test/api_testsuites_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_triggers_test.go
+++ b/go-sdk/test/api_triggers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/test/api_users_test.go
+++ b/go-sdk/test/api_users_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/test/basic_sdk_usage_example.go
+++ b/go-sdk/test/basic_sdk_usage_example.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 )
 
 // The function between the region:flow-lifecycle / endregion markers below is

--- a/go-sdk/test/common_test_setup.go
+++ b/go-sdk/test/common_test_setup.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 )
 
 // StaticFilter injects the signed CSRF token the UI uses into a meta tag.

--- a/go-sdk/test/queryfilters_test.go
+++ b/go-sdk/test/queryfilters_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
## Summary

The `go-sdk/v2.0.0-rc1` tag push failed release CI ([run 33079040023](https://github.com/kestra-io/client-sdk/actions/runs/33079040023), exit 22): `proxy.golang.org` rejects it because `go.mod`'s module path lacked the `/v2` suffix Go requires for major version >= 2.

> not found: ...go-sdk@v2.0.0-rc1: invalid version: module contains a go.mod file, so module path must match major version ("github.com/kestra-io/client-sdk/go-sdk/v2")

This bumps the module path to `github.com/kestra-io/client-sdk/go-sdk/v2` and updates every internal import and doc reference, then makes the release workflow major-aware.

## Strategy: major branch, not major subdirectory

Both are legal per the [module reference](https://go.dev/ref/mod) — "the module subdirectory is the part of the module path that names the directory, **not including the major version suffix**", so `.../go-sdk/v2` may live in either `go-sdk/` or `go-sdk/v2/`.

Keeping it in `go-sdk/` means the tag stays `go-sdk/vX.Y.Z` for both majors. Duplicating into `go-sdk/v2/` would force `go-sdk/v2/v2.0.0` and break the `${GITHUB_REF_NAME#go-sdk/}` strip.

- `main` -> v2 code, module path `.../go-sdk/v2`, tagged `go-sdk/v2.0.0`
- `releases/v1.3.x` -> v1 code, module path unchanged, tagged `go-sdk/v1.3.x`

`releases/v1.3.x` already carries the bare module path and does not contain 138f333c (the breaking Kestra 2.0 commit), so it is ready to cut v1 patches from as-is.

## Release workflow

The indexing URLs now derive the major suffix from the tag rather than hardcoding it, so v1 tags cut from the maintenance branch still resolve (v0/v1 bare, v2+ append `/vN`). The `pkg.go.dev` warm-up is now best effort — an unindexed brand-new version previously failed the job and skipped the Slack announcement.

> [!WARNING]
> Once this merges, a v1.x tag must be cut from `releases/v1.3.x` or an older commit — never from `main`. Tagging `go-sdk/v1.3.1` at a revision whose `go.mod` says `/v2` gets the mirror image of the error above.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean in `go-sdk/`
- [x] Release workflow YAML parses; tag parsing verified for `v1.3.1`, `v2.0.0-rc1`, `v2.0.0`, `v0.9.0`, `v10.1.0` (correct path each, no early exit under `bash -e`)
- [x] `EmbedSnippets --check README.md` exit 0 (the injected Go block carries no import line, so it is unaffected)
- [ ] Re-push a `go-sdk/v2.0.0-rc1` tag after merge and confirm `Announce Go SDK release` succeeds