### PR TITLE
refactor(javascript): move the SDK barrel off the root entry onto /all

### DIFF
--- a/README_JAVASCRIPT_SDK.md
+++ b/README_JAVASCRIPT_SDK.md
@@ -15,6 +15,18 @@ npm install @kestra-io/kestra-sdk
 
 The SDK is organized into domain-specific modules (e.g. `flows`, `executions`, `apps`, `plugins`). Import only the modules you need to keep your bundle lean and benefit from tree-shaking.
 
+### Entry points
+
+| Import | Contents |
+| --- | --- |
+| `@kestra-io/kestra-sdk` | `useClient` / `configureClient` / `setMockClient`, and every generated **type** |
+| `@kestra-io/kestra-sdk/client` | the shared HTTP client |
+| `@kestra-io/kestra-sdk/<module>` | the operations of one module, e.g. `/flows`, `/executions` |
+| `@kestra-io/kestra-sdk/all` | every operation at once — named exports, plus the namespace as `default` |
+
+The root entry exports no operations. Reach an operation through its module (the tree-shakeable
+form used throughout this guide), or through `/all` if one import is preferable to several.
+
 ### Configure the client
 
 Import and configure the shared HTTP client once, at the entry point of your application:

--- a/javascript/javascript-sdk/package.json
+++ b/javascript/javascript-sdk/package.json
@@ -12,6 +12,7 @@
     ".": "./dist/index.js",
     "./ai": "./dist/ai.js",
     "./ai-admin": "./dist/ai-admin.js",
+    "./all": "./dist/all.js",
     "./apps": "./dist/apps.js",
     "./assets": "./dist/assets.js",
     "./audit-logs": "./dist/audit-logs.js",

--- a/javascript/javascript-sdk/src/all.ts
+++ b/javascript/javascript-sdk/src/all.ts
@@ -1,0 +1,8 @@
+// The whole generated API surface behind one specifier, for consumers who prefer a single import
+// over the per-tag subpaths. This is the only place the barrel lives: the root entry exports the
+// client facade and the generated types, keeping the three Kestra SDKs (this one and the in-repo
+// OSS/EE UI SDKs) on the same entry-point shape.
+import * as sdk from "./openapi/index"
+
+export * from "./openapi/index"
+export default sdk

--- a/javascript/javascript-sdk/src/all.ts
+++ b/javascript/javascript-sdk/src/all.ts
@@ -1,7 +1,5 @@
-// The whole generated API surface behind one specifier, for consumers who prefer a single import
-// over the per-tag subpaths. This is the only place the barrel lives: the root entry exports the
-// client facade and the generated types, keeping the three Kestra SDKs (this one and the in-repo
-// OSS/EE UI SDKs) on the same entry-point shape.
+// The whole generated API surface behind one specifier, matching the in-repo OSS/EE UI SDKs
+// where the root entry cannot carry it (module federation pins a share's whole export surface).
 import * as sdk from "./openapi/index"
 
 export * from "./openapi/index"

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -3,7 +3,9 @@ import { formDataBodySerializer } from "./openapi/client"
 import type { ResolvedRequestOptions } from "./openapi/client"
 import { createConfigureClient } from "@kestra-io/hey-api-plugin/runtime"
 
