### PR TITLE
feat(go): bind the tenant-access API

### DIFF
--- a/go-sdk/kestra_api_client/client.go
+++ b/go-sdk/kestra_api_client/client.go
@@ -127,6 +127,10 @@ func (c *KestraClient) Triggers() *TriggersAPI {
 	return &TriggersAPI{baseAPI{client: c}}
 }
 
+func (c *KestraClient) TenantAccess() *TenantAccessAPI {
+	return &TenantAccessAPI{baseAPI{client: c}}
+}
+
 func (c *KestraClient) Users() *UsersAPI {
 	return &UsersAPI{baseAPI{client: c}}
 }

--- a/go-sdk/kestra_api_client/tenant_access_api.go
+++ b/go-sdk/kestra_api_client/tenant_access_api.go
@@ -1,0 +1,47 @@
+package kestra_api_client
+
+import "context"
+
+// TenantAccessAPI covers /api/v1/{tenant}/tenant-access.
+//
+// Since Kestra 2.0 tenant access is a prerequisite rather than something granted
+// as a side effect: adding a user to a group resolves the user through a
+// hasTenantAccess filter and rejects it otherwise, so the access has to be
+// granted first through one of the Create calls here.
+type TenantAccessAPI struct {
+	baseAPI
+}
+
+// ListTenantAccess returns the users that can reach the tenant.
+func (a *TenantAccessAPI) ListTenantAccess(ctx context.Context, tenant string, page, size *int, sort []string, filters []SearchFilter) (*PagedResultsIAMTenantAccessControllerApiUserTenantAccess, error) {
+	params := buildQueryParams("page", page, "size", size)
+	appendRepeatedParam(params, "sort", sort)
+	appendFilterParams(params, filters)
+	return doJSON[*PagedResultsIAMTenantAccessControllerApiUserTenantAccess](&a.baseAPI, ctx, "GET", tenantPath(tenant, "tenant-access"), nil, params)
+}
+
+// TenantAccess returns one user's access to the tenant.
+func (a *TenantAccessAPI) TenantAccess(ctx context.Context, userId, tenant string) (*IAMTenantAccessControllerApiTenantAccess, error) {
+	return doJSON[*IAMTenantAccessControllerApiTenantAccess](&a.baseAPI, ctx, "GET", tenantPath(tenant, "tenant-access", userId), nil, nil)
+}
+
+// CreateTenantAccess grants access by user id. The server answers 201 with no body.
+func (a *TenantAccessAPI) CreateTenantAccess(ctx context.Context, userId, tenant string) error {
+	return a.doVoidJSON(ctx, "PUT", tenantPath(tenant, "tenant-access", userId), nil, nil)
+}
+
+// CreateTenantAccessByEmail grants access by email. The server answers 204 with no
+// body, and 409 when the user already has access to the tenant.
+func (a *TenantAccessAPI) CreateTenantAccessByEmail(ctx context.Context, tenant string, request interface{}) error {
+	return a.doVoidJSON(ctx, "POST", tenantPath(tenant, "tenant-access"), request, nil)
+}
+
+// DeleteTenantAccess revokes a user's access to the tenant.
+func (a *TenantAccessAPI) DeleteTenantAccess(ctx context.Context, userId, tenant string) error {
+	return a.doVoidJSON(ctx, "DELETE", tenantPath(tenant, "tenant-access", userId), nil, nil)
+}
+
+// AutocompleteTenantAccess resolves users reachable from the tenant.
+func (a *TenantAccessAPI) AutocompleteTenantAccess(ctx context.Context, tenant string, request interface{}) ([]IAMTenantAccessControllerApiUserTenantAccess, error) {
+	return doJSON[[]IAMTenantAccessControllerApiUserTenantAccess](&a.baseAPI, ctx, "POST", tenantPath(tenant, "tenant-access", "autocomplete"), request, nil)
+}

