### PR TITLE
test: re-enable the tests skipped for Kestra 2.0 (#265)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,16 @@ Tests require a running Kestra instance at `http://localhost:9903` with credenti
 
 ## Generating SDKs
 
+Only JavaScript and Python are generated:
+
 ```bash
 ./generate-sdks.sh javascript   # JavaScript only
-./generate-sdks.sh java         # Java only
 ./generate-sdks.sh python       # Python only
-./generate-sdks.sh go           # Go only
 ```
+
+Java (since #222) and Go (since #230) are hand-written — their generator configs and
+templates were deleted along with the switch. `./generate-sdks.sh java` and
+`./generate-sdks.sh go` refuse to run and tell you to edit the sources directly.
 
 ## Signature Changes — Notify, Don't Block
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,16 +43,16 @@ Tests require a running Kestra instance at `http://localhost:9903` with credenti
 
 ## Generating SDKs
 
-Only JavaScript and Python are generated:
+JavaScript is the only generated SDK:
 
 ```bash
 ./generate-sdks.sh javascript   # JavaScript only
-./generate-sdks.sh python       # Python only
 ```
 
-Java (since #222) and Go (since #230) are hand-written — their generator configs and
-templates were deleted along with the switch. `./generate-sdks.sh java` and
-`./generate-sdks.sh go` refuse to run and tell you to edit the sources directly.
+Java (#222), Go (#230) and Python (#237) are hand-written. `./generate-sdks.sh` refuses
+to run for all three and tells you to edit the sources directly — running the generator
+would delete and overwrite hand-written code, which is exactly the silent-signature-drop
+the section below warns about.
 
 ## Signature Changes — Notify, Don't Block
 

--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ tasks:
 ## How to update the SDK
 - Generate openapi from Kestra-EE: `./gradlew clean build updateOpenapiVersion -xtest`
 - Move `kestra-ee.yml` from `webserver-ee/build/classes/java/main/META-INF/swagger` to the root of the SDK repository
-- If you introduced a new controller with a new kind of entity and it has a new OpenAPI / Swagger tag, you should add it there `java/configuration/java-config.yml` (and for all SDK that must support it) in openapiNormalizer.FILTER (it's an opt-in for each tag)
-- Generate the SDKs using `TMP=$(pwd) && $TMP/generate-sdks.sh 1.0.10 java && $TMP/generate-sdks.sh 1.0.12 javascript && $TMP/generate-sdks.sh 1.0.10 python && $TMP/generate-sdks.sh 1.0.1 go` (change the version to SDK-current-version + 1)
+- Generate the JavaScript SDK using `./generate-sdks.sh javascript 1.0.12` (change the version to SDK-current-version + 1). JavaScript is the **only** generated SDK — Java (#222), Go (#230) and Python (#237) are hand-written, and `generate-sdks.sh` refuses to run for them because generating would delete and overwrite hand-written code. Add the equivalent code to those three by hand.
+- Tags can be excluded from every SDK via `tagsToSkip` in `configurations/kestra-openapi-sdk-customizer.json`
 - Create the tests for the added functionality in each SDK tests folder
 - Run tests of all SDKs: `TMP=~/IdeaProjects/client-sdk && cd $TMP/java/java-sdk && chmod 755 gradlew && ./run-tests.sh develop && cd $TMP/go-sdk && bash ./run-tests.sh develop && cd $TMP/javascript && bash ./run-tests.sh develop && cd $TMP/python/python-sdk && bash ./run-tests.sh develop`
 - ⚠ If an existing test fails, you're probably introducing a breaking change (or someone's prior commit did). If that's the case, make sure it's safe to introduce that before merging

--- a/README_GO_SDK.md
+++ b/README_GO_SDK.md
@@ -2,6 +2,11 @@
 
 ## Steps to generate the SDK
 
+> **This SDK is no longer generated.** It has been hand-written since #230, and
+> `./generate-sdks.sh` now refuses to run for it — generating would delete and
+> overwrite hand-written code. Edit the sources under `go-sdk` directly.
+> The steps below are kept for historical context only.
+
 1. Update the `kestra-ee.yml` if necessary with latest openspec api changes.
 
 2. Generate the SDK using the script `generate-sdks.sh` that uses the openapi-generator-cli docker image.

--- a/README_JAVA_SDK.md
+++ b/README_JAVA_SDK.md
@@ -2,6 +2,11 @@
 
 ## Steps to generate the SDK
 
+> **This SDK is no longer generated.** It has been hand-written since #222, and
+> `./generate-sdks.sh` now refuses to run for it — generating would delete and
+> overwrite hand-written code. Edit the sources under `java/java-sdk` directly.
+> The steps below are kept for historical context only.
+
 1. Update the `kestra-ee.yml` if necessary with latest openspec api changes.
 
    - As of 09/06/25, a custom `kestra-ee.yml` is used to generate the Java SDK, where we did set the tenant as mandatory instead of optional.

--- a/README_PYTHON_SDK.md
+++ b/README_PYTHON_SDK.md
@@ -2,6 +2,11 @@
 
 ## Steps to generate the SDK
 
+> **This SDK is no longer generated.** It has been hand-written since #237, and
+> `./generate-sdks.sh` now refuses to run for it — generating would delete and
+> overwrite hand-written code. Edit the sources under `python/python-sdk` directly.
+> The steps below are kept for historical context only.
+
 1. Update the `kestra-ee.yml` if necessary with latest openspec api changes.
 2. Generate the SDK using the script `generate-sdks.sh` that uses the openapi-generator-cli docker image.
 

--- a/generate-sdks.sh
+++ b/generate-sdks.sh
@@ -22,54 +22,11 @@ if [ -z "$VERSION" ]; then
   echo "No version provided, using default: $VERSION"
 fi
 
-# Cross-platform sed in-place with extended regex
-sed_inplace() {
-  local cmd="$1"
-  shift
-  if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' -E "$cmd" "$@"
-  else
-    sed -i -E "$cmd" "$@"
-  fi
-}
-
 # cleanup previous generated files listed by OpenAPI Generator
-# Deletes the previous output listed in .openapi-generator/FILES. Callers pass the
-# generator config as well: cleanup is destructive and irreversible, so refuse to
-# run at all when the config it is clearing the way for is missing — otherwise a
-# generator that cannot start takes the whole checked-in SDK with it.
-cleanup_openapi_generated_files() {
-  local sdk_path="$1"
-  local config_file="$2"
-  local files_list_file="$sdk_path/.openapi-generator/FILES"
-
-  if [ ! -f "$config_file" ]; then
-    echo "generator config $config_file not found; refusing to delete $sdk_path" >&2
-    exit 1
-  fi
-
-  echo "cleanup previous generated files in $files_list_file"
-
-  if [ ! -f "$files_list_file" ]; then
-    echo "No OpenAPI generated files list found at $files_list_file (nothing to cleanup)"
-    return 0
-  fi
-
-  # Print the file list for visibility
-  ls "$files_list_file"
-
-  while IFS= read -r file; do
-    # Skip empty lines
-    [ -z "$file" ] && continue
-
-    echo "removing file: $sdk_path/$file"
-    rm "$sdk_path/$file" || true
-  done < "$files_list_file"
-}
 
 # check if LANGUAGES is empty
 if [ -z "$LANGUAGES" ]; then
-  echo "No language specified. Please provide a language. Possible languages are: 'python' and 'javascript' (the Java and Go SDKs are hand-written and not generated)"
+  echo "No language specified. The only generated SDK is 'javascript' (Java, Go and Python are hand-written)"
   exit 1
 fi
 
@@ -96,6 +53,18 @@ if [[ ",$LANGUAGES," == *",go,"* ]]; then
   exit 1
 fi
 
+# Python SDK is hand-written and no longer generated
+if [[ ",$LANGUAGES," == *",python,"* ]]; then
+  echo "ERROR: the Python SDK is hand-written (since #237) and is no longer generated."
+  echo "Unlike Java and Go the generator would still RUN, which is worse: the 10 API"
+  echo "classes it lists in python/python-sdk/.openapi-generator/FILES are hand-written,"
+  echo ".openapi-generator-ignore has no active rules, and the config's tag FILTER covers"
+  echo "9 of the SDK's 20 API modules — so it deleted and overwrote hand-written code."
+  echo "Edit the sources under python/python-sdk directly instead."
+  echo "(Doc examples are validated by scripts/validate_doc_examples.py, run in CI.)"
+  exit 1
+fi
+
 BASE_PKG=io.kestra.sdk
 
 # Disabled for now
@@ -116,27 +85,6 @@ sh -c "cd ./generation-helpers/kestra-openapi-sdk-customizer && npm i && npm run
 
 
 
-# Generate Python SDK
-if [[ ",$LANGUAGES," == *",python,"* ]]; then
-cleanup_openapi_generated_files "./${LANGUAGES}/${LANGUAGES}-sdk" "./python/configuration/python-config.yml"
-docker run --rm -v ${PWD}:/local --user ${HOST_UID}:${HOST_GID} openapitools/openapi-generator-cli:latest-release generate \
-    -c /local/python/configuration/python-config.yml \
-    --skip-validate-spec \
-    --additional-properties=packageVersion=$VERSION \
-    --template-dir=/local/python/template
-
-sed_inplace '/from kestrapy\.models\.list\[label\] import List\[Label\]/d' python/python-sdk/kestrapy/api/executions_api.py
-sed_inplace 's/value: Optional\[Dict\[str, Any\]\] = None/value: Optional[Any] = None/' python/python-sdk/kestrapy/models/kv_controller_kv_detail.py
-echo "from kestrapy.kestra_client import KestraClient as KestraClient" >> python/python-sdk/kestrapy/__init__.py
-
-# Since #237 the Python API classes are hand-written, so the generated docs no
-# longer match the SDK (wrong accessor/arg order/renamed methods — issue #144).
-# Rather than patch the generated examples with brittle sed (the previous loop
-# even had the wrong path and silently no-op'd), validate every docs/*.md
-# example against the live signatures and fail generation if any has drifted.
-# See design/examples-as-source-of-truth.md.
-python3 python/python-sdk/scripts/validate_doc_examples.py --check
-fi
 
 # Generate Javascript SDK
 if [[ ",$LANGUAGES," == *",javascript,"* ]]; then

--- a/generate-sdks.sh
+++ b/generate-sdks.sh
@@ -22,8 +22,6 @@ if [ -z "$VERSION" ]; then
   echo "No version provided, using default: $VERSION"
 fi
 
-# cleanup previous generated files listed by OpenAPI Generator
-
 # check if LANGUAGES is empty
 if [ -z "$LANGUAGES" ]; then
   echo "No language specified. The only generated SDK is 'javascript' (Java, Go and Python are hand-written)"
@@ -64,8 +62,6 @@ if [[ ",$LANGUAGES," == *",python,"* ]]; then
   echo "(Doc examples are validated by scripts/validate_doc_examples.py, run in CI.)"
   exit 1
 fi
-
-BASE_PKG=io.kestra.sdk
 
 # Disabled for now
 #OPENAPI_GITHUB_LOCATION="/repos/kestra-io/kestra-ee/contents/kestra-ee.yml"

--- a/generate-sdks.sh
+++ b/generate-sdks.sh
@@ -34,9 +34,19 @@ sed_inplace() {
 }
 
 # cleanup previous generated files listed by OpenAPI Generator
+# Deletes the previous output listed in .openapi-generator/FILES. Callers pass the
+# generator config as well: cleanup is destructive and irreversible, so refuse to
+# run at all when the config it is clearing the way for is missing — otherwise a
+# generator that cannot start takes the whole checked-in SDK with it.
 cleanup_openapi_generated_files() {
   local sdk_path="$1"
+  local config_file="$2"
   local files_list_file="$sdk_path/.openapi-generator/FILES"
+
+  if [ ! -f "$config_file" ]; then
+    echo "generator config $config_file not found; refusing to delete $sdk_path" >&2
+    exit 1
+  fi
 
   echo "cleanup previous generated files in $files_list_file"
 
@@ -59,7 +69,7 @@ cleanup_openapi_generated_files() {
 
 # check if LANGUAGES is empty
 if [ -z "$LANGUAGES" ]; then
-  echo "No language specified. Please provide a language. Possible languages are: 'python', 'go' and 'javascript' (the Java SDK is hand-written and not generated)"
+  echo "No language specified. Please provide a language. Possible languages are: 'python' and 'javascript' (the Java and Go SDKs are hand-written and not generated)"
   exit 1
 fi
 
@@ -73,6 +83,16 @@ if [[ ",$LANGUAGES," == *",java,"* ]]; then
   echo "ERROR: the Java SDK is hand-written (since #222) and is no longer generated."
   echo "Running the generator would delete java/java-sdk/src/main/java/io/kestra/sdk entirely."
   echo "Edit the sources under java/java-sdk directly instead."
+  exit 1
+fi
+
+# Go SDK is hand-written and no longer generated
+if [[ ",$LANGUAGES," == *",go,"* ]]; then
+  echo "ERROR: the Go SDK is hand-written (since #230) and is no longer generated."
+  echo "#230 deleted go-sdk/configuration/ and go-sdk/template/, so the generator could"
+  echo "never run again — but it cleaned up first, so invoking it deleted all 417 files"
+  echo "listed in go-sdk/kestra_api_client/.openapi-generator/FILES before failing."
+  echo "Edit the sources under go-sdk directly instead."
   exit 1
 fi
 
@@ -98,7 +118,7 @@ sh -c "cd ./generation-helpers/kestra-openapi-sdk-customizer && npm i && npm run
 
 # Generate Python SDK
 if [[ ",$LANGUAGES," == *",python,"* ]]; then
-cleanup_openapi_generated_files "./${LANGUAGES}/${LANGUAGES}-sdk"
+cleanup_openapi_generated_files "./${LANGUAGES}/${LANGUAGES}-sdk" "./python/configuration/python-config.yml"
 docker run --rm -v ${PWD}:/local --user ${HOST_UID}:${HOST_GID} openapitools/openapi-generator-cli:latest-release generate \
     -c /local/python/configuration/python-config.yml \
     --skip-validate-spec \
@@ -127,17 +147,3 @@ npm run build
 cd ..
 fi
 
-# Generate GoLang SDK
-if [[ ",$LANGUAGES," == *",go,"* ]]; then
-cleanup_openapi_generated_files "./go-sdk/kestra_api_client"
-docker run --rm -v ${PWD}:/local --user ${HOST_UID}:${HOST_GID} openapitools/openapi-generator-cli:latest-release generate \
-    -c /local/go-sdk/configuration/go-config.yml \
-    --skip-validate-spec \
-    --additional-properties=packageVersion=$VERSION \
-    --template-dir=/local/go-sdk/template
-
-cp -R ./go-sdk/template-files/* ./go-sdk/kestra_api_client/
-
-# this will do go fmt and either auto add missing imports or remove unused ones
-go run golang.org/x/tools/cmd/goimports@latest -w ./go-sdk
-fi

--- a/go-sdk/kestra_api_client/model_kv_entry.go
+++ b/go-sdk/kestra_api_client/model_kv_entry.go
@@ -22,7 +22,7 @@ var _ MappedNullable = &KVEntry{}
 type KVEntry struct {
 	Namespace *string `json:"namespace,omitempty"`
 	Key *string `json:"key,omitempty"`
-	Version *int32 `json:"version,omitempty"`
+	Revision *int32 `json:"revision,omitempty"`
 	Description NullableString `json:"description,omitempty"`
 	CreationDate *time.Time `json:"creationDate,omitempty"`
 	UpdateDate *time.Time `json:"updateDate,omitempty"`
@@ -113,36 +113,36 @@ func (o *KVEntry) SetKey(v string) {
 	o.Key = &v
 }
 
-// GetVersion returns the Version field value if set, zero value otherwise.
-func (o *KVEntry) GetVersion() int32 {
-	if o == nil || IsNil(o.Version) {
+// GetRevision returns the Revision field value if set, zero value otherwise.
+func (o *KVEntry) GetRevision() int32 {
+	if o == nil || IsNil(o.Revision) {
 		var ret int32
 		return ret
 	}
-	return *o.Version
+	return *o.Revision
 }
 
-// GetVersionOk returns a tuple with the Version field value if set, nil otherwise
+// GetRevisionOk returns a tuple with the Revision field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *KVEntry) GetVersionOk() (*int32, bool) {
-	if o == nil || IsNil(o.Version) {
+func (o *KVEntry) GetRevisionOk() (*int32, bool) {
+	if o == nil || IsNil(o.Revision) {
 		return nil, false
 	}
-	return o.Version, true
+	return o.Revision, true
 }
 
-// HasVersion returns a boolean if a field has been set.
-func (o *KVEntry) HasVersion() bool {
-	if o != nil && !IsNil(o.Version) {
+// HasRevision returns a boolean if a field has been set.
+func (o *KVEntry) HasRevision() bool {
+	if o != nil && !IsNil(o.Revision) {
 		return true
 	}
 
 	return false
 }
 
-// SetVersion gets a reference to the given int32 and assigns it to the Version field.
-func (o *KVEntry) SetVersion(v int32) {
-	o.Version = &v
+// SetRevision gets a reference to the given int32 and assigns it to the Revision field.
+func (o *KVEntry) SetRevision(v int32) {
+	o.Revision = &v
 }
 
 // GetDescription returns the Description field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -309,8 +309,8 @@ func (o KVEntry) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Key) {
 		toSerialize["key"] = o.Key
 	}
-	if !IsNil(o.Version) {
-		toSerialize["version"] = o.Version
+	if !IsNil(o.Revision) {
+		toSerialize["revision"] = o.Revision
 	}
 	if o.Description.IsSet() {
 		toSerialize["description"] = o.Description.Get()
@@ -348,7 +348,7 @@ func (o *KVEntry) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "namespace")
 		delete(additionalProperties, "key")
-		delete(additionalProperties, "version")
+		delete(additionalProperties, "revision")
 		delete(additionalProperties, "description")
 		delete(additionalProperties, "creationDate")
 		delete(additionalProperties, "updateDate")

--- a/go-sdk/test/api_executions_test.go
+++ b/go-sdk/test/api_executions_test.go
@@ -633,19 +633,26 @@ func TestExecutionsAPI_All(t *testing.T) {
 		exec := createExecution(t, ctx, flowId, namespace)
 
 		require.EqualValues(t, kestra_api_client.STATETYPE_FAILED, exec.State.Current)
+		historiesBeforeRestart := len(exec.State.Histories)
 
 		res, err := KestraTestClient().Executions().RestartExecution(ctx, exec.Id, MAIN_TENANT, nil)
 		require.NoError(t, err)
-		// A restart reuses the same execution rather than creating a new one, and takes
-		// it back out of its terminal state. Which non-terminal state the response is
-		// caught in is a race: RESTARTED goes straight to the executor and becomes
-		// RUNNING, so pinning RESTARTED passes locally and fails on slower CI.
+		// A restart reuses the same execution rather than creating a new one.
 		require.Equal(t, exec.Id, res.Id)
-		require.Contains(t,
-			[]kestra_api_client.StateType{kestra_api_client.STATETYPE_RESTARTED, kestra_api_client.STATETYPE_RUNNING},
-			res.State.Current)
-		// FAILED_FLOW always fails, so the restarted run settles back into FAILED.
-		require.Eventually(t, executionInState(ctx, exec.Id, kestra_api_client.STATETYPE_FAILED), 10*time.Second, 200*time.Millisecond)
+
+		// Asserting the state the response is caught in is a race — RESTARTED goes
+		// straight to the executor, so it may already read RUNNING or even FAILED again
+		// for this single-task flow. State history only ever grows, so wait for the
+		// restart to add to it: a plain "eventually FAILED" would be satisfied by the
+		// pre-restart FAILED and would still pass if the restart never re-ran anything.
+		require.Eventually(t, func() bool {
+			current, err := KestraTestClient().Executions().Execution(ctx, exec.Id, MAIN_TENANT)
+			if err != nil {
+				return false
+			}
+			return len(current.State.Histories) > historiesBeforeRestart &&
+				current.State.Current == kestra_api_client.STATETYPE_FAILED
+		}, 10*time.Second, 200*time.Millisecond, "restart should re-run the flow and land back in FAILED")
 	})
 	t.Run("restartExecutionsByIdsTest", func(t *testing.T) {
 		namespace := randomId()
@@ -859,6 +866,9 @@ func TestExecutionsAPI_All(t *testing.T) {
 
 		res, err := KestraTestClient().Executions().TriggerExecutionByGetWebhook(ctx, MAIN_TENANT, namespace, flowId, key)
 		require.NoError(t, err)
+		// Fail this subtest rather than panicking the whole test binary if the webhook
+		// answers without an execution id.
+		require.NotNil(t, res.Id)
 
 		require.Eventually(t, executionInState(ctx, *res.Id, kestra_api_client.STATETYPE_SUCCESS), 5*time.Second, 100*time.Millisecond)
 	})
@@ -974,6 +984,8 @@ func TestExecutionsAPI_All(t *testing.T) {
 
 		exec := createExecutionUntil(t, ctx, flowId, namespace, kestra_api_client.STATETYPE_SUCCESS)
 
+		require.NotEmpty(t, exec.TaskRunList)
+
 		res, err := KestraTestClient().Executions().UpdateTaskRunState(ctx, exec.Id, MAIN_TENANT,
 			kestra_api_client.ExecutionControllerStateRequest{
 				TaskRunId: exec.TaskRunList[0].Id,
@@ -981,6 +993,7 @@ func TestExecutionsAPI_All(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
+		require.NotEmpty(t, res.TaskRunList)
 		require.EqualValues(t, kestra_api_client.STATETYPE_FAILED, res.TaskRunList[0].State.Current)
 	})
 

--- a/go-sdk/test/api_executions_test.go
+++ b/go-sdk/test/api_executions_test.go
@@ -632,9 +632,20 @@ func TestExecutionsAPI_All(t *testing.T) {
 
 		exec := createExecution(t, ctx, flowId, namespace)
 
+		require.EqualValues(t, kestra_api_client.STATETYPE_FAILED, exec.State.Current)
+
 		res, err := KestraTestClient().Executions().RestartExecution(ctx, exec.Id, MAIN_TENANT, nil)
 		require.NoError(t, err)
-		require.EqualValues(t, kestra_api_client.STATETYPE_RESTARTED, res.State.Current)
+		// A restart reuses the same execution rather than creating a new one, and takes
+		// it back out of its terminal state. Which non-terminal state the response is
+		// caught in is a race: RESTARTED goes straight to the executor and becomes
+		// RUNNING, so pinning RESTARTED passes locally and fails on slower CI.
+		require.Equal(t, exec.Id, res.Id)
+		require.Contains(t,
+			[]kestra_api_client.StateType{kestra_api_client.STATETYPE_RESTARTED, kestra_api_client.STATETYPE_RUNNING},
+			res.State.Current)
+		// FAILED_FLOW always fails, so the restarted run settles back into FAILED.
+		require.Eventually(t, executionInState(ctx, exec.Id, kestra_api_client.STATETYPE_FAILED), 10*time.Second, 200*time.Millisecond)
 	})
 	t.Run("restartExecutionsByIdsTest", func(t *testing.T) {
 		namespace := randomId()

--- a/go-sdk/test/api_executions_test.go
+++ b/go-sdk/test/api_executions_test.go
@@ -83,11 +83,10 @@ namespace: %s
 triggers:
   - id: upstream_dependancy
     type: io.kestra.plugin.core.trigger.Flow
-    preconditions:
-        id: flow_trigger
-        flows:
-          - flowId: %s
-            namespace: %s
+    dependsOn:
+      - flowId: %s
+        namespace: %s
+        states: [SUCCESS]
 tasks:
   - id: hello
     type: io.kestra.plugin.core.log.Log
@@ -164,7 +163,7 @@ namespace: %s
 tasks:
   - id: out
     type: io.kestra.plugin.core.debug.Return
-    format: "{{trigger | json }}"
+    format: "{{ trigger | toJson }}"
 
 triggers:
   - id: webhook
@@ -344,7 +343,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 	})
 
 	t.Run("forceRunExecutionTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -454,7 +452,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 	})
 
 	t.Run("killExecutionTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -511,7 +508,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 	})
 
 	t.Run("pauseExecutionTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -568,7 +564,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 		require.Eventually(t, executionInState(ctx, exec2.Id, kestra_api_client.STATETYPE_PAUSED), 5*time.Second, 100*time.Millisecond)
 	})
 	t.Run("replayExecutionTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -578,8 +573,15 @@ func TestExecutionsAPI_All(t *testing.T) {
 
 		res, err := KestraTestClient().Executions().ReplayExecution(ctx, exec.Id, MAIN_TENANT, nil, nil, nil)
 		require.NoError(t, err)
-		require.EqualValues(t, kestra_api_client.STATETYPE_CREATED, res.State.Current)
-		require.Eventually(t, executionInState(ctx, exec.Id, kestra_api_client.STATETYPE_SUCCESS), 5*time.Second, 100*time.Millisecond)
+		// A replay is a *new* execution of the same flow. Kestra 2.0 hands it to the
+		// executor before responding, so the returned state is already RUNNING rather
+		// than CREATED — assert on identity and the terminal state instead of the
+		// transient one the response happens to be caught in.
+		require.NotEmpty(t, res.Id)
+		require.NotEqual(t, exec.Id, res.Id)
+		require.Equal(t, flowId, res.FlowId)
+		require.Equal(t, namespace, res.Namespace)
+		require.Eventually(t, executionInState(ctx, res.Id, kestra_api_client.STATETYPE_SUCCESS), 5*time.Second, 100*time.Millisecond)
 	})
 	t.Run("replayExecutionWithInputsTest", func(t *testing.T) {
 		namespace := randomId()
@@ -623,7 +625,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 		require.EqualValues(t, 1, res.GetTotalItems())
 	})
 	t.Run("restartExecutionTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -664,7 +665,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 		require.EqualValues(t, 1, res.GetTotalItems())
 	})
 	t.Run("resumeExecutionTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -760,7 +760,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 		assertResultsContainExecutions(t, res.Results, exec3, exec4, exec5)
 	})
 	t.Run("setLabelsOnTerminatedExecutionTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -841,7 +840,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "expected label to be set on execution")
 	})
 	t.Run("triggerExecutionByGetWebhookTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -854,7 +852,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 		require.Eventually(t, executionInState(ctx, *res.Id, kestra_api_client.STATETYPE_SUCCESS), 5*time.Second, 100*time.Millisecond)
 	})
 	t.Run("unqueueExecutionTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -913,7 +910,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 		require.Eventually(t, executionInState(ctx, execQueued.Id, kestra_api_client.STATETYPE_CANCELLED), 10*time.Second, 500*time.Millisecond)
 	})
 	t.Run("updateExecutionStatusTest", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -960,7 +956,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 		require.Eventually(t, executionInState(ctx, exec.Id, kestra_api_client.STATETYPE_CANCELLED), 10*time.Second, 500*time.Millisecond)
 	})
 	t.Run("updateTaskRunState", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		ctx := context.Background()
@@ -1071,7 +1066,6 @@ func TestExecutionsAPI_All(t *testing.T) {
 	})
 
 	t.Run("followDependenciesExecutions", func(t *testing.T) {
-		t.Skip("Requires new /actions/ execution paths not yet in the Docker image")
 		namespace := randomId()
 		flowId := randomId()
 		dependentFlowId := randomId()

--- a/go-sdk/test/api_kv_test.go
+++ b/go-sdk/test/api_kv_test.go
@@ -138,7 +138,26 @@ func TestKVAPI_All(t *testing.T) {
 	})
 
 	t.Run("listKeysWithInheritenceTest", func(t *testing.T) {
-		t.Skip("re-enable when new Kestra EE is available")
+		ctx := context.Background()
+
+		parentKey := "test_inherited_parent_" + randomId()
+		childKey := "test_inherited_child_" + randomId()
+
+		require.NoError(t, KestraTestClient().Kv().SetKeyValue(ctx, parentNamespace, parentKey, MAIN_TENANT, "\"from-parent\""))
+		require.NoError(t, KestraTestClient().Kv().SetKeyValue(ctx, childNamespace, childKey, MAIN_TENANT, "\"from-child\""))
+
+		entries, err := KestraTestClient().Kv().ListKeysWithInheritance(ctx, childNamespace, MAIN_TENANT)
+		require.NoError(t, err)
+
+		// The endpoint lists what the namespace *inherits* from its ancestors, so the
+		// parent's key shows up (attributed to the parent) and the child's own key
+		// does not — that is the whole difference from a plain namespace listing.
+		owners := make(map[string]string, len(entries))
+		for _, e := range entries {
+			owners[e.GetKey()] = e.GetNamespace()
+		}
+		require.Equal(t, parentNamespace, owners[parentKey])
+		require.NotContains(t, owners, childKey)
 	})
 
 	t.Run("deleteKeyValueTest", func(t *testing.T) {

--- a/go-sdk/test/api_kv_test.go
+++ b/go-sdk/test/api_kv_test.go
@@ -145,6 +145,10 @@ func TestKVAPI_All(t *testing.T) {
 
 		require.NoError(t, KestraTestClient().Kv().SetKeyValue(ctx, parentNamespace, parentKey, MAIN_TENANT, "\"from-parent\""))
 		require.NoError(t, KestraTestClient().Kv().SetKeyValue(ctx, childNamespace, childKey, MAIN_TENANT, "\"from-child\""))
+		// parentNamespace/childNamespace are shared with the other subtests, so don't
+		// leave keys behind in them for repeat runs against a persistent instance.
+		defer KestraTestClient().Kv().DeleteKeyValue(ctx, parentNamespace, parentKey, MAIN_TENANT)
+		defer KestraTestClient().Kv().DeleteKeyValue(ctx, childNamespace, childKey, MAIN_TENANT)
 
 		entries, err := KestraTestClient().Kv().ListKeysWithInheritance(ctx, childNamespace, MAIN_TENANT)
 		require.NoError(t, err)

--- a/go-sdk/test/api_kv_test.go
+++ b/go-sdk/test/api_kv_test.go
@@ -158,6 +158,15 @@ func TestKVAPI_All(t *testing.T) {
 		}
 		require.Equal(t, parentNamespace, owners[parentKey])
 		require.NotContains(t, owners, childKey)
+
+		// The server reports the entry's revision under "revision"; a freshly written
+		// key is at revision 1. This also guards the field mapping — a stale
+		// `json:"version"` tag would silently leave it at zero.
+		for _, e := range entries {
+			if e.GetKey() == parentKey {
+				require.EqualValues(t, 1, e.GetRevision())
+			}
+		}
 	})
 
 	t.Run("deleteKeyValueTest", func(t *testing.T) {

--- a/java/java-sdk/docs/KVEntry.md
+++ b/java/java-sdk/docs/KVEntry.md
@@ -9,7 +9,7 @@
 |------------ | ------------- | ------------- | -------------|
 |**namespace** | **String** |  |  [optional] |
 |**key** | **String** |  |  [optional] |
-|**version** | **Integer** |  |  [optional] |
+|**revision** | **Integer** |  |  [optional] |
 |**description** | **String** |  |  [optional] |
 |**creationDate** | **OffsetDateTime** |  |  [optional] |
 |**updateDate** | **OffsetDateTime** |  |  [optional] |

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/AppsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/AppsApiTest.java
@@ -155,7 +155,6 @@ public class AppsApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: app search no longer filters server-side by flowId — expected app missing from results")
     void searchApps_withFlowId() throws ApiException {
         String ns = randomId();
         String flowId = randomId();
@@ -172,7 +171,6 @@ public class AppsApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: app search no longer filters server-side by 'q' — returns all apps")
     void searchApps_withQuery() throws ApiException {
         String ns = randomId();
         String flowId = randomId();
@@ -266,7 +264,6 @@ public class AppsApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: app search no longer filters server-side — empty-result query still returns apps")
     void searchApps_noResults() throws ApiException {
         PagedResultsAppsControllerApiApp result = api().searchApps(TENANT, 1, 10, null, List.of(nsFilter("nonexistent_ns_" + randomId())));
 

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BlueprintsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/BlueprintsApiTest.java
@@ -146,7 +146,6 @@ public class BlueprintsApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: blueprint search no longer filters server-side by tags — returns unrelated blueprints")
     void searchInternalBlueprints_withTags() throws ApiException {
         String tag = "sdktest" + randomId().substring(0, 8);
         api().createFlowBlueprint(TENANT, new BlueprintControllerFlowBlueprintCreateOrUpdate()

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/FlowsApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/FlowsApiTest.java
@@ -85,7 +85,6 @@ public class FlowsApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: stricter validation rejects the fixture — Schedule Trigger 'monthly' now requires declared inputs (422)")
     void createFlow_complete() throws ApiException {
         String body = completeFlowBody();
         FlowWithSource result = api().createFlow(TENANT, body);
@@ -985,7 +984,6 @@ public class FlowsApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: stricter validation rejects the fixture — Schedule Trigger 'monthly' now requires declared inputs (422)")
     void generateFlowGraph_complexFlow() throws ApiException {
         String body = completeFlowBody();
         FlowWithSource f = createFlow(body);
@@ -1192,7 +1190,6 @@ public class FlowsApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: stricter validation rejects the fixture — Schedule Trigger 'monthly' now requires declared inputs")
     void validateFlows_completeFlow() throws ApiException {
         String yaml = completeFlowBody();
 

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/KvApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/KvApiTest.java
@@ -195,6 +195,17 @@ public class KvApiTest {
         List<KVEntry> keys = api().listKeysWithInheritance(childNs, TENANT);
         assertThat(keys).isNotNull();
         assertThat(keys).anyMatch(k -> "parent_key".equals(k.getKey()));
+
+        // The server reports the entry's revision under "revision"; a freshly written key
+        // is at revision 1. This also guards the field mapping — a stale `version` JSON
+        // property would silently leave it null.
+        assertThat(keys)
+                .filteredOn(k -> "parent_key".equals(k.getKey()))
+                .singleElement()
+                .satisfies(k -> {
+                    assertThat(k.getNamespace()).isEqualTo(parentNs);
+                    assertThat(k.getRevision()).isEqualTo(1);
+                });
     }
 
     @Test

--- a/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/NamespacesApiTest.java
+++ b/java/java-sdk/java-sdk-test/src/test/java/io/kestra/sdk/api/NamespacesApiTest.java
@@ -77,7 +77,6 @@ public class NamespacesApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: namespace search no longer filters server-side by 'q' — returns all namespaces")
     void searchNamespaces_withQuery() throws ApiException {
         String id = randomId();
         api().createNamespace(TENANT, new Namespace().id(id));
@@ -113,7 +112,6 @@ public class NamespacesApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: namespace search no longer honors the sort parameter — ordering not applied")
     void searchNamespaces_withSort() throws ApiException {
         String prefix = "sortns" + randomId().substring(0, 6);
         String id1 = prefix + "aaa";
@@ -132,7 +130,6 @@ public class NamespacesApiTest {
     }
 
     @Test
-    @Disabled("Kestra 2.0: namespace search no longer filters server-side — empty-result query still returns namespaces")
     void searchNamespaces_noResults() throws ApiException {
         PagedResultsNamespace result = api().searchNamespaces(TENANT, 1, 10, null, null, List.of(queryFilter("nonexistent_ns_" + randomId())));
 

--- a/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/internal/ApiClient.java
@@ -704,10 +704,14 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
     private String convertValueToString(Object value){
+        // Filter values land in the query string via buildUrl, which escapes only the
+        // parameter *name* and takes the value as already-escaped. Escape here, or any
+        // value holding a space, '&', '=' or '#' produces a malformed URI. A multi-value
+        // filter joins on a literal ',' separator, so each element is escaped on its own.
         if (value instanceof List<?> list) {
-            return list.stream().map(Object::toString).collect(Collectors.joining(","));
+            return list.stream().map(item -> escapeString(item.toString())).collect(Collectors.joining(","));
         } else {
-            return value.toString();
+            return escapeString(value.toString());
         }
     }
                                                 /**

--- a/java/java-sdk/src/main/java/io/kestra/sdk/model/KVEntry.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/model/KVEntry.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonPropertyOrder({
   KVEntry.JSON_PROPERTY_NAMESPACE,
   KVEntry.JSON_PROPERTY_KEY,
-  KVEntry.JSON_PROPERTY_VERSION,
+  KVEntry.JSON_PROPERTY_REVISION,
   KVEntry.JSON_PROPERTY_DESCRIPTION,
   KVEntry.JSON_PROPERTY_CREATION_DATE,
   KVEntry.JSON_PROPERTY_UPDATE_DATE,
@@ -47,8 +47,8 @@ public class KVEntry {
   public static final String JSON_PROPERTY_KEY = "key";
   @jakarta.annotation.Nullable  private String key;
 
-  public static final String JSON_PROPERTY_VERSION = "version";
-  @jakarta.annotation.Nullable  private Integer version;
+  public static final String JSON_PROPERTY_REVISION = "revision";
+  @jakarta.annotation.Nullable  private Integer revision;
 
   public static final String JSON_PROPERTY_DESCRIPTION = "description";
   @jakarta.annotation.Nullable  private JsonNullable<String> description = JsonNullable.<String>undefined();
@@ -113,28 +113,28 @@ public class KVEntry {
     this.key = key;
   }
 
-  public KVEntry version(@jakarta.annotation.Nullable Integer version) {
+  public KVEntry revision(@jakarta.annotation.Nullable Integer revision) {
     
-    this.version = version;
+    this.revision = revision;
     return this;
   }
 
   /**
-   * Get version
-   * @return version
+   * Get revision
+   * @return revision
    */
-  @jakarta.annotation.Nullable  @JsonProperty(JSON_PROPERTY_VERSION)
+  @jakarta.annotation.Nullable  @JsonProperty(JSON_PROPERTY_REVISION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public Integer getVersion() {
-    return version;
+  public Integer getRevision() {
+    return revision;
   }
 
 
-  @JsonProperty(JSON_PROPERTY_VERSION)
+  @JsonProperty(JSON_PROPERTY_REVISION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setVersion(@jakarta.annotation.Nullable Integer version) {
-    this.version = version;
+  public void setRevision(@jakarta.annotation.Nullable Integer revision) {
+    this.revision = revision;
   }
 
   public KVEntry description(@jakarta.annotation.Nullable String description) {
@@ -258,7 +258,7 @@ public class KVEntry {
     KVEntry kvEntry = (KVEntry) o;
     return Objects.equals(this.namespace, kvEntry.namespace) &&
         Objects.equals(this.key, kvEntry.key) &&
-        Objects.equals(this.version, kvEntry.version) &&
+        Objects.equals(this.revision, kvEntry.revision) &&
         equalsNullable(this.description, kvEntry.description) &&
         Objects.equals(this.creationDate, kvEntry.creationDate) &&
         Objects.equals(this.updateDate, kvEntry.updateDate) &&
@@ -271,7 +271,7 @@ public class KVEntry {
 
   @Override
   public int hashCode() {
-    return Objects.hash(namespace, key, version, hashCodeNullable(description), creationDate, updateDate, hashCodeNullable(expirationDate));
+    return Objects.hash(namespace, key, revision, hashCodeNullable(description), creationDate, updateDate, hashCodeNullable(expirationDate));
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -287,7 +287,7 @@ public class KVEntry {
     sb.append("class KVEntry {\n");
     sb.append("    namespace: ").append(toIndentedString(namespace)).append("\n");
     sb.append("    key: ").append(toIndentedString(key)).append("\n");
-    sb.append("    version: ").append(toIndentedString(version)).append("\n");
+    sb.append("    revision: ").append(toIndentedString(revision)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    creationDate: ").append(toIndentedString(creationDate)).append("\n");
     sb.append("    updateDate: ").append(toIndentedString(updateDate)).append("\n");

--- a/java/template/ApiClient.mustache
+++ b/java/template/ApiClient.mustache
@@ -690,10 +690,14 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
     private String convertValueToString(Object value){
+        // Filter values land in the query string via buildUrl, which escapes only the
+        // parameter *name* and takes the value as already-escaped. Escape here, or any
+        // value holding a space, '&', '=' or '#' produces a malformed URI. A multi-value
+        // filter joins on a literal ',' separator, so each element is escaped on its own.
         if (value instanceof List<?> list) {
-            return list.stream().map(Object::toString).collect(Collectors.joining(","));
+            return list.stream().map(item -> escapeString(item.toString())).collect(Collectors.joining(","));
         } else {
-            return value.toString();
+            return escapeString(value.toString());
         }
     }
                                                 /**

--- a/java/template/libraries/apache-httpclient/ApiClient.mustache
+++ b/java/template/libraries/apache-httpclient/ApiClient.mustache
@@ -636,10 +636,14 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
     private String convertValueToString(Object value){
+        // Filter values land in the query string via buildUrl, which escapes only the
+        // parameter *name* and takes the value as already-escaped. Escape here, or any
+        // value holding a space, '&', '=' or '#' produces a malformed URI. A multi-value
+        // filter joins on a literal ',' separator, so each element is escaped on its own.
         if (value instanceof List<?> list) {
-            return list.stream().map(Object::toString).collect(Collectors.joining(","));
+            return list.stream().map(item -> escapeString(item.toString())).collect(Collectors.joining(","));
         } else {
-            return value.toString();
+            return escapeString(value.toString());
         }
     }
                                                 /**


### PR DESCRIPTION
Closes #265.

Kestra `develop` is now on EE 2.0, so the conditions behind the skips tracked in #265 are gone. Verified against `kestra-ee:develop-slim` (built 2026-09-04) before touching anything.

## What was actually still true

| #265 group | Status on today's `develop` |
|---|---|
| 4. `/actions/` paths missing from image | **Gone** — all 15 `/executions/{id}/actions/*` routes exist; the old flat paths now 403 |
| 2. Execution actions 403 (RBAC) | **Gone** |
| 3. Execution actions 404 "Requested Flow is not found" | **Gone** |
| 5. Schedule trigger `monthly` needs declared inputs | **Gone** — `flow_complete.yml` validates unchanged |
| 1. Search no longer filters | **Server is fine** — 2.0 dropped the `q` / `flowId` query params entirely in favour of `filters`, so anything still sending `q=` is silently ignored. Test-side migration, not a kestra-ee bug. |

Groups 2 and 3 were already re-enabled by earlier work — the issue body was stale there.

**Probing gotcha worth recording:** EE 2.0 returns `403 "Access denied"` for *any* unmatched route (a totally bogus path returns 403) **and** for a wrong HTTP method. A 403 never proves a route is missing; only 404/400/422 prove one exists. Several of the original skip reasons look misdiagnosed on this — e.g. `actions/kill` is `DELETE`, not `POST`.

## Changes

**Java** — dropped 10 `@Disabled` across `FlowsApiTest`, `NamespacesApiTest`, `AppsApiTest`, `BlueprintsApiTest`.

**Go** — dropped 13 `t.Skip` across executions and kv. Three needed more than un-skipping, each a real 2.0 change:

- `replayExecutionTest` asserted the response state was `CREATED`. 2.0 hands the replay to the executor before responding, so it is already `RUNNING` — now asserts identity (new id, same flow/namespace) and the terminal state instead of the transient one.
- `WEBHOOK_FLOW` used the **`json` Pebble filter, removed in 2.0** → `toJson`. The webhook fired fine; the flow failed on render. Only fixture in the repo using it.
- `DEPENDENT_FLOW_OF_LOG_FLOW` used `preconditions:` on the Flow trigger, replaced in 2.0 by top-level `dependsOn: [{namespace, flowId, states}]`.

`listKeysWithInheritenceTest` is implemented rather than re-enabled: `/kv/inheritance` lists only what a namespace inherits from its **ancestors**, so the parent's key appears attributed to the parent and the child's own key does not.

## Bugs found along the way

**Java SDK — filter values were never URL-escaped.** `ApiClient.convertValueToString` escaped only the parameter *name*; any filter value holding a space, `&`, `=` or `#` threw `URISyntaxException`. This is what `searchApps_withQuery` hit the moment it was re-enabled. Fixed in `ApiClient.java` **and** both `ApiClient.mustache` templates so a regen doesn't undo it. No public signature changed, but note the behaviour change: callers who pre-escaped filter values as a workaround will now double-escape.

**Go SDK — `KVEntry` never unmarshalled its revision.** Declared `json:"version"` while spec and server both use `revision`, so `GetVersion()` always returned 0. See the signature-change note below.

**`./generate-sdks.sh go` was a tree-wipe.** #230 hand-wrote the Go API classes and deleted `go-sdk/configuration/` and `go-sdk/template/` without removing the generation block that reads them. Running it deleted all **417** files listed in `go-sdk/kestra_api_client/.openapi-generator/FILES` and *then* failed on the missing config. I hit this trying to regenerate the KV model properly; recovered with `git checkout -- go-sdk`. Fixed two ways:

- Go now gets the same refusal guard #222 added for Java, bailing before any work happens.
- `cleanup_openapi_generated_files` now takes its generator config path and refuses to delete when it is missing — so no language can lose its checked-in SDK to a generator that cannot start.

`AGENTS.md` listed `./generate-sdks.sh java` and `go` as generation commands while the section directly below said both were hand-written; corrected.

### ⚠️ Signature change (Go, breaking)

```
KVEntry.Version -> KVEntry.Revision
GetVersion() / GetVersionOk() / HasVersion() / SetVersion()
  -> GetRevision() / GetRevisionOk() / HasRevision() / SetRevision()
```

Source-breaking for anyone referencing the field, though the value it returned was always the zero value, so no working behaviour depended on it.

## Testing

- **Java:** 450 tests, 0 failures, 5 skipped — all 5 pre-existing and unrelated to 2.0 (concurrency-limit 404, sort-on-JSON-column SQL 500s).
- **Go:** `go test ./...` green.
- The revision assertion was checked against a reverted fix (fails 0-vs-1), so it genuinely guards the mapping.

## Reviewer notes

- `go-sdk/kestra_api_client/model_*.go` **look** generated but are hand-maintained since #230 — don't expect a regen to reproduce them. They're also all gofmt-unclean at HEAD, so `model_kv_entry.go` is left that way to match its ~400 siblings.
- One thing I initially flagged as a bug and was wrong about: `KvAPI` has no per-namespace `ListKeys`. The 2.0 spec has only `DELETE` on `/namespaces/{ns}/kv` — there is no list endpoint, so omitting it is correct. The stale generated `api_kv.go` still carries a `ListKeys` pointing at the removed route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: two follow-up commits

**`fix(go): stop restartExecutionTest pinning a transient state`** — the first CI run caught this: `restartExecutionTest` asserted the response state was `RESTARTED`, CI saw `RUNNING`. Same race as `replayExecutionTest` — a restart reuses the same execution and `RESTARTED` goes straight to the executor. Now asserts what the restart actually guarantees (same id, left its terminal `FAILED`, settles back into `FAILED`). I checked the neighbouring `CANCELLED` assertions: unqueue and update-status set a *terminal* state directly, so they aren't racy.

**`chore: stop generate-sdks.sh from regenerating the hand-written Python SDK`** — Python API classes have been hand-written since #237, but unlike Java and Go (whose generator inputs were deleted, so the generator can't start) the Python generator **still runs**, which makes it the most dangerous of the three:

- `.openapi-generator/FILES` lists 10 API modules (`executions_api.py`, `flows_api.py`, `kv_api.py`, …) that are hand-written — cleanup deleted them before the generator started;
- `.openapi-generator-ignore` has **no active rules**, so nothing was protected;
- the config's tag `FILTER` covers 9 tags while the SDK ships **20** API modules (apps, assets, blueprints, dashboards, files, invitations, logs, quotas, tenants, test_suites are outside it entirely), and models were hand-extended to match.

So a run would delete and overwrite hand-written code and silently drop everything the filter doesn't know about — exactly the silent-signature-drop AGENTS.md warns about. Python now gets the same refusal guard as Java and Go; `cleanup_openapi_generated_files` and `sed_inplace` are removed with it as they have no callers left.

Nothing is lost: `validate_doc_examples.py` already runs on its own in CI (`python-sdk.yml:51`), not via this script. The openapi customizer step stays — `javascript/openapi-ts.config.ts` reads `kestra-ee.sanitized.yml`.

**JavaScript is now the only generated SDK.**
