### PR TITLE
fix(go): route the single-execution actions to their 2.0 /actions/ paths

### DIFF
--- a/go-sdk/kestra_api_client/api_executions.go
+++ b/go-sdk/kestra_api_client/api_executions.go
@@ -1994,7 +1994,7 @@ func (a *ExecutionsAPIService) ForceRunExecutionExecute(r ApiForceRunExecutionRe
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/force-run"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/force-run"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -2237,7 +2237,7 @@ func (a *ExecutionsAPIService) KillExecutionExecute(r ApiKillExecutionRequest) (
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/kill"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/kill"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -2721,7 +2721,7 @@ func (a *ExecutionsAPIService) PauseExecutionExecute(r ApiPauseExecutionRequest)
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/pause"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/pause"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -3105,7 +3105,7 @@ func (a *ExecutionsAPIService) ReplayExecutionExecute(r ApiReplayExecutionReques
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/replay"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/replay"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -3264,7 +3264,7 @@ func (a *ExecutionsAPIService) ReplayExecutionWithinputsExecute(r ApiReplayExecu
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/replay-with-inputs"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/replay-with-inputs"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -3704,7 +3704,7 @@ func (a *ExecutionsAPIService) RestartExecutionExecute(r ApiRestartExecutionRequ
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/restart"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/restart"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -4077,7 +4077,7 @@ func (a *ExecutionsAPIService) ResumeExecutionExecute(r ApiResumeExecutionReques
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/resume"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/resume"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -4817,7 +4817,7 @@ func (a *ExecutionsAPIService) SetLabelsOnTerminatedExecutionExecute(r ApiSetLab
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/labels"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/labels"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -5337,7 +5337,7 @@ func (a *ExecutionsAPIService) UnqueueExecutionExecute(r ApiUnqueueExecutionRequ
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/unqueue"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/unqueue"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -5741,7 +5741,7 @@ func (a *ExecutionsAPIService) UpdateExecutionStatusExecute(r ApiUpdateExecution
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/change-status"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/change-status"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
@@ -6156,7 +6156,7 @@ func (a *ExecutionsAPIService) UpdateTaskRunStateExecute(r ApiUpdateTaskRunState
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/state"
+	localVarPath := localBasePath + "/api/v1/{tenant}/executions/{executionId}/actions/state"
 	localVarPath = strings.Replace(localVarPath, "{"+"executionId"+"}", url.PathEscape(parameterValueToString(r.executionId, "executionId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 

--- a/go-sdk/kestra_api_client/api_executions.go
+++ b/go-sdk/kestra_api_client/api_executions.go
@@ -1832,7 +1832,7 @@ func (r ApiForceRunByIdsRequest) GetRequestBody() *[]string {
 	return r.requestBody
 }
 
-func (r ApiForceRunByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiForceRunByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.ForceRunByIdsExecute(r)
 }
 
@@ -1853,13 +1853,13 @@ func (a *ExecutionsAPIService) ForceRunByIds(ctx context.Context, tenant string)
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) ForceRunByIdsExecute(r ApiForceRunByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) ForceRunByIdsExecute(r ApiForceRunByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.ForceRunByIds")
@@ -2323,7 +2323,7 @@ func (r ApiKillExecutionsByIdsRequest) GetRequestBody() *[]string {
 	return r.requestBody
 }
 
-func (r ApiKillExecutionsByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiKillExecutionsByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.KillExecutionsByIdsExecute(r)
 }
 
@@ -2344,13 +2344,13 @@ func (a *ExecutionsAPIService) KillExecutionsByIds(ctx context.Context, tenant s
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) KillExecutionsByIdsExecute(r ApiKillExecutionsByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) KillExecutionsByIdsExecute(r ApiKillExecutionsByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodDelete
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.KillExecutionsByIds")
@@ -2794,7 +2794,7 @@ func (r ApiPauseExecutionsByIdsRequest) GetRequestBody() *[]string {
 	return r.requestBody
 }
 
-func (r ApiPauseExecutionsByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiPauseExecutionsByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.PauseExecutionsByIdsExecute(r)
 }
 
@@ -2815,13 +2815,13 @@ func (a *ExecutionsAPIService) PauseExecutionsByIds(ctx context.Context, tenant 
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) PauseExecutionsByIdsExecute(r ApiPauseExecutionsByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) PauseExecutionsByIdsExecute(r ApiPauseExecutionsByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.PauseExecutionsByIds")
@@ -3395,7 +3395,7 @@ func (r ApiReplayExecutionsByIdsRequest) GetLatestRevision() *bool {
 	return r.latestRevision
 }
 
-func (r ApiReplayExecutionsByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiReplayExecutionsByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.ReplayExecutionsByIdsExecute(r)
 }
 
@@ -3417,13 +3417,13 @@ func (a *ExecutionsAPIService) ReplayExecutionsByIds(ctx context.Context, tenant
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) ReplayExecutionsByIdsExecute(r ApiReplayExecutionsByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) ReplayExecutionsByIdsExecute(r ApiReplayExecutionsByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.ReplayExecutionsByIds")
@@ -3789,7 +3789,7 @@ func (r ApiRestartExecutionsByIdsRequest) GetRequestBody() *[]string {
 	return r.requestBody
 }
 
-func (r ApiRestartExecutionsByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiRestartExecutionsByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.RestartExecutionsByIdsExecute(r)
 }
 
@@ -3810,13 +3810,13 @@ func (a *ExecutionsAPIService) RestartExecutionsByIds(ctx context.Context, tenan
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) RestartExecutionsByIdsExecute(r ApiRestartExecutionsByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) RestartExecutionsByIdsExecute(r ApiRestartExecutionsByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.RestartExecutionsByIds")
@@ -4188,7 +4188,7 @@ func (r ApiResumeExecutionsByIdsRequest) GetRequestBody() *[]string {
 	return r.requestBody
 }
 
-func (r ApiResumeExecutionsByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiResumeExecutionsByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.ResumeExecutionsByIdsExecute(r)
 }
 
@@ -4209,13 +4209,13 @@ func (a *ExecutionsAPIService) ResumeExecutionsByIds(ctx context.Context, tenant
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) ResumeExecutionsByIdsExecute(r ApiResumeExecutionsByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) ResumeExecutionsByIdsExecute(r ApiResumeExecutionsByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.ResumeExecutionsByIds")
@@ -4904,7 +4904,7 @@ func (r ApiSetLabelsOnTerminatedExecutionsByIdsRequest) GetExecutionControllerSe
 	return r.executionControllerSetLabelsByIdsRequest
 }
 
-func (r ApiSetLabelsOnTerminatedExecutionsByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiSetLabelsOnTerminatedExecutionsByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.SetLabelsOnTerminatedExecutionsByIdsExecute(r)
 }
 
@@ -4925,13 +4925,13 @@ func (a *ExecutionsAPIService) SetLabelsOnTerminatedExecutionsByIds(ctx context.
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) SetLabelsOnTerminatedExecutionsByIdsExecute(r ApiSetLabelsOnTerminatedExecutionsByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) SetLabelsOnTerminatedExecutionsByIdsExecute(r ApiSetLabelsOnTerminatedExecutionsByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.SetLabelsOnTerminatedExecutionsByIds")
@@ -5433,7 +5433,7 @@ func (r ApiUnqueueExecutionsByIdsRequest) GetRequestBody() *[]string {
 	return r.requestBody
 }
 
-func (r ApiUnqueueExecutionsByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiUnqueueExecutionsByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.UnqueueExecutionsByIdsExecute(r)
 }
 
@@ -5454,13 +5454,13 @@ func (a *ExecutionsAPIService) UnqueueExecutionsByIds(ctx context.Context, tenan
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) UnqueueExecutionsByIdsExecute(r ApiUnqueueExecutionsByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) UnqueueExecutionsByIdsExecute(r ApiUnqueueExecutionsByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.UnqueueExecutionsByIds")
@@ -5837,7 +5837,7 @@ func (r ApiUpdateExecutionsStatusByIdsRequest) GetRequestBody() *[]string {
 	return r.requestBody
 }
 
-func (r ApiUpdateExecutionsStatusByIdsRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiUpdateExecutionsStatusByIdsRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.UpdateExecutionsStatusByIdsExecute(r)
 }
 
@@ -5858,13 +5858,13 @@ func (a *ExecutionsAPIService) UpdateExecutionsStatusByIds(ctx context.Context, 
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) UpdateExecutionsStatusByIdsExecute(r ApiUpdateExecutionsStatusByIdsRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) UpdateExecutionsStatusByIdsExecute(r ApiUpdateExecutionsStatusByIdsRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.UpdateExecutionsStatusByIds")
@@ -5982,7 +5982,7 @@ func (r ApiUpdateExecutionsStatusByQueryRequest) GetFilters() *[]QueryFilter {
 	return r.filters
 }
 
-func (r ApiUpdateExecutionsStatusByQueryRequest) Execute() (*BulkResponse, *http.Response, error) {
+func (r ApiUpdateExecutionsStatusByQueryRequest) Execute() (*ApiAsyncOperationResponse, *http.Response, error) {
 	return r.ApiService.UpdateExecutionsStatusByQueryExecute(r)
 }
 
@@ -6003,13 +6003,13 @@ func (a *ExecutionsAPIService) UpdateExecutionsStatusByQuery(ctx context.Context
 
 // Execute executes the request
 //
-//	@return BulkResponse
-func (a *ExecutionsAPIService) UpdateExecutionsStatusByQueryExecute(r ApiUpdateExecutionsStatusByQueryRequest) (*BulkResponse, *http.Response, error) {
+//	@return ApiAsyncOperationResponse
+func (a *ExecutionsAPIService) UpdateExecutionsStatusByQueryExecute(r ApiUpdateExecutionsStatusByQueryRequest) (*ApiAsyncOperationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *BulkResponse
+		localVarReturnValue *ApiAsyncOperationResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExecutionsAPIService.UpdateExecutionsStatusByQuery")


### PR DESCRIPTION
## What

`api_executions.go` was still on the Kestra 1.x URL scheme. Two fixes, both bringing it back in line with `kestra-ee.yml`:

1. The 11 single-execution actions move under `/executions/{executionId}/actions/`.
2. The 10 executions action bulk methods are retyped from `*BulkResponse` to `*ApiAsyncOperationResponse`.

## Why it drifted

`api_executions.go` was restored from the pre-2.0 generated output in #259, to keep the v1 request-builder surface alive alongside the new hand-written client. The 2.0 route move never reached it. Since the Go generator config was removed in #230, nothing regenerated it either.

The spec has been right the whole time — so the generated Python/JavaScript SDKs are unaffected. This is isolated to the Go v1-compat surface.

## The symptom is misleading

On 2.0 only `kill` returns something recognisable (403). The POST actions fall through to `POST /executions/{namespace}/{flowId}`, so:

```
POST /api/v1/main/executions/{id}/replay          -> 404 "Requested Flow is not found."
POST /api/v1/main/executions/{id}/actions/replay  -> 200
```

That 404 is the server looking for a *flow* named `replay`. It reads like a missing execution, which is what sent the original report looking in the wrong place.

The mirror image already existed: the hand-written `executions_api.go` was written against the 2.0 spec, so its `eval` 403s on 1.3. **Neither half of the SDK worked on both servers** — the generated half only on 1.3, the hand-written half only on 2.0.

## Scope

| | |
|---|---|
| **Re-pathed (11)** | `change-status`, `force-run`, `kill`, `labels`, `pause`, `replay`, `replay-with-inputs`, `restart`, `resume`, `state`, `unqueue` |
| **Untouched — did not move in 2.0** | `file`, `file/metas`, `flow`, `follow`, `follow-dependencies`, `graph` |
| **Untouched — bulk paths never moved** | `<action>/by-ids`, `<action>/by-query` |

All confirmed against a live 2.0.0-rc13, not inferred from the spec. After this change every path in `api_executions.go` resolves in `kestra-ee.yml`.

## The bulk retype

The executions action bulk endpoints answer with the 2.0 async-operation shape; the spec types all 18 as `ApiAsyncOperationResponse`. `BulkResponse` only has `count`, so the number was dropped at decode — the call succeeded, the executions were killed, and the caller read **0**. A silent wrong answer rather than an error.

```
DELETE /api/v1/main/executions/kill/by-ids
  2.0.0-rc13 -> 202 {"operationId":"2gtoTYnQy1KHopwSQAXE3y","totalItems":1}
  1.3.35     -> 200 {"count":1}
```

`DeleteExecutionsByIds` stays `*BulkResponse` — the spec still types the *delete* bulk endpoints that way, so `count` is correct there. The remaining `by-query` variants already return `map[string]interface{}`; they're untyped rather than mistyped, so I left them alone.

## ⚠️ Signature change

Per AGENTS.md. Return type only — parameters and arity are unchanged on every method.

`(*BulkResponse, *http.Response, error)` → `(*ApiAsyncOperationResponse, *http.Response, error)`

on `ForceRunByIds`, `KillExecutionsByIds`, `PauseExecutionsByIds`, `ReplayExecutionsByIds`, `RestartExecutionsByIds`, `ResumeExecutionsByIds`, `SetLabelsOnTerminatedExecutionsByIds`, `UnqueueExecutionsByIds`, `UpdateExecutionsStatusByIds`, `UpdateExecutionsStatusByQuery` (and their `*Execute` counterparts).

Callers read `GetTotalItems()` instead of `GetCount()`. This is a compile-time break, which is the intent — the value they were reading was always 0 on 2.0. **v2 is still rc, so this lands before GA rather than after.** I measured the blast radius on the one known consumer, kestractl: 9 call sites, all loud compile errors, no silent behaviour change. Happy to split this commit out if you'd rather take the path fix alone first.

## Verification

I could not run `go-sdk/run-tests.sh` locally — it needs the EE licence CI secret for `test-utils/docker-setup/application-secrets.yml`, so **CI needs to confirm the suite**. What I did run:

- `go build ./...` and `go vet ./kestra_api_client/` clean.
- End-to-end against **live EE 2.0.0-rc13 and EE 1.3.35 side by side**, driving every affected method through kestractl built against this branch: `kill`, `pause`, `force-run`, `replay`, `restart`, `resume`, `eval-expression`, `replay-with-inputs`, `set-labels`, `change-status`, plus the `-bulk` and `-by-query` families. All pass on 2.0, with correct bulk counts.
- Each action was exercised against a correctly-stated execution (a FAILED one for `restart`, a genuinely paused one for `resume`), so a state conflict could not be mistaken for a passing route.

One consequence worth flagging for downstream: with this branch, a 2.x-targeting SDK reading `totalItems` gets 0 from a 1.3 server, which still sends `count`. That's expected — this SDK targets 2.x — and consumers wanting one binary against both servers need a compat shim either way. kestractl has one.

Refs kestra-io/kestractl#117
