### PR TITLE
fix(java): allow building an unauthenticated KestraClient

### DIFF
--- a/java/java-sdk/README.md
+++ b/java/java-sdk/README.md
@@ -853,6 +853,11 @@ Authentication schemes defined for the API:
 
 - **Type**: HTTP Bearer Token authentication (Bearer)
 
+Both are optional: the `KestraClient` builder sends no `Authorization` header unless
+`basicAuth(username, password)` or `tokenAuth(token)` is called, so an unsecured Kestra API can
+be reached with `KestraClient.builder().url("http://localhost:8080").build()`. `noAuth()` states
+this explicitly and resets any previously configured authentication.
+
 
 ## Configuring timeouts
 
@@ -865,7 +870,7 @@ import java.time.Duration;
 
 var client = KestraClient.builder()
     .url("https://kestra.example.com")
-    .token("your-api-token")
+    .tokenAuth("your-api-token")
     .connectTimeout(Duration.ofSeconds(10))   // 0 = infinite (default)
     .readTimeout(Duration.ofMinutes(30))       // 0 = infinite (default)
     .build();

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/KestraClientAuthTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/KestraClientAuthTest.java
@@ -1,0 +1,70 @@
+package io.kestra.sdk;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KestraClientAuthTest {
+
+    @Test
+    void noCredentials_sendsNoAuthorizationHeader() {
+        var client = KestraClient.builder().build();
+        assertThat(client.apiClient().getDefaultHeaders()).doesNotContainKey("Authorization");
+    }
+
+    @Test
+    void noAuth_sendsNoAuthorizationHeader() {
+        var client = KestraClient.builder().noAuth().build();
+        assertThat(client.apiClient().getDefaultHeaders()).doesNotContainKey("Authorization");
+    }
+
+    @Test
+    void noAuth_overridesBasicAuth() {
+        var client = KestraClient.builder().basicAuth("user", "pass").noAuth().build();
+        assertThat(client.apiClient().getDefaultHeaders()).doesNotContainKey("Authorization");
+    }
+
+    @Test
+    void noAuth_overridesTokenAuth() {
+        var client = KestraClient.builder().tokenAuth("my-token").noAuth().build();
+        assertThat(client.apiClient().getDefaultHeaders()).doesNotContainKey("Authorization");
+    }
+
+    @Test
+    void basicAuth_overridesNoAuth() {
+        var client = KestraClient.builder().noAuth().basicAuth("user", "pass").build();
+        assertThat(client.apiClient().getDefaultHeaders())
+                .containsEntry("Authorization", "Basic " + base64("user:pass"));
+    }
+
+    @Test
+    void basicAuth_sendsBase64EncodedCredentials() {
+        var client = KestraClient.builder().basicAuth("user", "pass").build();
+        assertThat(client.apiClient().getDefaultHeaders())
+                .containsEntry("Authorization", "Basic " + base64("user:pass"));
+    }
+
+    @Test
+    void tokenAuth_sendsBearerToken() {
+        var client = KestraClient.builder().tokenAuth("my-token").build();
+        assertThat(client.apiClient().getDefaultHeaders())
+                .containsEntry("Authorization", "Bearer my-token");
+    }
+
+    @Test
+    void defaultHeaders_isASnapshot() {
+        var apiClient = KestraClient.builder().build().apiClient();
+        var headers = apiClient.getDefaultHeaders();
+
+        apiClient.addDefaultHeader("Authorization", "Bearer sneaked-in");
+
+        assertThat(headers).doesNotContainKey("Authorization");
+    }
+
+    private static String base64(String credentials) {
+        return Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/java/java-sdk/src/main/java/io/kestra/sdk/KestraClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/KestraClient.java
@@ -39,7 +39,7 @@ public class KestraClient {
         this.apiClient = apiClient;
     }
 
-    /** Exposed for testing timeout propagation without a live server. */
+    /** Exposed for testing the client configuration without a live server. */
     ApiClient apiClient() {
         return apiClient;
     }
@@ -119,7 +119,7 @@ public class KestraClient {
      */
     public static class KestraClientBuilder {
         private String url = "http://localhost:8080";
-        private Auth auth = Auth.BASIC;
+        private Auth auth = Auth.NONE;
         private String token;
         private String username;
         private String password;
@@ -152,6 +152,18 @@ public class KestraClient {
             this.username = Objects.requireNonNull(username);
             this.password = Objects.requireNonNull(password);
             this.auth = Auth.BASIC;
+
+            return this;
+        }
+
+        /**
+         * Disable authentication and reset any previously set credentials. This is the default.
+         */
+        public KestraClientBuilder noAuth() {
+            this.token = null;
+            this.username = null;
+            this.password = null;
+            this.auth = Auth.NONE;
 
             return this;
         }

--- a/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
@@ -425,6 +425,15 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Get the default headers sent with every request.
+   *
+   * @return An immutable snapshot of the default headers
+   */
+  public Map<String, String> getDefaultHeaders() {
+    return Map.copyOf(defaultHeaderMap);
+  }
+
+  /**
    * Add a default cookie.
    *
    * @param key The cookie's key
@@ -508,7 +517,7 @@ public class ApiClient extends JavaTimeFormatter {
 
   /**
    * Set the date format used to parse/format date parameters.
-   * @param dateFormat Date format
+   * @param newDateFormat Date format
    * @return API client
    */
   public ApiClient setDateFormat(DateFormat newDateFormat) {


### PR DESCRIPTION
Closes https://github.com/kestra-io/client-sdk/issues/407.

`KestraClientBuilder`'s constructor initialised `auth = Auth.BASIC`. With neither
`basicAuth(...)` nor `tokenAuth(...)` called, `build()` took the BASIC branch with both
credentials still `null` and emitted `Authorization: Basic bnVsbDpudWxs` — base64 of the
literal string `null:null`. `Auth.NONE` existed and was already the no-header case, but
nothing could select it.

### Changes

- `KestraClientBuilder.noAuth()` selects `Auth.NONE`, and can reset a previously set auth.
- The builder default becomes `Auth.NONE`.
- `ApiClient.getDefaultHeaders()` returns an unmodifiable view of the default headers, so the
  test can assert on what the client actually sends.
- README: document the no-auth path, and fix the timeouts snippet that used a non-existent
  `.token(...)` builder method instead of `.tokenAuth(...)`.

`noAuth()` rather than a public `auth(Auth)`: it mirrors the existing `tokenAuth`/`basicAuth`
mode-named setters that assign `this.auth` themselves, and a public `auth(Auth.TOKEN)` would
re-open the same hole — selecting a mode with no credentials behind it.

`ApiClient.java` is in the diff only for that getter. It is hand-edited already (#275 added the
timeout setters) and `generate-sdks.sh` refuses `java`, so there is no generator to overwrite it.

### ⚠️ Signature change

No public method signature changed. One default behavior did:

`KestraClientBuilder` default auth `Auth.BASIC` → `Auth.NONE`, so
`KestraClient.builder().url(x).build()` now sends no `Authorization` header instead of
`Authorization: Basic bnVsbDpudWxs`.

Not considered a break: against a secured instance both the old and the new behavior yield a
401; against an unsecured one the old header was simply ignored. Every
`KestraClient.builder()` usage in this repo (tests, `docs/*.md` samples) sets auth explicitly,
so none depended on the default. The flip also makes the bug unconstructable rather than merely
unlikely — `Auth.BASIC` is now reachable only through `basicAuth(...)`, which `requireNonNull`s
both arguments.

### Verification

The new test asserts on the built client's actual default headers, not on `notNull`. Before the
fix it failed with:

    Expecting actual:
      {"Authorization"="Basic bnVsbDpudWxs", "User-Agent"="OpenAPI-Generator/v1.0.5/java"}
    not to contain key:
      "Authorization"

`KestraClientAuthTest` covers: no credentials, explicit `noAuth()`, `noAuth()` after
`basicAuth(...)`, the exact base64 for basic, and the exact `Bearer` value for token.

Ran `compileJava` + `compileTestJava` over `java-sdk-test`, then `KestraClientAuthTest` (5) and
`KestraClientTimeoutTest` (4) — all green. The remaining `java-sdk-test` classes need the docker
Kestra instance from `run-tests.sh` and were not run.

Once published, this unblocks the "unsecured Kestra API" option that kestra-io/plugin-ai#414,
kestra-io/plugin-kestra#181, kestra-io/plugin-git#331 and kestra-io/plugin-ee-git#164 each had to
revert.
