### PR TITLE
fix(go)!: bind /acls/permissions and stop decoding actions into a closed enum

### DIFF
--- a/go-sdk/kestra_api_client/api_misc.go
+++ b/go-sdk/kestra_api_client/api_misc.go
@@ -350,12 +350,21 @@ func (r ApiListActionsRequest) GetTenant() string {
 	return r.tenant
 }
 
-func (r ApiListActionsRequest) Execute() ([]Action, *http.Response, error) {
+func (r ApiListActionsRequest) Execute() ([]string, *http.Response, error) {
 	return r.ApiService.ListActionsExecute(r)
 }
 
 /*
 ListActions Retrieve list of actions
+
+Kestra 1.x only: 2.0 removed /acls/actions when it replaced the flat action
+vocabulary with the per-resource model. Use ListPermissions against 2.x.
+
+The actions come back as plain strings rather than the Action enum, for the same
+reason as ListPermissions: this endpoint reports the server's own vocabulary, and
+a closed enum cannot represent a server that disagrees with it. Kestra 1.3
+returns READ, which the Action enum has never had, so every 1.3 call decoded
+into []Action failed even though the server answered 200.
 
 Actions are used to restrict possible operations for each permission. Each action must be one of the following: CREATE, READ, UPDATE, DELETE. Using permissions and actions together, you can control access to resources e.g. only allow a user to read a flow, but not update or delete it.
 
@@ -373,13 +382,13 @@ func (a *MiscAPIService) ListActions(ctx context.Context, tenant string) ApiList
 
 // Execute executes the request
 //
-//	@return []Action
-func (a *MiscAPIService) ListActionsExecute(r ApiListActionsRequest) ([]Action, *http.Response, error) {
+//	@return []string
+func (a *MiscAPIService) ListActionsExecute(r ApiListActionsRequest) ([]string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue []Action
+		localVarReturnValue []string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "MiscAPIService.ListActions")
@@ -388,6 +397,129 @@ func (a *MiscAPIService) ListActionsExecute(r ApiListActionsRequest) ([]Action, 
 	}
 
 	localVarPath := localBasePath + "/api/v1/{tenant}/acls/actions"
+	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type ApiListPermissionsRequest struct {
+	ctx        context.Context
+	ApiService *MiscAPIService
+	tenant     string
+}
+
+func (r ApiListPermissionsRequest) GetTenant() string {
+	return r.tenant
+}
+
+func (r ApiListPermissionsRequest) Execute() (map[string][]string, *http.Response, error) {
+	return r.ApiService.ListPermissionsExecute(r)
+}
+
+/*
+ListPermissions Retrieve resource-to-actions mapping
+
+Returns the full mapping of resources to their valid actions, as Kestra 2.0
+serves it: {"FLOW": ["VIEW", "CREATE", ...], "EXECUTION": [...], ...}.
+
+The actions are returned as plain strings rather than the Action enum on
+purpose. This endpoint exists to *discover* the server's action vocabulary, so
+decoding it into a closed enum defeats it: a server that adds an action fails
+the whole call. Kestra 2.0.0-rc13 already returns LOCK, PROMOTE and TEMPLATE,
+none of which the Action enum knows.
+
+This replaces ListActions, which 2.0 removed along with the flat action
+vocabulary. Both are kept because they are not interchangeable: 1.x answers
+/acls/permissions with a flat list of resource *names*, so it cannot serve this
+method, and 2.x has no /acls/actions at all. A caller supporting both server
+lines must pick by server version, not by falling back on a 403/404.
+
+Actions are used to restrict possible operations for each permission. Each action must be one of the following: CREATE, READ, UPDATE, DELETE. Using permissions and actions together, you can control access to resources e.g. only allow a user to read a flow, but not update or delete it.
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param tenant
+	@return ApiListPermissionsRequest
+*/
+func (a *MiscAPIService) ListPermissions(ctx context.Context, tenant string) ApiListPermissionsRequest {
+	return ApiListPermissionsRequest{
+		ApiService: a,
+		ctx:        ctx,
+		tenant:     tenant,
+	}
+}
+
+// Execute executes the request
+//
+//	@return map[string][]string
+func (a *MiscAPIService) ListPermissionsExecute(r ApiListPermissionsRequest) (map[string][]string, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue map[string][]string
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "MiscAPIService.ListPermissions")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/{tenant}/acls/permissions"
 	localVarPath = strings.Replace(localVarPath, "{"+"tenant"+"}", url.PathEscape(parameterValueToString(r.tenant, "tenant")), -1)
 
 	localVarHeaderParams := make(map[string]string)


### PR DESCRIPTION
## What was wrong

`MiscAPI.ListActions` calls `GET /acls/actions`, which **Kestra 2.0 removed** when `#7550` replaced the flat action vocabulary with the per-resource `Resource`/`Action` model. Against 2.0 the call 403s, so kestractl's `server actions` is dead there — the same 403 route-miss signature as kestra-io/kestractl#117.

The replacement is `GET /acls/permissions` (`listPermissions` in `kestra-ee.yml`). This PR binds it and keeps both methods.

## Why both, and why no fallback is possible

This is **not** a path rename you can shim. `/acls/permissions` exists on *both* server lines and returns incompatible bodies. From `AclController` on `releases/v1.3.x` vs `develop`:

| | 1.3 | 2.0 |
|---|---|---|
| `GET /acls/actions` | `List<Action>` | **removed** |
| `GET /acls/permissions` | `List<Permission>` | `Map<Resource, Set<Action>>` |

Verified on the wire:

```
1.3.35      GET /acls/actions      -> ["READ","CREATE","UPDATE","DELETE"]
            GET /acls/permissions  -> ["FLOW","BLUEPRINT","TEMPLATE", ...]
2.0.0-rc13  GET /acls/actions      -> 403
            GET /acls/permissions  -> {"FLOW":["VIEW",...],"ASSET":[...], ...}
```

Same path, different *kind* of answer. A transport-level rewrite of `actions`→`permissions` would, on 1.x, silently hand the caller a list of resource **names** rendered as actions — wrong data, no error. So choosing by server version is the only correct option, and both doc comments say so explicitly.

## Actions are now strings, not the `Action` enum

These endpoints exist to report *the server's own* action vocabulary. Decoding them into a generated closed enum defeats that: any value the enum doesn't know fails the entire call. That isn't hypothetical in either direction:

- **1.3** returns `READ`, which `Action` has never contained — so *every* 1.3 call failed to decode despite a 200. kestractl already carried a workaround, recovering the raw list out of the error body. It can now delete it.
- **2.0** returns `LOCK`, `PROMOTE` and `TEMPLATE`, none of which `Action` contains.

Adding those members would fix today and break on the next server that adds an action. Strings don't.

## ⚠️ Signature change

Per AGENTS.md. Parameters and arity unchanged.

```
MiscAPI.ListActions      ([]Action,  *http.Response, error)
                      -> ([]string,  *http.Response, error)

MiscAPI.ListPermissions  new
                      -> (map[string][]string, *http.Response, error)
```

The `Action` enum itself is untouched — it's still used by the role and binding models, where its staleness (no `READ`, `LOCK`, `PROMOTE`, `TEMPLATE`) is a separate question worth its own look.

## Verification

Live against **EE 1.3.35** and **EE 2.0.0-rc13**, both methods against both servers:

| | `ListActions` | `ListPermissions` |
|---|---|---|
| 1.3.35 | `[READ CREATE UPDATE DELETE]` ✅ | decode error — correct, wrong server line |
| 2.0.0-rc13 | 403 — correct, endpoint removed | 28 resources, no error ✅ |

`go build ./...` and `go vet` clean.

## Context

Found during a pre-GA sweep of the generated v1-compat surface against `kestra-ee.yml`, prompted by kestra-io/kestractl#117. Two other drifted endpoints turned up in the same audit — `FlowsAPI.UpdateTask` (`PATCH /flows/{ns}/{id}/{taskId}`) and `TriggersAPI.UpdateTrigger` (`PUT /triggers`) — both of which have **no** counterpart operation in the 2.0 spec at all and are called by nothing. Those are a separate cleanup PR; this one is the only drifted endpoint with a live consumer.