--- a/go-sdk/test/api_tenant_access_test.go
+++ b/go-sdk/test/api_tenant_access_test.go
@@ -1,0 +1,111 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantAccessAPI_All(t *testing.T) {
+	// A user created without tenants has no access to the tenant, which is the
+	// state the grant has to fix.
+	createUserWithoutTenantAccess := func(t *testing.T, ctx context.Context, prefix string) string {
+		t.Helper()
+		created, err := KestraTestClient().Users().CreateUser(ctx, map[string]interface{}{
+			"email": prefix + randomId() + "@kestra.io",
+		})
+		require.NoError(t, err)
+		return created.GetId()
+	}
+
+	t.Run("createTenantAccessByIdTest", func(t *testing.T) {
+		ctx := context.Background()
+		userId := createUserWithoutTenantAccess(t, ctx, "test_tenant_access_")
+
+		require.NoError(t, KestraTestClient().TenantAccess().CreateTenantAccess(ctx, userId, MAIN_TENANT))
+
+		access, err := KestraTestClient().TenantAccess().TenantAccess(ctx, userId, MAIN_TENANT)
+		require.NoError(t, err)
+		require.NotNil(t, access)
+
+		require.NoError(t, KestraTestClient().Users().DeleteUser(ctx, userId))
+	})
+
+	t.Run("createTenantAccessByEmailTest", func(t *testing.T) {
+		ctx := context.Background()
+		email := "test_tenant_access_email_" + randomId() + "@kestra.io"
+		created, err := KestraTestClient().Users().CreateUser(ctx, map[string]interface{}{"email": email})
+		require.NoError(t, err)
+
+		require.NoError(t, KestraTestClient().TenantAccess().CreateTenantAccessByEmail(ctx, MAIN_TENANT,
+			map[string]interface{}{"email": email}))
+
+		access, err := KestraTestClient().TenantAccess().TenantAccess(ctx, created.GetId(), MAIN_TENANT)
+		require.NoError(t, err)
+		require.NotNil(t, access)
+
+		require.NoError(t, KestraTestClient().Users().DeleteUser(ctx, created.GetId()))
+	})
+
+	t.Run("listTenantAccessTest", func(t *testing.T) {
+		ctx := context.Background()
+		userId := createUserWithoutTenantAccess(t, ctx, "test_tenant_access_list_")
+		require.NoError(t, KestraTestClient().TenantAccess().CreateTenantAccess(ctx, userId, MAIN_TENANT))
+
+		page, size := 1, 100
+		results, err := KestraTestClient().TenantAccess().ListTenantAccess(ctx, MAIN_TENANT, &page, &size, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, results)
+
+		found := false
+		for _, item := range results.GetResults() {
+			if item.GetId() == userId {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "the granted user should be listed as having tenant access")
+
+		require.NoError(t, KestraTestClient().Users().DeleteUser(ctx, userId))
+	})
+
+	t.Run("deleteTenantAccessTest", func(t *testing.T) {
+		ctx := context.Background()
+		userId := createUserWithoutTenantAccess(t, ctx, "test_tenant_access_delete_")
+		require.NoError(t, KestraTestClient().TenantAccess().CreateTenantAccess(ctx, userId, MAIN_TENANT))
+
+		require.NoError(t, KestraTestClient().TenantAccess().DeleteTenantAccess(ctx, userId, MAIN_TENANT))
+
+		_, err := KestraTestClient().TenantAccess().TenantAccess(ctx, userId, MAIN_TENANT)
+		assert.Error(t, err, "the access should be gone once revoked")
+
+		require.NoError(t, KestraTestClient().Users().DeleteUser(ctx, userId))
+	})
+
+	// The reason this API matters: since Kestra 2.0 a group add resolves the user
+	// through a hasTenantAccess filter, so granting access first is what makes it
+	// work for a user created without tenants.
+	t.Run("grantThenAddToGroupTest", func(t *testing.T) {
+		ctx := context.Background()
+		userId := createUserWithoutTenantAccess(t, ctx, "test_tenant_access_group_")
+
+		group, err := KestraTestClient().Groups().CreateGroup(ctx, MAIN_TENANT, map[string]interface{}{
+			"name": "test_tenant_access_group_" + randomId(),
+		})
+		require.NoError(t, err)
+
+		_, err = KestraTestClient().Groups().AddUserToGroup(ctx, group.GetId(), userId, MAIN_TENANT)
+		require.Error(t, err, "without tenant access the group add is rejected")
+
+		require.NoError(t, KestraTestClient().TenantAccess().CreateTenantAccess(ctx, userId, MAIN_TENANT))
+
+		member, err := KestraTestClient().Groups().AddUserToGroup(ctx, group.GetId(), userId, MAIN_TENANT)
+		require.NoError(t, err, "the group add should succeed once tenant access is granted")
+		require.NotNil(t, member)
+
+		require.NoError(t, KestraTestClient().Groups().DeleteGroup(ctx, group.GetId(), MAIN_TENANT))
+		require.NoError(t, KestraTestClient().Users().DeleteUser(ctx, userId))
+	})
+}


### PR DESCRIPTION
Closes #398.

## Why

Only `POST /tenant-access/autocomplete` was reachable. The CRUD under `/api/v1/{tenant}/tenant-access` had **no bindings at all**, even though every model was already generated (`IAMTenantAccessControllerApiTenantAccess`, `...ApiUserTenantAccess`, `...ApiCreateTenantAccessRequest`, `PagedResults...`).

Kestra 2.0 made tenant access a prerequisite rather than something granted as a side effect — kestra-ee [#10493](https://github.com/kestra-io/kestra-ee/pull/10493) changed `addUserToGroup` to resolve the user through a `hasTenantAccess` filter and reject it otherwise. Callers have to grant access first, and the Go SDK gave them no way to.

This is also what blocks a `kestra_tenant_access` resource in the Terraform provider, which is why `TestAccUserGroupMembership` is currently skipped there (kestra-io/terraform-provider-kestra#289): `kestra_user` has no `tenants` attribute and there's no tenant-access resource, so the provider cannot express the grant at all.

## What

`TenantAccessAPI`, wired as `KestraClient.TenantAccess()`:

| Method | Call |
|---|---|
| `GET /` | `ListTenantAccess(ctx, tenant, page, size, sort, filters)` |
| `GET /{userId}` | `TenantAccess(ctx, userId, tenant)` |
| `PUT /{userId}` | `CreateTenantAccess(ctx, userId, tenant)` — 201, no body |
| `POST /` | `CreateTenantAccessByEmail(ctx, tenant, request)` — 204, 409 if already granted |
| `DELETE /{userId}` | `DeleteTenantAccess(ctx, userId, tenant)` |
| `POST /autocomplete` | `AutocompleteTenantAccess(ctx, tenant, request)` |

No model changes were needed.

## Tests

Five subtests, all passing against a live `develop` instance:

```
--- PASS: TestTenantAccessAPI_All/createTenantAccessByIdTest
--- PASS: TestTenantAccessAPI_All/createTenantAccessByEmailTest
--- PASS: TestTenantAccessAPI_All/listTenantAccessTest
--- PASS: TestTenantAccessAPI_All/deleteTenantAccessTest
--- PASS: TestTenantAccessAPI_All/grantThenAddToGroupTest
```

The last one pins the reason the API exists rather than just exercising it: a group add for a user created **without** `tenants` is rejected, then succeeds once the access is granted. It would fail if the grant were a no-op.

## Follow-ups

- The Java SDK has the same gap and should get the equivalent binding.
- `kestra_tenant_access` in the Terraform provider, which unskips `TestAccUserGroupMembership`.