### PR TITLE
test(java,go): grant tenant access before adding a user to a group

### DIFF
--- a/go-sdk/test/api_groups_test.go
+++ b/go-sdk/test/api_groups_test.go
@@ -21,6 +21,8 @@ func TestGroupsAPI_All(t *testing.T) {
 
 		userReq := map[string]interface{}{
 			"email": "test_add_user_to_group_" + randomId() + "@kestra.io",
+			// 2.0: adding a user to a group no longer auto-grants tenant access
+			"tenants": []string{MAIN_TENANT},
 		}
 		createdUser, err := KestraTestClient().Users().CreateUser(ctx, userReq)
 		require.NoError(t, err)
@@ -107,6 +109,8 @@ func TestGroupsAPI_All(t *testing.T) {
 
 		userReq := map[string]interface{}{
 			"email": "test_delete_user_from_group_" + randomId() + "@kestra.io",
+			// 2.0: adding a user to a group no longer auto-grants tenant access
+			"tenants": []string{MAIN_TENANT},
 		}
 		user, err := KestraTestClient().Users().CreateUser(ctx, userReq)
 		require.NoError(t, err)
@@ -175,6 +179,8 @@ func TestGroupsAPI_All(t *testing.T) {
 
 		userReq := map[string]interface{}{
 			"email": "test_search_group_members_" + randomId() + "@kestra.io",
+			// 2.0: adding a user to a group no longer auto-grants tenant access
+			"tenants": []string{MAIN_TENANT},
 		}
 		user, err := KestraTestClient().Users().CreateUser(ctx, userReq)
 		require.NoError(t, err)
@@ -249,6 +255,8 @@ func TestGroupsAPI_All(t *testing.T) {
 
 		userReq := map[string]interface{}{
 			"email": "test_set_user_membership_for_group_" + randomId() + "@kestra.io",
+			// 2.0: adding a user to a group no longer auto-grants tenant access
+			"tenants": []string{MAIN_TENANT},
 		}
 		user, err := KestraTestClient().Users().CreateUser(ctx, userReq)
 		require.NoError(t, err)

--- a/go-sdk/test/api_users_test.go
+++ b/go-sdk/test/api_users_test.go
@@ -21,6 +21,8 @@ func TestUsersAPI_All(t *testing.T) {
 		email := "test_autocomplete_users_" + randomId() + "@kestra.io"
 		userReq := map[string]interface{}{
 			"email": email,
+			// 2.0: adding a user to a group no longer auto-grants tenant access
+			"tenants": []string{MAIN_TENANT},
 		}
 		createdUser, err := KestraTestClient().Users().CreateUser(ctx, userReq)
 		require.NoError(t, err)

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/GroupsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/GroupsApiTest.java
@@ -246,6 +246,8 @@ public class GroupsApiTest {
     static IAMUserControllerApiUser createTestUser() throws ApiException {
         IAMUserControllerApiCreateOrUpdateUserRequest request =
                 new IAMUserControllerApiCreateOrUpdateUserRequest()
+                        // 2.0: adding a user to a group no longer auto-grants tenant access
+                        .tenants(List.of(TENANT))
                         .email("grp-" + randomId() + "@test.com")
                         .firstName("Group")
                         .lastName("Member")


### PR DESCRIPTION
Fixes main, red on both the Java and Go jobs since kestra-ee [#10493](https://github.com/kestra-io/kestra-ee/pull/10493) merged.

## Cause

Not an SDK regression. #10493 rewrote `IAMGroupController.addUserToGroup` to resolve the user through a new filter:

```java
private String resolveTenantUserId(final String tenantId, final String idOrUsername) {
    return userRepository.findById(value)
        .or(() -> userRepository.findByUsername(value))
        .map(User::getId)
        .filter(resolvedId -> rbacService.hasTenantAccess(tenantId, resolvedId))  // new
        .orElseThrow(() -> new UserNotFoundException(value));
}
```

The same commit rewrote the endpoint's own description, which states the change plainly:

- before — *"If the user does not already have access to the tenant, tenant access will be created automatically."*
- after — *"The user must already have access to the tenant."*

Both suites create a user with no tenants and then add it to a group, so all five call sites now 404.

## Verification

Same SDK code (`27ec2b7d`), two servers:

| Server | Java `GroupsApiTest` | Go groups + users |
|---|---|---|
| `v2.0.0-rc11` | 20 passed | passed |
| `develop` | 4 failed | 5 failed |

With this patch, against `develop`: full Java suite green (427 tests), full Go suite green. Reverting just the Go hunks reproduces exactly the 5 failures, so the change is causally the fix and not a fresh-container artifact.

## Two things worth a look, outside this PR

1. **This is a breaking API change shipped as a `fix:`.** Auto-provisioning tenant access on group-add was documented behaviour; a 1.x client relying on it now gets a 404. The new behaviour may well be correct — granting tenant access as a side effect of a group operation is surprising — but it belongs in the 2.0 breaking-change notes.

2. **The error is misleading.** `UserNotFoundException` renders as `"User does not exist for id '<id>'"`, but the user does exist and is fetched successfully one line earlier; it just lacks tenant access. A 403 with a cause, or at least a distinct message, would point at the real problem.