### PR TITLE
fix(javascript): pass npm --tag when publishing a prerelease version

### DIFF
--- a/.github/workflows/javascript-sdk.yml
+++ b/.github/workflows/javascript-sdk.yml
@@ -212,9 +212,20 @@ jobs:
           ./generate-sdks.sh ${{ steps.resolveVersion.outputs.kestra_version }} \
           javascript
 
-      - name: Publish to npm with latest tag
+      - name: Publish to npm
         working-directory: ./javascript/javascript-sdk
-        run: npm publish --access public
+        # npm refuses a bare `publish` for a prerelease version (e.g. `-rc1`) —
+        # it won't guess whether that should move the `latest` dist-tag, so an
+        # explicit --tag is required. Stable versions still get `latest`;
+        # prereleases get a tag matching their prerelease identifier (e.g. `rc1`).
+        run: |
+          VERSION="${{ steps.resolveVersion.outputs.kestra_version }}"
+          if [[ "$VERSION" == *-* ]]; then
+            NPM_TAG="${VERSION#*-}"
+          else
+            NPM_TAG="latest"
+          fi
+          npm publish --access public --tag "$NPM_TAG"
 
       - name: Add version tag
         working-directory: ./javascript/javascript-sdk


### PR DESCRIPTION
npm refuses a bare `npm publish` for a prerelease version (e.g. 2.0.0-rc1) since it won't guess whether it should move the `latest` dist-tag. This broke the v2.0.0-rc1-javascript release
(https://github.com/kestra-io/client-sdk/actions/runs/33391404074).

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
