### PR TITLE
feat(go): bind the Quotas endpoints and a Tenants API

### DIFF
--- a/go-sdk/kestra_api_client/client.go
+++ b/go-sdk/kestra_api_client/client.go
@@ -178,3 +178,11 @@ func (c *KestraClient) Invitations() *InvitationsAPI {
 func (c *KestraClient) Outputs() *OutputsAPI {
 	return &OutputsAPI{baseAPI{client: c}}
 }
+
+func (c *KestraClient) Quotas() *QuotasAPI {
+	return &QuotasAPI{baseAPI{client: c}}
+}
+
+func (c *KestraClient) Tenants() *TenantsAPI {
+	return &TenantsAPI{baseAPI{client: c}}
+}

--- a/go-sdk/kestra_api_client/quotas_api.go
+++ b/go-sdk/kestra_api_client/quotas_api.go
@@ -1,0 +1,24 @@
+package kestra_api_client
+
+import "context"
+
+type QuotasAPI struct {
+	baseAPI
+}
+
+// SearchQuotaLimits returns the current quota limit counters of the tenant.
+func (a *QuotasAPI) SearchQuotaLimits(ctx context.Context, tenant string) ([]QuotaLimit, error) {
+	return doJSON[[]QuotaLimit](&a.baseAPI, ctx, "GET", tenantPath(tenant, "quota-limits"), nil, nil)
+}
+
+// ResetQuotaLimit resets one quota limit counter. Namespace and flowId narrow
+// the reset to a namespace- or flow-scoped counter; nil targets the
+// tenant-wide one.
+func (a *QuotasAPI) ResetQuotaLimit(ctx context.Context, tenant, id string, namespace, flowId *string) error {
+	request := map[string]interface{}{
+		"id":        id,
+		"namespace": namespace,
+		"flowId":    flowId,
+	}
+	return a.doVoidJSON(ctx, "POST", tenantPath(tenant, "quota-limits", "reset"), request, nil)
+}

--- a/go-sdk/kestra_api_client/tenants_api.go
+++ b/go-sdk/kestra_api_client/tenants_api.go
@@ -1,0 +1,33 @@
+package kestra_api_client
+
+import "context"
+
+// TenantsAPI covers the instance-level /api/v1/tenants routes (instance-owner-only).
+type TenantsAPI struct {
+	baseAPI
+}
+
+func (a *TenantsAPI) CreateTenant(ctx context.Context, tenant Tenant) (*Tenant, error) {
+	return doJSON[*Tenant](&a.baseAPI, ctx, "POST", superadminPath("tenants"), tenant, nil)
+}
+
+func (a *TenantsAPI) SearchTenants(ctx context.Context, page, size *int, sort []string, filters []SearchFilter) (*PagedResultsTenant, error) {
+	params := buildQueryParams("page", page, "size", size)
+	appendRepeatedParam(params, "sort", sort)
+	appendFilterParams(params, filters)
+	return doJSON[*PagedResultsTenant](&a.baseAPI, ctx, "GET", superadminPath("tenants", "search"), nil, params)
+}
+
+func (a *TenantsAPI) Tenant(ctx context.Context, id string) (*Tenant, error) {
+	return doJSON[*Tenant](&a.baseAPI, ctx, "GET", superadminPath("tenants", id), nil, nil)
+}
+
+func (a *TenantsAPI) UpdateTenant(ctx context.Context, id string, tenant Tenant) (*Tenant, error) {
+	return doJSON[*Tenant](&a.baseAPI, ctx, "PUT", superadminPath("tenants", id), tenant, nil)
+}
+
+// DeleteTenant deletes the tenant and all resources linked to it (flows,
+// namespaces, apps, ...).
+func (a *TenantsAPI) DeleteTenant(ctx context.Context, id string) error {
+	return a.doVoidJSON(ctx, "DELETE", superadminPath("tenants", id), nil, nil)
+}

--- a/go-sdk/test/api_quotas_test.go
+++ b/go-sdk/test/api_quotas_test.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+)
+
+func TestQuotasAPI_All(t *testing.T) {
+	t.Run("searchQuotaLimitsTest", func(t *testing.T) {
+		ctx := context.Background()
+		limits, err := KestraTestClient().Quotas().SearchQuotaLimits(ctx, MAIN_TENANT)
+		require.NoError(t, err, "listing quota limits should succeed even with no quotas configured")
+		for _, limit := range limits {
+			require.NotEmpty(t, limit.GetId())
+		}
+	})
+
+	t.Run("resetQuotaLimitTest", func(t *testing.T) {
+		ctx := context.Background()
+		err := KestraTestClient().Quotas().ResetQuotaLimit(ctx, MAIN_TENANT, "nonexistent_"+randomId(), nil, nil)
+		var apiErr *kestra_api_client.ApiError
+		require.ErrorAs(t, err, &apiErr, "resetting an unknown quota limit id should reach the endpoint and be rejected")
+		require.Equal(t, 404, apiErr.StatusCode, "the server answers 404 Quota limit not found")
+		require.Contains(t, string(apiErr.Body), "Quota limit not found",
+			"a 404 without this message means the route itself was not reached")
+	})
+}

