### PR TITLE
fix: correct kestra-api-client SCM url to point to client-sdk repo

### DIFF
--- a/java/java-sdk/build.gradle
+++ b/java/java-sdk/build.gradle
@@ -57,7 +57,7 @@ mavenPublishing {
     pom {
         name = "${project.name}"
         description = "${project.group}:${project.name}:${project.version}"
-        url = "https://github.com/kestra-io/${project.name}"
+        url = "https://github.com/kestra-io/client-sdk"
         licenses {
             license {
                 name = 'The Apache License, Version 2.0'
@@ -73,7 +73,7 @@ mavenPublishing {
         }
         scm {
             connection = 'scm:git:'
-            url = "https://github.com/kestra-io/${project.name}"
+            url = "https://github.com/kestra-io/client-sdk"
         }
     }
 }


### PR DESCRIPTION
## Summary
Maven Central's Sonatype crawler flagged `kestra-api-client` with a 404 on SCM repository lookup while reviewing our OSS-publishing exemption request. Root cause: the published POM's `url`/`scm.url` in `java/java-sdk/build.gradle` were built from `${project.name}` ("kestra-api-client", the Gradle module name), not the actual GitHub repo name (`client-sdk`).

## Change
- `url` and `scm.url` now point to `https://github.com/kestra-io/client-sdk`.

## Test plan
- [x] Config-only change, no build/test impact expected