### PR TITLE
feat(java): bind the two missing tenant-access operations

### DIFF
--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/TenantAccessApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/TenantAccessApiTest.java
@@ -18,6 +18,10 @@ public class TenantAccessApiTest {
         return client().users();
     }
 
+    static GroupsApi groupsApi() {
+        return client().groups();
+    }
+
     static IAMUserControllerApiUser createTestUser() throws ApiException {
         IAMUserControllerApiCreateOrUpdateUserRequest req =
                 new IAMUserControllerApiCreateOrUpdateUserRequest()
@@ -52,6 +56,50 @@ public class TenantAccessApiTest {
                 new IAMTenantAccessControllerApiCreateTenantAccessRequest().email(user.getEmail()));
 
         assertThatCode(() -> api().deleteTenantAccess(user.getId(), TENANT))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void createTenantAccessById_grantsAccess() throws ApiException {
+        IAMUserControllerApiUser user = createTestUser();
+
+        api().createTenantAccessById(user.getId(), TENANT);
+
+        IAMTenantAccessControllerApiTenantAccess access = api().tenantAccess(user.getId(), TENANT);
+        assertThat(access).isNotNull();
+        assertThat(access.getUserId()).isEqualTo(user.getId());
+        assertThat(access.getTenantId()).isEqualTo(TENANT);
+    }
+
+    @Test
+    void tenantAccess_unknownUser() throws ApiException {
+        assertThatThrownBy(() -> api().tenantAccess(randomId(), TENANT))
+                .isInstanceOf(ApiException.class)
+                .extracting(e -> ((ApiException) e).getCode())
+                .isEqualTo(404);
+    }
+
+    /**
+     * Pins the reason this API exists: since Kestra 2.0 a group add resolves the user
+     * through a {@code hasTenantAccess} filter, so it fails for a user created without
+     * tenant access and succeeds once the access is granted.
+     */
+    @Test
+    void createTenantAccessById_isPrerequisiteForGroupMembership() throws ApiException {
+        IAMUserControllerApiUser user = createTestUser();
+        IAMGroupControllerApiGroupDetail group = groupsApi().createGroup(TENANT,
+                new IAMGroupControllerApiCreateGroupRequest()
+                        .name("ta-group-" + randomId())
+                        .description("tenant-access prerequisite test"));
+
+        assertThatThrownBy(() -> groupsApi().addUserToGroup(group.getId(), user.getId(), TENANT))
+                .isInstanceOf(ApiException.class)
+                .extracting(e -> ((ApiException) e).getCode())
+                .isEqualTo(404);
+
+        api().createTenantAccessById(user.getId(), TENANT);
+
+        assertThatCode(() -> groupsApi().addUserToGroup(group.getId(), user.getId(), TENANT))
                 .doesNotThrowAnyException();
     }
 

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/TenantAccessApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/TenantAccessApi.java
@@ -9,12 +9,25 @@ import io.kestra.sdk.internal.Configuration;
 import io.kestra.sdk.internal.Pair;
 
 import io.kestra.sdk.model.IAMTenantAccessControllerApiCreateTenantAccessRequest;
-import io.kestra.sdk.model.IAMTenantAccessControllerApiUserTenantAccess;
+import io.kestra.sdk.model.IAMTenantAccessControllerApiTenantAccess;
 import io.kestra.sdk.model.PagedResultsIAMTenantAccessControllerApiUserTenantAccess;
+import io.kestra.sdk.model.QueryFilter;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Covers {@code /api/v1/{tenant}/tenant-access}.
+ *
+ * <p>Since Kestra 2.0 tenant access is a prerequisite rather than something granted
+ * as a side effect: adding a user to a group resolves the user through a
+ * {@code hasTenantAccess} filter and rejects it otherwise, so the access has to be
+ * granted first through one of the create calls here.
+ *
+ * <p>There are two of those, mirroring the two server routes: {@link #createTenantAccess}
+ * identifies the user by email, {@link #createTenantAccessById} by user id.
+ */
 public class TenantAccessApi extends BaseApi {
 
     public TenantAccessApi() {
@@ -33,11 +46,9 @@ public class TenantAccessApi extends BaseApi {
                 JSON, null, returnType);
     }
 
-    private <T> T postJson(String path, Object body, List<Pair> queryParams,
-                           List<Pair> collectionQueryParams,
-                           TypeReference<T> returnType) throws ApiException {
-        return invoke("POST", path, body, queryParams, collectionQueryParams,
-                JSON, JSON, returnType);
+    private void putNoBody(String path) throws ApiException {
+        invoke("PUT", path, null, Collections.emptyList(), Collections.emptyList(),
+                null, null, null);
     }
 
     private void delete(String path) throws ApiException {
@@ -56,6 +67,22 @@ public class TenantAccessApi extends BaseApi {
                 Collections.emptyList(), Collections.emptyList(), JSON, JSON, null);
     }
 
+    public void createTenantAccessById(
+            @jakarta.annotation.Nonnull String userId,
+            @jakarta.annotation.Nonnull String tenant) throws ApiException {
+        putNoBody(tenantPath(tenant, "tenant-access", userId));
+    }
+
+    public IAMTenantAccessControllerApiTenantAccess tenantAccess(
+            @jakarta.annotation.Nonnull String userId,
+            @jakarta.annotation.Nonnull String tenant) throws ApiException {
+        return get(
+                tenantPath(tenant, "tenant-access", userId),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                new TypeReference<>() {});
+    }
+
     public void deleteTenantAccess(
             @jakarta.annotation.Nonnull String userId,
             @jakarta.annotation.Nonnull String tenant) throws ApiException {
@@ -70,10 +97,22 @@ public class TenantAccessApi extends BaseApi {
             @jakarta.annotation.Nonnull String tenant,
             @jakarta.annotation.Nullable Integer page,
             @jakarta.annotation.Nullable Integer size) throws ApiException {
+        return listTenantAccess(tenant, page, size, null, null);
+    }
+
+    public PagedResultsIAMTenantAccessControllerApiUserTenantAccess listTenantAccess(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nullable Integer page,
+            @jakarta.annotation.Nullable Integer size,
+            @jakarta.annotation.Nullable List<String> sort,
+            @jakarta.annotation.Nullable List<QueryFilter> filters) throws ApiException {
+        List<Pair> collectionParams = new ArrayList<>();
+        collectionParams.addAll(csvParams("sort", sort));
+        collectionParams.addAll(filterParams(filters));
         return get(
                 tenantPath(tenant, "tenant-access"),
                 queryParams("page", page, "size", size),
-                Collections.emptyList(),
+                collectionParams,
                 new TypeReference<>() {});
     }
 


### PR DESCRIPTION
`TenantAccessApi` covered four of the six routes the server exposes. This adds the other two.

| Route | Method | Status |
|---|---|---|
| `GET /{tenant}/tenant-access` | `TenantAccessApi.listTenantAccess` | was bound |
| `POST /{tenant}/tenant-access` | `TenantAccessApi.createTenantAccess` (by email) | was bound |
| `DELETE /{tenant}/tenant-access/{userId}` | `TenantAccessApi.deleteTenantAccess` | was bound |
| `POST /{tenant}/tenant-access/autocomplete` | `UsersApi.autocompleteUsers` | was bound |
| `PUT /{tenant}/tenant-access/{userId}` | `TenantAccessApi.createTenantAccessById` | **new** |
| `GET /{tenant}/tenant-access/{userId}` | `TenantAccessApi.tenantAccess` | **new** |

The autocomplete route lives on `UsersApi` because the spec tags that operation `Users` (operationId `autocompleteUsers`); it is left where it is rather than duplicated here.

### Why `PUT /{userId}` is the one that matters

Since Kestra 2.0 tenant access is a prerequisite rather than something granted as a side effect: `addUserToGroup` resolves the user through a `hasTenantAccess` filter and rejects it otherwise. Granting by id is how a caller that already holds the user id satisfies that — without it the only route to a grant was by email.

### Notes

- **No new models.** All nine `IAMTenantAccessControllerApi*` classes were already generated; this is binding code only.
- **`listTenantAccess` gains a `sort`/`filters` overload.** The spec marks `filters` as required on that route and the existing three-argument signature could send neither. The old signature delegates to the new one, so callers are unaffected.
- **Naming follows the spec's operationIds, not the Go SDK's.** The by-email `POST` keeps `createTenantAccess` (matching operationId `createTenantAccess`), so the new `PUT` is `createTenantAccessById` rather than taking the shorter name. Go picked the opposite split; renaming the Java method to match would have been a breaking change.

### Verification

Against `kestra-ee:v2.0.0-rc12`:

- 7 `TenantAccessApiTest` tests pass, including one that pins the reason the API exists: a group add for a user without tenant access fails with a **404** (the `hasTenantAccess` filter makes the user unresolvable), then succeeds on the same group and user ids once the grant lands — so the 404 is isolated to the missing access rather than a bad id.
- Full `java-sdk-test` suite green: **430 tests, 0 failures, 15 skipped.**
- Neutering the new `PUT` binding fails the tests that cover it, confirming they are not vacuous.

Closes the Java half of #398. Companion to #399 (the Go bindings).