--- a/go-sdk/test/api_tenants_test.go
+++ b/go-sdk/test/api_tenants_test.go
@@ -1,0 +1,77 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+)
+
+func TestTenantsAPI_All(t *testing.T) {
+	t.Run("tenantLifecycleTest", func(t *testing.T) {
+		ctx := context.Background()
+		id := "sdktest" + randomId()
+
+		tenant := *kestra_api_client.NewTenant(id, "SDK test tenant", false)
+		tenant.Concurrency = &kestra_api_client.Concurrency{
+			Limit:    5,
+			Behavior: kestra_api_client.CONCURRENCYBEHAVIOR_QUEUE,
+		}
+		tenant.Quotas = []kestra_api_client.Quota{
+			{
+				Duration: "PT1H",
+				Limit:    100,
+				Behavior: kestra_api_client.QUOTABEHAVIOR_FAIL,
+			},
+		}
+
+		created, err := KestraTestClient().Tenants().CreateTenant(ctx, tenant)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			KestraTestClient().Tenants().DeleteTenant(context.Background(), id)
+		})
+		require.NotNil(t, created)
+		require.Equal(t, id, created.Id)
+
+		fetched, err := KestraTestClient().Tenants().Tenant(ctx, id)
+		require.NoError(t, err)
+		require.NotNil(t, fetched)
+		require.NotNil(t, fetched.Concurrency, "the concurrency config should round-trip")
+		assert.Equal(t, int32(5), fetched.Concurrency.Limit)
+		assert.Equal(t, kestra_api_client.CONCURRENCYBEHAVIOR_QUEUE, fetched.Concurrency.Behavior)
+		require.Len(t, fetched.Quotas, 1, "the quota config should round-trip")
+		assert.Equal(t, "PT1H", fetched.Quotas[0].Duration)
+		assert.Equal(t, int64(100), fetched.Quotas[0].Limit)
+		assert.Equal(t, kestra_api_client.QUOTABEHAVIOR_FAIL, fetched.Quotas[0].Behavior)
+
+		fetched.Name = "SDK test tenant renamed"
+		fetched.Concurrency.Limit = 7
+		updated, err := KestraTestClient().Tenants().UpdateTenant(ctx, id, *fetched)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		assert.Equal(t, "SDK test tenant renamed", updated.Name)
+		require.NotNil(t, updated.Concurrency)
+		assert.Equal(t, int32(7), updated.Concurrency.Limit)
+
+		page, size := 1, MAX_PAGE_SIZE
+		results, err := KestraTestClient().Tenants().SearchTenants(ctx, &page, &size, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, results)
+		found := false
+		for _, item := range results.Results {
+			if item.Id == id {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "the created tenant should be listed by the search")
+
+		require.NoError(t, KestraTestClient().Tenants().DeleteTenant(ctx, id))
+
+		_, err = KestraTestClient().Tenants().Tenant(ctx, id)
+		assert.Error(t, err, "the tenant should be gone once deleted")
+	})
+}


### PR DESCRIPTION
## What

Adds two missing surfaces to the hand-written Go SDK layer, wired onto `KestraClient` as `Quotas()` and `Tenants()`.

| Method | Route |
|---|---|
| `QuotasAPI.SearchQuotaLimits` | `GET /api/v1/{tenant}/quota-limits` |
| `QuotasAPI.ResetQuotaLimit` | `POST /api/v1/{tenant}/quota-limits/reset` |
| `TenantsAPI.CreateTenant` | `POST /api/v1/tenants` |
| `TenantsAPI.SearchTenants` | `GET /api/v1/tenants/search` |
| `TenantsAPI.Tenant` | `GET /api/v1/tenants/{id}` |
| `TenantsAPI.UpdateTenant` | `PUT /api/v1/tenants/{id}` |
| `TenantsAPI.DeleteTenant` | `DELETE /api/v1/tenants/{id}` |

The logo, apps-catalog and settings/default-dashboards sub-resources of `/tenants/{id}` are deliberately out of scope.

## Why

- The `Tenant` model already carries `Concurrency` and `Quotas`, but without a TenantsAPI they were unreachable from Go — tenant-level concurrency and quota configuration could not be managed at all.
- The quota-limit counters (`searchQuotaLimits` / `resetQuotaLimit`, Quotas tag in `kestra-ee.yml`) were only reachable from the generated JS SDK.

## Verification

Against a live EE `v2.0.0-rc12` (`docker-compose-ci.yml`):

- `go build ./... && go vet ./...` clean; new files gofmt-clean.
- Full `go test ./test/` suite passes (`ok ... 59.7s`), including the two new tests:
  - `TestTenantsAPI_All/tenantLifecycleTest`: creates a tenant with `Concurrency{Limit:5, Behavior:QUEUE}` and a `Quota{PT1H, 100, FAIL}`, asserts both round-trip through get, updates, finds it via search, deletes, and asserts the get then fails.
  - `TestQuotasAPI_All`: list succeeds (empty on a fresh instance); resetting an unknown id is pinned to the observed rc12 behavior — `404` with body `"Quota limit not found"` (the body assertion distinguishes it from a route-level 404).
- Neutering check — each binding pointed at a wrong path segment in turn, confirming at least one test fails, then restored:
  - `SearchQuotaLimits` → `searchQuotaLimitsTest` fails
  - `ResetQuotaLimit` → `resetQuotaLimitTest` fails
  - `CreateTenant`, `SearchTenants`, `Tenant`, `UpdateTenant`, `DeleteTenant` → `tenantLifecycleTest` fails for each