### PR TITLE
feat: close the last Go/Java coverage gaps against the rc12 spec

### DIFF
--- a/go-sdk/kestra_api_client/apps_api.go
+++ b/go-sdk/kestra_api_client/apps_api.go
@@ -89,3 +89,9 @@ func (a *AppsAPI) LogsFromAppExecution(ctx context.Context, uid, tenant string, 
 	appendRepeatedParam(params, "taskIds", taskIds)
 	return a.doDownload(ctx, "GET", tenantPath(tenant, "apps", "view", uid, "logs", "download"), nil, params)
 }
+
+// StreamAppEventsFromApp follows an app's event stream. The channel is closed when
+// the stream ends or ctx is cancelled.
+func (a *AppsAPI) StreamAppEvents(ctx context.Context, id, stream, tenant string) (<-chan *EventAppResponse, error) {
+	return followSSE[EventAppResponse](&a.baseAPI, ctx, tenantPath(tenant, "apps", "view", id, "streams", stream), nil)
+}

--- a/go-sdk/kestra_api_client/cases_api.go
+++ b/go-sdk/kestra_api_client/cases_api.go
@@ -1,0 +1,16 @@
+package kestra_api_client
+
+import "context"
+
+// CasesAPI covers /api/v1/{tenant}/cases.
+type CasesAPI struct {
+	baseAPI
+}
+
+// CreateCaseFromTask creates a case from a task run, or attaches the triggering
+// execution to a matching already-open case. It backs the CreateCase plugin task,
+// and is a check-then-act rather than an atomic operation: concurrent runs of the
+// same task can each create their own case.
+func (a *CasesAPI) CreateCaseFromTask(ctx context.Context, tenant string, request interface{}) (map[string]interface{}, error) {
+	return doJSON[map[string]interface{}](&a.baseAPI, ctx, "POST", tenantPath(tenant, "cases", "from-task"), request, nil)
+}

--- a/go-sdk/kestra_api_client/client.go
+++ b/go-sdk/kestra_api_client/client.go
@@ -95,6 +95,10 @@ func WithLogger(w io.Writer) ClientOption {
 	}
 }
 
+func (c *KestraClient) Cases() *CasesAPI {
+	return &CasesAPI{baseAPI{client: c}}
+}
+
 func (c *KestraClient) Executions() *ExecutionsAPI {
 	return &ExecutionsAPI{baseAPI{client: c}}
 }

--- a/go-sdk/kestra_api_client/executions_api.go
+++ b/go-sdk/kestra_api_client/executions_api.go
@@ -485,6 +485,38 @@ func (a *ExecutionsAPI) ReplayExecution(
 	return &result, nil
 }
 
+// ReplayExecutionWithInputs replays an execution from a specific task run, supplying
+// fresh inputs. The inputs go out as multipart form fields, which is what the endpoint
+// expects; use ReplayExecution when the original inputs should be reused.
+func (a *ExecutionsAPI) ReplayExecutionWithInputs(
+	ctx context.Context,
+	executionId, tenant string,
+	taskRunId *string,
+	revision *int,
+	breakpoints *string,
+	inputs map[string]string,
+) (*Execution, error) {
+	path := tenantPath(tenant, "executions", executionId, "actions", "replay-with-inputs")
+	params := buildQueryParams("taskRunId", taskRunId, "revision", revision, "breakpoints", breakpoints)
+
+	formParams := make(map[string]interface{}, len(inputs))
+	for k, v := range inputs {
+		formParams[k] = v
+	}
+
+	resp, err := a.doMultipartJSON(ctx, "POST", path, params, formParams)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result Execution
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // ReplayExecutionsByIds replays multiple executions by their IDs.
 func (a *ExecutionsAPI) ReplayExecutionsByIds(
 	ctx context.Context,

--- a/go-sdk/test/api_apps_test.go
+++ b/go-sdk/test/api_apps_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/stretchr/testify/require"
@@ -347,5 +348,27 @@ func TestAppsAPI_All(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Greater(t, len(result), 0)
+	})
+}
+
+func TestAppsAPI_Streams(t *testing.T) {
+	// The server answers a stream subscription with 200 and an SSE body, so a bad
+	// path is what surfaces as an error here. An app with no such stream simply
+	// yields nothing and the channel closes; the assertion is that the call opens
+	// the stream and terminates rather than hanging.
+	t.Run("streamAppEvents_closesWhenStreamHasNoEvents", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		ch, err := KestraTestClient().Apps().StreamAppEvents(ctx, randomId(), randomId(), MAIN_TENANT)
+		require.NoError(t, err)
+		require.NotNil(t, ch)
+
+		select {
+		case _, open := <-ch:
+			require.False(t, open, "expected the stream to close without yielding an event")
+		case <-time.After(10 * time.Second):
+			t.Fatal("stream neither yielded an event nor closed")
+		}
 	})
 }

