### PR TITLE
fix(tests): grant tenant access before referencing a user in tenant IAM calls

### DIFF
--- a/go-sdk/kestra_api_client/client.go
+++ b/go-sdk/kestra_api_client/client.go
@@ -170,3 +170,7 @@ func (c *KestraClient) Blueprints() *BlueprintsAPI {
 func (c *KestraClient) Invitations() *InvitationsAPI {
 	return &InvitationsAPI{baseAPI{client: c}}
 }
+
+func (c *KestraClient) TenantAccess() *TenantAccessAPI {
+	return &TenantAccessAPI{baseAPI{client: c}}
+}

--- a/go-sdk/kestra_api_client/tenant_access_api.go
+++ b/go-sdk/kestra_api_client/tenant_access_api.go
@@ -1,0 +1,15 @@
+package kestra_api_client
+
+import "context"
+
+type TenantAccessAPI struct {
+	baseAPI
+}
+
+// CreateTenantAccess grants a user access to the tenant. Users created through
+// POST /api/v1/users exist instance-wide but hold no tenant access, and the
+// tenant-scoped IAM endpoints reject them with 404 "User does not exist" until
+// this is called. The user is identified by email, not id.
+func (a *TenantAccessAPI) CreateTenantAccess(ctx context.Context, tenant string, request interface{}) error {
+	return a.doVoidJSON(ctx, "POST", tenantPath(tenant, "tenant-access"), request, nil)
+}

--- a/go-sdk/test/api_groups_test.go
+++ b/go-sdk/test/api_groups_test.go
@@ -19,11 +19,7 @@ func TestGroupsAPI_All(t *testing.T) {
 		createdGroup, err := KestraTestClient().Groups().CreateGroup(ctx, MAIN_TENANT, groupReq)
 		require.NoError(t, err)
 
-		userReq := map[string]interface{}{
-			"email": "test_add_user_to_group_" + randomId() + "@kestra.io",
-		}
-		createdUser, err := KestraTestClient().Users().CreateUser(ctx, userReq)
-		require.NoError(t, err)
+		createdUser := createTenantUser(ctx, t, "test_add_user_to_group_"+randomId()+"@kestra.io")
 
 		member, err := KestraTestClient().Groups().AddUserToGroup(ctx, createdGroup.GetId(), createdUser.GetId(), MAIN_TENANT)
 		require.NoError(t, err)
@@ -105,11 +101,7 @@ func TestGroupsAPI_All(t *testing.T) {
 		group, err := KestraTestClient().Groups().CreateGroup(ctx, MAIN_TENANT, groupReq)
 		require.NoError(t, err)
 
-		userReq := map[string]interface{}{
-			"email": "test_delete_user_from_group_" + randomId() + "@kestra.io",
-		}
-		user, err := KestraTestClient().Users().CreateUser(ctx, userReq)
-		require.NoError(t, err)
+		user := createTenantUser(ctx, t, "test_delete_user_from_group_"+randomId()+"@kestra.io")
 
 		_, err = KestraTestClient().Groups().AddUserToGroup(ctx, group.GetId(), user.GetId(), MAIN_TENANT)
 		require.NoError(t, err)
@@ -173,11 +165,7 @@ func TestGroupsAPI_All(t *testing.T) {
 		group, err := KestraTestClient().Groups().CreateGroup(ctx, MAIN_TENANT, groupReq)
 		require.NoError(t, err)
 
-		userReq := map[string]interface{}{
-			"email": "test_search_group_members_" + randomId() + "@kestra.io",
-		}
-		user, err := KestraTestClient().Users().CreateUser(ctx, userReq)
-		require.NoError(t, err)
+		user := createTenantUser(ctx, t, "test_search_group_members_"+randomId()+"@kestra.io")
 
 		_, err = KestraTestClient().Groups().AddUserToGroup(ctx, group.GetId(), user.GetId(), MAIN_TENANT)
 		require.NoError(t, err)
@@ -247,11 +235,7 @@ func TestGroupsAPI_All(t *testing.T) {
 		group, err := KestraTestClient().Groups().CreateGroup(ctx, MAIN_TENANT, groupReq)
 		require.NoError(t, err)
 
-		userReq := map[string]interface{}{
-			"email": "test_set_user_membership_for_group_" + randomId() + "@kestra.io",
-		}
-		user, err := KestraTestClient().Users().CreateUser(ctx, userReq)
-		require.NoError(t, err)
+		user := createTenantUser(ctx, t, "test_set_user_membership_for_group_"+randomId()+"@kestra.io")
 
 		_, err = KestraTestClient().Groups().AddUserToGroup(ctx, group.GetId(), user.GetId(), MAIN_TENANT)
 		require.NoError(t, err)

--- a/go-sdk/test/api_users_test.go
+++ b/go-sdk/test/api_users_test.go
@@ -19,12 +19,7 @@ func TestUsersAPI_All(t *testing.T) {
 
 		// Create user
 		email := "test_autocomplete_users_" + randomId() + "@kestra.io"
-		userReq := map[string]interface{}{
-			"email": email,
-		}
-		createdUser, err := KestraTestClient().Users().CreateUser(ctx, userReq)
-		require.NoError(t, err)
-		require.NotNil(t, createdUser)
+		createdUser := createTenantUser(ctx, t, email)
 
 		// Create group and add user
 		groupReq := map[string]interface{}{

--- a/go-sdk/test/common_test_setup.go
+++ b/go-sdk/test/common_test_setup.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -14,9 +15,11 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+	"github.com/stretchr/testify/require"
 )
 
 // StaticFilter injects the signed CSRF token the UI uses into a meta tag.
@@ -249,4 +252,21 @@ func get(filePath string) string {
 		panic(err)
 	}
 	return string(b)
+}
+
+// createTenantUser creates an instance-wide user and grants it access to tenant.
+// Both steps are required before the user can be referenced by the tenant-scoped
+// IAM endpoints (group members, autocomplete), which otherwise reject it with
+// 404 "User does not exist for id".
+func createTenantUser(ctx context.Context, t *testing.T, email string) *kestra_api_client.IAMUserControllerApiUser {
+	t.Helper()
+
+	user, err := KestraTestClient().Users().CreateUser(ctx, map[string]interface{}{"email": email})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+
+	err = KestraTestClient().TenantAccess().CreateTenantAccess(ctx, MAIN_TENANT, map[string]interface{}{"email": email})
+	require.NoError(t, err)
+
+	return user
 }

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/GroupsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/GroupsApiTest.java
@@ -244,13 +244,23 @@ public class GroupsApiTest {
     }
 
     static IAMUserControllerApiUser createTestUser() throws ApiException {
+        String email = "grp-" + randomId() + "@test.com";
         IAMUserControllerApiCreateOrUpdateUserRequest request =
                 new IAMUserControllerApiCreateOrUpdateUserRequest()
-                        .email("grp-" + randomId() + "@test.com")
+                        .email(email)
                         .firstName("Group")
                         .lastName("Member")
                         .password("TestPass!1234");
-        return usersApi().createUser(request);
+        IAMUserControllerApiUser user = usersApi().createUser(request);
+
+        // Users created through /api/v1/users exist instance-wide but hold no tenant
+        // access, and the tenant-scoped group endpoints reject them with 404
+        // "User does not exist for id" until it is granted.
+        client().tenantAccess().createTenantAccess(
+                TENANT,
+                new IAMTenantAccessControllerApiCreateTenantAccessRequest().email(email));
+
+        return user;
     }
 
     @Test

--- a/python/python-sdk/kestrapy/__init__.py
+++ b/python/python-sdk/kestrapy/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "FlowsApi",
     "GroupsApi",
     "InvitationsApi",
+    "TenantAccessApi",
     "KVApi",
     "LogsApi",
     "NamespacesApi",
@@ -449,6 +450,7 @@ from kestrapy.api.files_api import FilesApi as FilesApi
 from kestrapy.api.flows_api import FlowsApi as FlowsApi
 from kestrapy.api.groups_api import GroupsApi as GroupsApi
 from kestrapy.api.invitations_api import InvitationsApi as InvitationsApi
+from kestrapy.api.tenant_access_api import TenantAccessApi as TenantAccessApi
 from kestrapy.api.kv_api import KVApi as KVApi
 from kestrapy.api.logs_api import LogsApi as LogsApi
 from kestrapy.api.namespaces_api import NamespacesApi as NamespacesApi

--- a/python/python-sdk/kestrapy/api/__init__.py
+++ b/python/python-sdk/kestrapy/api/__init__.py
@@ -10,6 +10,7 @@ from kestrapy.api.files_api import FilesApi
 from kestrapy.api.flows_api import FlowsApi
 from kestrapy.api.groups_api import GroupsApi
 from kestrapy.api.invitations_api import InvitationsApi
+from kestrapy.api.tenant_access_api import TenantAccessApi
 from kestrapy.api.kv_api import KVApi
 from kestrapy.api.logs_api import LogsApi
 from kestrapy.api.namespaces_api import NamespacesApi

--- a/python/python-sdk/kestrapy/api/tenant_access_api.py
+++ b/python/python-sdk/kestrapy/api/tenant_access_api.py
@@ -1,0 +1,20 @@
+from kestrapy.base_api import BaseApi
+from kestrapy.models.iam_tenant_access_controller_api_create_tenant_access_request import IAMTenantAccessControllerApiCreateTenantAccessRequest
+
+
+class TenantAccessApi(BaseApi):
+
+    def create_tenant_access(
+        self,
+        tenant: str,
+        request: IAMTenantAccessControllerApiCreateTenantAccessRequest,
+    ) -> None:
+        """Grant a user access to the tenant.
+
+        Users created through POST /api/v1/users exist instance-wide but hold no
+        tenant access, and the tenant-scoped IAM endpoints reject them with
+        404 "User does not exist" until this is called. The user is identified by
+        email, not id.
+        """
+        path = self._tenant_path(tenant, "tenant-access")
+        self._void_request("POST", path, body=request, content_type=self.JSON)

--- a/python/python-sdk/kestrapy/kestra_client.py
+++ b/python/python-sdk/kestrapy/kestra_client.py
@@ -12,6 +12,7 @@ from kestrapy.api.triggers_api import TriggersApi
 from kestrapy.api.flows_api import FlowsApi
 from kestrapy.api.executions_api import ExecutionsApi
 from kestrapy.api.invitations_api import InvitationsApi
+from kestrapy.api.tenant_access_api import TenantAccessApi
 from kestrapy.api.logs_api import LogsApi
 from kestrapy.api.files_api import FilesApi
 from kestrapy.api.assets_api import AssetsApi
@@ -93,6 +94,8 @@ class KestraClient:
     def service_account(self): return self._get_api(ServiceAccountApi)
     @property
     def invitations(self): return self._get_api(InvitationsApi)
+    @property
+    def tenant_access(self): return self._get_api(TenantAccessApi)
 
     def close(self):
         self._session.close()

--- a/python/python-sdk/testApis/test_groups_api.py
+++ b/python/python-sdk/testApis/test_groups_api.py
@@ -4,6 +4,7 @@ from kestrapy import (
     IAMGroupControllerApiCreateGroupRequest,
     IAMGroupControllerApiUpdateGroupRequest,
     IAMUserControllerApiCreateOrUpdateUserRequest,
+    IAMTenantAccessControllerApiCreateTenantAccessRequest,
     ApiAutocomplete,
     ApiIds,
     GroupIdentifierMembership,
@@ -25,13 +26,24 @@ def create_test_group(client, name):
 
 
 def create_test_user(client):
+    email = "grp-" + random_id() + "@test.com"
     request = IAMUserControllerApiCreateOrUpdateUserRequest(
-        email="grp-" + random_id() + "@test.com",
+        email=email,
         first_name="Group",
         last_name="Member",
         password="TestPass!1234",
     )
-    return client.users.create_user(request)
+    user = client.users.create_user(request)
+
+    # Users created through /api/v1/users exist instance-wide but hold no tenant
+    # access, and the tenant-scoped group endpoints reject them with 404
+    # "User does not exist for id" until it is granted.
+    client.tenant_access.create_tenant_access(
+        TENANT,
+        IAMTenantAccessControllerApiCreateTenantAccessRequest(email=email),
+    )
+
+    return user
 
 
 # ========================================================================


### PR DESCRIPTION
## Summary

Group-membership tests started failing against the Kestra 2.0 `develop` image with:

> `404 Not Found: User does not exist for id '4LeYKUcqzLlRGlnKAzeqvF'`
> on `/api/v1/main/groups/{groupId}/members/{userId}`

A user created through `POST /api/v1/users` exists **instance-wide but holds no tenant access**, and the tenant-scoped IAM endpoints reject it until access is granted. The spec is explicit about the missing step:

> `POST /api/v1/{tenant}/tenant-access` — "Grants tenant access permissions to a user identified by email" (404 *User not found*, 409 *User already has access*)

So the tests need `createUser` -> `createTenantAccess` -> `addUserToGroup`.

## Not caused by the `/v2` module bump

The Java suite failed at **15:08** with the identical error — nine minutes **before** the Go `/v2` merge at 15:17 — and both suites were green at 10:59. CI targets `kestra-ee:${KESTRA_VERSION}-no-plugins` with `KESTRA_VERSION=develop`, a moving tag, so the server changed under both SDKs between those runs.

| Run | Suite | Result |
|---|---|---|
| [33065429936](https://github.com/kestra-io/client-sdk/actions/runs/33065429936) 10:59 | Go | pass |
| [33086170105](https://github.com/kestra-io/client-sdk/actions/runs/33086170105) 15:08 | Java | **fail** (pre-`/v2`) |
| [33087034912](https://github.com/kestra-io/client-sdk/actions/runs/33087034912) 15:17 | Go | **fail** |

## Changes

- **Go** — add `TenantAccessAPI` + `KestraClient.TenantAccess()`; add a `createTenantUser` test helper and use it at the 5 affected call sites.
- **Java** — grant tenant access in `GroupsApiTest.createTestUser()`, which all 7 call sites share. `TenantAccessApi` already existed.
- **Python** — add `TenantAccessApi` + `client.tenant_access`; grant access in `create_test_user`.

The tenant-access **models** were already generated in every SDK; only the API class and client accessor were missing in Go and Python. Only `createTenantAccess` is added — `get`/`list`/`delete` exist in the spec but nothing needs them yet.

## Why Python is included

Its group tests follow the same create-user-then-add-to-group shape and have not run since the server changed (last run 2026-07-31), so they would fail on their next execution.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] Java `compileTestJava` passes against the locally published SDK
- [x] Python `py_compile` clean; `IAMTenantAccessControllerApiCreateTenantAccessRequest` confirmed exported from `kestrapy`
- [ ] CI green on Go + Java (needs the live EE container — not reproducible locally)

> [!NOTE]
> **JavaScript is not covered here.** `javascript/test_javascript_sdk/GroupsApi.spec.ts` and `UsersApi.spec.ts` have the same create-user-then-add-to-group shape and will likely break the same way, but its SDK source under `src/openapi/` is generated and not checked in, so the generated `TenantAccess` call shape could not be verified locally. Worth a follow-up.

> [!WARNING]
> This adapts the SDKs to the server's current behaviour. If the tenant-access requirement on these endpoints was **not** an intentional 2.0 change, the real fix belongs in `kestra-ee` and this should be reverted — worth a quick confirmation with the backend team, since the behaviour changed within a few hours today.