-export * from "./openapi/index"
+// Types only. The generated operations live on their per-tag subpaths, or all together on
+// `@kestra-io/kestra-sdk/all`.
+export type * from "./openapi/types.gen"
 
 declare global {
     interface Window {

--- a/javascript/javascript-sdk/src/index.ts
+++ b/javascript/javascript-sdk/src/index.ts
@@ -3,8 +3,7 @@ import { formDataBodySerializer } from "./openapi/client"
 import type { ResolvedRequestOptions } from "./openapi/client"
 import { createConfigureClient } from "@kestra-io/hey-api-plugin/runtime"
 
-// Types only. The generated operations live on their per-tag subpaths, or all together on
-// `@kestra-io/kestra-sdk/all`.
+// Types only: the operations live on their per-tag subpaths, or all together on `./all`.
 export type * from "./openapi/types.gen"
 
 declare global {

--- a/javascript/javascript-sdk/tsdown.config.ts
+++ b/javascript/javascript-sdk/tsdown.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     platform: "browser",
     entry: {
         "index": "src/index.ts",
+        "all": "src/all.ts",
         "client": "src/openapi/client.gen.ts",
         ...sdkEntries,
     },

--- a/javascript/test_javascript_sdk/GroupsApi.spec.ts
+++ b/javascript/test_javascript_sdk/GroupsApi.spec.ts
@@ -1,6 +1,7 @@
 // testApis/GroupsApi.spec.ts
 import { describe, it, expect } from 'vitest';
 import { randomId } from './_utils.js';
+import { tenantId } from './_setup.js';
 import * as Groups from '@kestra-io/kestra-sdk/groups';
 import * as Users from '@kestra-io/kestra-sdk/users';
 import type { QueryFilter, QueryFilterField, QueryFilterOp } from '@kestra-io/kestra-sdk';
@@ -23,6 +24,8 @@ describe('GroupsApi', () => {
 
         const user = await Users.createUser({
             email: `test_add_user_to_group_${randomId()}@kestra.io`,
+            // 2.0: adding a user to a group no longer auto-grants tenant access
+            tenants: [tenantId],
         });
 
         if (!group.id || !user.id) {
@@ -87,6 +90,8 @@ describe('GroupsApi', () => {
 
         const user = await Users.createUser({
             email: `test_delete_user_from_group_${randomId()}@kestra.io`,
+            // 2.0: adding a user to a group no longer auto-grants tenant access
+            tenants: [tenantId],
         });
 
         if (!group.id || !user.id) {
@@ -140,6 +145,8 @@ describe('GroupsApi', () => {
 
         const user = await Users.createUser({
             email: `test_search_group_members_${randomId()}@kestra.io`,
+            // 2.0: adding a user to a group no longer auto-grants tenant access
+            tenants: [tenantId],
         });
 
         if (!group.id || !user.id) {
@@ -184,6 +191,8 @@ describe('GroupsApi', () => {
 
         const user = await Users.createUser({
             email: `test_set_user_membership_for_group_${randomId()}@kestra.io`,
+            // 2.0: adding a user to a group no longer auto-grants tenant access
+            tenants: [tenantId],
         });
 
         if (!group.id || !user.id) {

--- a/javascript/test_javascript_sdk/UsersApi.spec.ts
+++ b/javascript/test_javascript_sdk/UsersApi.spec.ts
@@ -12,6 +12,8 @@ describe('UsersApi', () => {
         // create user
         const createdUser = await Users.createUser({
             email,
+            // 2.0: adding a user to a group no longer auto-grants tenant access
+            tenants: [tenantId],
         });
 
         // create group to grant tenant access, then add user to group


### PR DESCRIPTION
### What changes are being made and why?

Puts this SDK on the same entry-point shape as the in-repo OSS/EE UI SDKs, which had to make this split for a build reason: their root entry is a module-federation share, so MF pins every name it exports and re-exporting the operations there held all per-tag modules in the host's initial graph (~228 KB). That constraint doesn't apply here — this package is plain npm and consumers tree-shake normally — so this is for consistency: the same import should work whichever SDK you're holding.

- Root entry: client facade (`useClient` / `configureClient` / `setMockClient`) + generated **types** only.
- New `@kestra-io/kestra-sdk/all`: every operation — named exports, plus the namespace as `default`.
- `README_JAVASCRIPT_SDK.md` gains an entry-point table.

**BREAKING CHANGE:** no operations on the package root. Use its module subpath (`@kestra-io/kestra-sdk/flows`) — the only form this guide documents — or `/all` for a one-line migration. Types, `/client` and per-module entries unaffected. This is the published SDK, so it wants a major version.

Also carries `08f7e0e`: the JavaScript half of #397, ported to unblock CI here. Kestra 2.0 stopped auto-granting tenant access on group add, so 5 tests failed with `404 User does not exist` — unrelated to this PR, and a no-op once #397 lands.

---

### How the changes have been QAed?

Regenerated from the committed spec, then `npm run build`, `npm run check:types` and CI's own suite — all green. Loading the built `dist/`: root exposes exactly the 3 client functions and no operation; `/all` exposes 1188 named exports and its `default` is the namespace. `tsdown`'s `exports: true` regenerated `package.json` with `"./all"`; that's included.

Unrelated: `npm run typecheck` in `javascript-sdk` is broken on `main` — it calls `vue-tsc`, which the package doesn't install. Worth a separate fix.

---

### Setup Instructions

None.

## Related PRs

- [kestra-io/kestra#18754](https://github.com/kestra-io/kestra/pull/18754) — OSS UI SDK split, plus two unrelated warning fixes
- [kestra-io/kestra-ee#10528](https://github.com/kestra-io/kestra-ee/pull/10528) — EE UI SDK split and the federation share config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvrhcR8x2kPEDVaf1E6XJS