--- a/go-sdk/test/api_cases_test.go
+++ b/go-sdk/test/api_cases_test.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCasesAPI_All(t *testing.T) {
+	t.Run("createCaseFromTaskTest", func(t *testing.T) {
+		ctx := context.Background()
+		namespace := randomId()
+		flowId := randomId()
+		createSimpleFlow(ctx, flowId, namespace)
+
+		res, err := KestraTestClient().Cases().CreateCaseFromTask(ctx, MAIN_TENANT, map[string]interface{}{
+			"namespace":     namespace,
+			"flowNamespace": namespace,
+			"flowId":        flowId,
+			"taskId":        "hello",
+			"title":         "case from " + flowId,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+}

--- a/go-sdk/test/api_executions_test.go
+++ b/go-sdk/test/api_executions_test.go
@@ -581,6 +581,19 @@ func TestExecutionsAPI_All(t *testing.T) {
 		require.EqualValues(t, kestra_api_client.STATETYPE_CREATED, res.State.Current)
 		require.Eventually(t, executionInState(ctx, exec.Id, kestra_api_client.STATETYPE_SUCCESS), 5*time.Second, 100*time.Millisecond)
 	})
+	t.Run("replayExecutionWithInputsTest", func(t *testing.T) {
+		namespace := randomId()
+		flowId := randomId()
+		ctx := context.Background()
+		createSimpleFlow(ctx, flowId, namespace)
+
+		exec := createExecution(t, ctx, flowId, namespace)
+
+		res, err := KestraTestClient().Executions().ReplayExecutionWithInputs(ctx, exec.Id, MAIN_TENANT, nil, nil, nil, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Id)
+		require.NotEqual(t, exec.Id, res.Id)
+	})
 	t.Run("replayExecutionsByIdsTest", func(t *testing.T) {
 		namespace := randomId()
 		flowId := randomId()

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BindingsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BindingsApiTest.java
@@ -81,6 +81,24 @@ public class BindingsApiTest {
                 .doesNotThrowAnyException();
     }
 
+    @Test
+    void bulkCreateBindings_createsOnePerRequest() throws ApiException {
+        IAMRoleControllerApiRoleDetail role = createTestRole();
+        IAMUserControllerApiUser first = createTestUser();
+        IAMUserControllerApiUser second = createTestUser();
+
+        List<IAMBindingControllerApiBindingDetail> result = api().bulkCreateBindings(TENANT, List.of(
+                new IAMBindingControllerApiCreateBindingRequest()
+                        .type(BindingType.USER).externalId(first.getId()).roleId(role.getId()),
+                new IAMBindingControllerApiCreateBindingRequest()
+                        .type(BindingType.USER).externalId(second.getId()).roleId(role.getId())));
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allSatisfy(b -> assertThat(b.getId()).isNotBlank());
+        assertThat(result).extracting(b -> b.getUser().getId())
+                .containsExactlyInAnyOrder(first.getId(), second.getId());
+    }
+
     // ========================================================================
     // Search
     // ========================================================================

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BlueprintsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BlueprintsApiTest.java
@@ -280,4 +280,17 @@ public class BlueprintsApiTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(created.getId());
     }
+
+    // ========================================================================
+    // Validation
+    // ========================================================================
+
+    @Test
+    void validateFlowBlueprint_acceptsValidSource() throws ApiException {
+        ValidateConstraintViolation result = api().validateFlowBlueprint(TENANT,
+                logFlowYaml(randomId(), randomId()));
+
+        assertThat(result).isNotNull();
+        assertThat(result.getConstraints()).isNull();
+    }
 }

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/MiscApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/MiscApiTest.java
@@ -1,0 +1,25 @@
+package io.kestra.sdk.api;
+
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.model.MiscControllerEEConfiguration;
+import org.junit.jupiter.api.*;
+
+import static io.kestra.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+public class MiscApiTest {
+
+    static MiscApi api() {
+        return client().misc();
+    }
+
+    @Test
+    void configuration_basic() throws ApiException {
+        MiscControllerEEConfiguration result = api().configuration();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getUuid()).isNotBlank();
+        assertThat(result.getVersion()).isNotBlank();
+        assertThat(result.getEdition()).isNotNull();
+    }
+}

--- a/java/java-sdk/src/main/java/io/kestra/sdk/KestraClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/KestraClient.java
@@ -110,6 +110,8 @@ public class KestraClient {
 
     public TenantsApi tenants() { return new TenantsApi(this.apiClient); }
 
+    public MiscApi misc() { return new MiscApi(this.apiClient); }
+
     // END -- Individual API
 
     /**

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/BindingsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/BindingsApi.java
@@ -51,6 +51,15 @@ public class BindingsApi extends BaseApi {
     // CRUD
     // ========================================================================
 
+    public List<IAMBindingControllerApiBindingDetail> bulkCreateBindings(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nonnull List<IAMBindingControllerApiCreateBindingRequest> requests) throws ApiException {
+        return postJson(
+                tenantPath(tenant, "bindings", "bulk"),
+                requests, Collections.emptyList(), Collections.emptyList(),
+                new TypeReference<>() {});
+    }
+
     public IAMBindingControllerApiBindingDetail createBinding(
             @jakarta.annotation.Nonnull String tenant,
             @jakarta.annotation.Nonnull IAMBindingControllerApiCreateBindingRequest request) throws ApiException {

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/BlueprintsApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/BlueprintsApi.java
@@ -16,6 +16,7 @@ import io.kestra.sdk.model.BlueprintWithFlowEntity;
 import io.kestra.sdk.model.PagedResultsBlueprintControllerApiBlueprintItem;
 import io.kestra.sdk.model.PagedResultsBlueprint;
 import io.kestra.sdk.model.QueryFilter;
+import io.kestra.sdk.model.ValidateConstraintViolation;
 
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import java.util.Map;
 public class BlueprintsApi extends BaseApi {
 
     private static final String YAML_ACCEPT = "application/yaml";
+    private static final String YAML = "application/x-yaml";
 
     public BlueprintsApi() {
         super(Configuration.getDefaultApiClient());
@@ -88,6 +90,16 @@ public class BlueprintsApi extends BaseApi {
     // ========================================================================
     // Flow Blueprints
     // ========================================================================
+
+    public ValidateConstraintViolation validateFlowBlueprint(
+            @jakarta.annotation.Nonnull String tenant,
+            @jakarta.annotation.Nonnull String yamlBody) throws ApiException {
+        return invoke("POST",
+                tenantPath(tenant, "blueprints", "flows", "validate"),
+                yamlBody, null, null,
+                JSON, YAML,
+                new TypeReference<>() {});
+    }
 
     public BlueprintControllerApiFlowBlueprint createFlowBlueprint(
             @jakarta.annotation.Nonnull String tenant,

--- a/java/java-sdk/src/main/java/io/kestra/sdk/api/MiscApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/api/MiscApi.java
@@ -1,0 +1,31 @@
+package io.kestra.sdk.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.kestra.sdk.internal.ApiClient;
+import io.kestra.sdk.internal.ApiException;
+import io.kestra.sdk.internal.BaseApi;
+import io.kestra.sdk.internal.Configuration;
+
+import io.kestra.sdk.model.MiscControllerEEConfiguration;
+
+import java.util.Collections;
+
+public class MiscApi extends BaseApi {
+
+    public MiscApi() {
+        super(Configuration.getDefaultApiClient());
+    }
+
+    public MiscApi(ApiClient apiClient) {
+        super(apiClient);
+    }
+
+    public MiscControllerEEConfiguration configuration() throws ApiException {
+        return invoke("GET", "/api/v1/configs",
+                null, Collections.emptyList(), Collections.emptyList(),
+                JSON, null,
+                new TypeReference<>() {});
+    }
+
+}


### PR DESCRIPTION
Auditing both hand-written SDKs against `kestra-ee.yml` — which is current with `v2.0.0-rc12`, no route drift — left six routes bound in one language but not the other. This closes all six, three per side.

### Go gains what Java already had

| Route | Method |
|---|---|
| `POST /{tenant}/cases/from-task` | `CasesAPI.CreateCaseFromTask` |
| `POST /{tenant}/executions/{id}/actions/replay-with-inputs` | `ExecutionsAPI.ReplayExecutionWithInputs` |
| `GET /{tenant}/apps/view/{id}/streams/{stream}` | `AppsAPI.StreamAppEvents` |

Cases had no Go binding at all, so `CasesAPI` is new and wired onto `KestraClient`. `from-task` takes an `interface{}` body because no Go model is generated for `CasesController.CaseFromTaskRequest`. `ReplayExecutionWithInputs` sends inputs as multipart form fields, which is what the endpoint expects; `ReplayExecution` remains the call for reusing the original inputs.

### Java gains what Go already had

| Route | Method |
|---|---|
| `POST /{tenant}/blueprints/flows/validate` | `BlueprintsApi.validateFlowBlueprint` |
| `POST /{tenant}/bindings/bulk` | `BindingsApi.bulkCreateBindings` |
| `GET /api/v1/configs` | `MiscApi.configuration` |

`/api/v1/configs` is instance-level and had no home, so `MiscApi` is new and wired onto `KestraClient`.

### Two tests that assert less than you might expect

Both are deliberate, and both still fail if the binding is wrong:

- **`streamAppEvents`** asserts the channel *closes* rather than that the call errors. The server answers a stream subscription with `200` and an SSE body even for an unknown app, so a bad path — not a missing app — is what surfaces as an error.
- **`validateFlowBlueprint`** only asserts a valid source is accepted. That endpoint returns `constraints=null` for every input on the `-no-plugins` image, including malformed YAML and unknown task types, so a negative assertion would pin nothing.

### Verification

Against `kestra-ee:v2.0.0-rc12`:

- Full `go-sdk` suite green.
- Full `java-sdk-test` suite green — **430 tests, 0 failures, 15 skipped.**
- Each of the six new bindings was neutered in turn (path pointed at a wrong segment) and the covering test failed in every case, so none of them is vacuous.

After this, both SDKs bind the same set of routes and neither has a route the rc12 spec no longer serves.