### PR TITLE
feat(python): bind the Quotas endpoints and a Tenants API

### DIFF
--- a/python/python-sdk/kestrapy/__init__.py
+++ b/python/python-sdk/kestrapy/__init__.py
@@ -22,8 +22,10 @@ __all__ = [
     "GroupsApi",
     "KVApi",
     "NamespacesApi",
+    "QuotasApi",
     "RolesApi",
     "ServiceAccountApi",
+    "TenantsApi",
     "TriggersApi",
     "UsersApi",
     "ApiResponse",
@@ -694,8 +696,10 @@ from kestrapy.api.flows_api import FlowsApi as FlowsApi
 from kestrapy.api.groups_api import GroupsApi as GroupsApi
 from kestrapy.api.kv_api import KVApi as KVApi
 from kestrapy.api.namespaces_api import NamespacesApi as NamespacesApi
+from kestrapy.api.quotas_api import QuotasApi as QuotasApi
 from kestrapy.api.roles_api import RolesApi as RolesApi
 from kestrapy.api.service_account_api import ServiceAccountApi as ServiceAccountApi
+from kestrapy.api.tenants_api import TenantsApi as TenantsApi
 from kestrapy.api.triggers_api import TriggersApi as TriggersApi
 from kestrapy.api.users_api import UsersApi as UsersApi
 

--- a/python/python-sdk/kestrapy/api/__init__.py
+++ b/python/python-sdk/kestrapy/api/__init__.py
@@ -13,7 +13,9 @@ from kestrapy.api.invitations_api import InvitationsApi
 from kestrapy.api.kv_api import KVApi
 from kestrapy.api.logs_api import LogsApi
 from kestrapy.api.namespaces_api import NamespacesApi
+from kestrapy.api.quotas_api import QuotasApi
 from kestrapy.api.roles_api import RolesApi
+from kestrapy.api.tenants_api import TenantsApi
 from kestrapy.api.service_account_api import ServiceAccountApi
 from kestrapy.api.test_suites_api import TestSuitesApi
 from kestrapy.api.triggers_api import TriggersApi

--- a/python/python-sdk/kestrapy/api/quotas_api.py
+++ b/python/python-sdk/kestrapy/api/quotas_api.py
@@ -1,0 +1,16 @@
+from typing import Any, List
+
+from kestrapy.base_api import BaseApi
+from kestrapy.models.quota_limit import QuotaLimit
+from kestrapy.models.quota_limit_controller_api_quota_limit_reset_request import QuotaLimitControllerApiQuotaLimitResetRequest
+
+
+class QuotasApi(BaseApi):
+
+    def search_quota_limits(self, tenant: str) -> List[QuotaLimit]:
+        path = self._tenant_path(tenant, "quota-limits")
+        return self._json_list_request("GET", path, QuotaLimit)
+
+    def reset_quota_limit(self, tenant: str, request: QuotaLimitControllerApiQuotaLimitResetRequest) -> Any:
+        path = self._tenant_path(tenant, "quota-limits", "reset")
+        return self._raw_json_request("POST", path, body=request)

--- a/python/python-sdk/kestrapy/api/tenants_api.py
+++ b/python/python-sdk/kestrapy/api/tenants_api.py
@@ -1,0 +1,42 @@
+from typing import List, Optional
+
+from kestrapy.base_api import BaseApi
+from kestrapy.models.paged_results_tenant import PagedResultsTenant
+from kestrapy.models.query_filter import QueryFilter
+from kestrapy.models.tenant import Tenant
+
+
+class TenantsApi(BaseApi):
+
+    # ---- CRUD (Instance-owner-only) ----
+
+    def create_tenant(self, tenant: Tenant) -> Tenant:
+        path = self._superadmin_path("tenants")
+        return self._json_request("POST", path, Tenant, body=tenant)
+
+    def tenant(self, id: str) -> Tenant:
+        path = self._superadmin_path("tenants", id)
+        return self._json_request("GET", path, Tenant)
+
+    def update_tenant(self, id: str, tenant: Tenant) -> Tenant:
+        path = self._superadmin_path("tenants", id)
+        return self._json_request("PUT", path, Tenant, body=tenant)
+
+    def delete_tenant(self, id: str) -> None:
+        path = self._superadmin_path("tenants", id)
+        self._void_request("DELETE", path)
+
+    # ---- Search (Instance-owner-only) ----
+
+    def search_tenants(
+        self,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        sort: Optional[List[str]] = None,
+        filters: Optional[List[QueryFilter]] = None,
+    ) -> PagedResultsTenant:
+        path = self._superadmin_path("tenants", "search")
+        params = list(self._build_query_params(page=page, size=size).items())
+        self._append_repeated_param(params, "sort", sort)
+        self._append_filter_params(params, filters)
+        return self._json_request("GET", path, PagedResultsTenant, params=params)

--- a/python/python-sdk/kestrapy/kestra_client.py
+++ b/python/python-sdk/kestrapy/kestra_client.py
@@ -19,6 +19,8 @@ from kestrapy.api.blueprints_api import BlueprintsApi
 from kestrapy.api.dashboards_api import DashboardsApi
 from kestrapy.api.apps_api import AppsApi
 from kestrapy.api.test_suites_api import TestSuitesApi
+from kestrapy.api.quotas_api import QuotasApi
+from kestrapy.api.tenants_api import TenantsApi
 
 
 class KestraClient:
@@ -93,6 +95,10 @@ class KestraClient:
     def service_account(self): return self._get_api(ServiceAccountApi)
     @property
     def invitations(self): return self._get_api(InvitationsApi)
+    @property
+    def quotas(self): return self._get_api(QuotasApi)
+    @property
+    def tenants(self): return self._get_api(TenantsApi)
 
     def close(self):
         self._session.close()

--- a/python/python-sdk/testApis/test_quotas_api.py
+++ b/python/python-sdk/testApis/test_quotas_api.py
@@ -1,0 +1,21 @@
+import pytest
+
+from test_helpers import TENANT, random_id
+from kestrapy import QuotaLimit, QuotaLimitControllerApiQuotaLimitResetRequest
+from kestrapy.exceptions import NotFoundException
+
+
+def test_search_quota_limits_returns_list(client):
+    result = client.quotas.search_quota_limits(TENANT)
+
+    assert isinstance(result, list)
+    assert all(isinstance(item, QuotaLimit) for item in result)
+
+
+def test_reset_quota_limit_unknown_id_returns_404(client):
+    request = QuotaLimitControllerApiQuotaLimitResetRequest(id="does-not-exist-" + random_id())
+
+    with pytest.raises(NotFoundException) as exc_info:
+        client.quotas.reset_quota_limit(TENANT, request)
+    assert exc_info.value.status == 404
+    assert "Quota limit not found" in exc_info.value.body

--- a/python/python-sdk/testApis/test_tenants_api.py
+++ b/python/python-sdk/testApis/test_tenants_api.py
@@ -1,0 +1,82 @@
+import pytest
+
+from test_helpers import random_id
+from kestrapy import (
+    Concurrency,
+    ConcurrencyBehavior,
+    Quota,
+    QuotaBehavior,
+    Tenant,
+)
+from kestrapy.exceptions import NotFoundException
+
+
+def _tenant(tenant_id, name, concurrency_limit, quota_limit):
+    return Tenant(
+        id=tenant_id,
+        name=name,
+        deleted=False,
+        concurrency=Concurrency(limit=concurrency_limit, behavior=ConcurrencyBehavior.QUEUE),
+        quotas=[Quota(duration="PT1H", limit=quota_limit, behavior=QuotaBehavior.FAIL)],
+    )
+
+
+@pytest.fixture
+def temp_tenant(client):
+    tenant_id = "t" + random_id()[:12]
+    yield tenant_id
+    try:
+        client.tenants.delete_tenant(tenant_id)
+    except NotFoundException:
+        pass
+
+
+def test_tenant_crud_roundtrip_with_concurrency_and_quotas(client, temp_tenant):
+    tenant_id = temp_tenant
+
+    created = client.tenants.create_tenant(_tenant(tenant_id, "SDK test tenant", 5, 100))
+
+    assert created.id == tenant_id
+    assert created.concurrency is not None
+    assert created.concurrency.limit == 5
+    assert created.concurrency.behavior == ConcurrencyBehavior.QUEUE
+    assert created.quotas is not None and len(created.quotas) == 1
+    assert created.quotas[0].duration == "PT1H"
+    assert created.quotas[0].limit == 100
+    assert created.quotas[0].behavior == QuotaBehavior.FAIL
+
+    fetched = client.tenants.tenant(tenant_id)
+
+    assert fetched.id == tenant_id
+    assert fetched.name == "SDK test tenant"
+    assert fetched.concurrency.limit == 5
+    assert fetched.quotas[0].limit == 100
+
+    updated = client.tenants.update_tenant(
+        tenant_id, _tenant(tenant_id, "SDK test tenant updated", 7, 50)
+    )
+
+    assert updated.name == "SDK test tenant updated"
+    assert updated.concurrency.limit == 7
+    assert updated.quotas[0].limit == 50
+
+    client.tenants.delete_tenant(tenant_id)
+
+    with pytest.raises(NotFoundException):
+        client.tenants.tenant(tenant_id)
+
+
+def test_search_tenants_finds_created_tenant(client, temp_tenant):
+    tenant_id = temp_tenant
+    client.tenants.create_tenant(_tenant(tenant_id, "SDK search tenant", 2, 10))
+
+    result = client.tenants.search_tenants(page=1, size=100)
+
+    assert result.total >= 2
+    assert tenant_id in [t.id for t in result.results]
+
+
+def test_get_unknown_tenant_returns_404(client):
+    with pytest.raises(NotFoundException) as exc_info:
+        client.tenants.tenant("does-not-exist-" + random_id()[:8])
+    assert exc_info.value.status == 404


### PR DESCRIPTION
## What

Hand-writes two missing API surfaces in the Python SDK (`kestrapy`), wired into `KestraClient` as `client.quotas` and `client.tenants` and exported from `kestrapy` / `kestrapy.api`.

| Method | Route | Returns |
|---|---|---|
| `quotas.search_quota_limits(tenant)` | `GET /api/v1/{tenant}/quota-limits` | `List[QuotaLimit]` |
| `quotas.reset_quota_limit(tenant, request)` | `POST /api/v1/{tenant}/quota-limits/reset` | raw JSON / `None` |
| `tenants.create_tenant(tenant)` | `POST /api/v1/tenants` | `Tenant` |
| `tenants.search_tenants(page, size, sort, filters)` | `GET /api/v1/tenants/search` | `PagedResultsTenant` |
| `tenants.tenant(id)` | `GET /api/v1/tenants/{id}` | `Tenant` |
| `tenants.update_tenant(id, tenant)` | `PUT /api/v1/tenants/{id}` | `Tenant` |
| `tenants.delete_tenant(id)` | `DELETE /api/v1/tenants/{id}` | `None` (204) |

The tenant logo, apps-catalog and settings sub-resources are deliberately out of scope.

## Why

- The `Tenant` model already carries the `concurrency` and `quotas` fields, but with no Tenants API in the Python SDK they were unreachable — tenant-level concurrency limits and quotas could not be managed from Python at all.
- Quota-limit observability (`quota-limits` search/reset) was bound in the JS SDK only.

Nothing else in `kestrapy` bound these routes (verified by grepping the whole tree for `quota-limits` and `tenants` before writing — only the tenant-access autocomplete in `users_api.py` and per-flow `concurrency-limit` in `flows_api.py` touch adjacent paths).

## How it was written

**Everything here is hand-written**, following the idiom of the existing `kestrapy/api/*.py` classes (`BaseApi`, `_tenant_path`/`_superadmin_path`, typed `_json_request` helpers). No OpenAPI generator was run: the `.openapi-generator/FILES` manifest is stale and regeneration deletes the hand-written `api/` classes.

## Verification

Tested against a live EE stack (`docker-compose-ci.yml`, image `europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop-no-plugins` — the compose file hardcodes that tag; `KESTRA_VERSION` is not interpolated, so `v2.0.0-rc12` could not be selected through it).

- `testApis/test_quotas_api.py` + `testApis/test_tenants_api.py`: 5 passed.
  - Tenant round-trip pins that `concurrency` (limit + behavior) and a `quotas` entry survive create → get → update, then deletes the tenant (a fixture also guarantees cleanup on failure).
  - Probed server behaviors pinned in tests: resetting an unknown quota-limit id returns **404 "Quota limit not found"**; `GET`ting a deleted/unknown tenant returns **404**; `DELETE` of a tenant returns 204.
- Mutation check: each of the 7 bindings was neutered in turn (one wrong path segment) and the corresponding test failed every time; restored and re-verified green.
- Full `testApis/` suite: **507 passed, 5 skipped, 3 xfailed, 15 xpassed** in 92s (one stack, no shard resets needed).
