### PR TITLE
Target Kestra 2.0.0 GA for the go-sdk 2.0.0 release

### DIFF
--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -9,6 +9,11 @@ on:
       - 'go-sdk/**'
       - 'README.md'
       - 'test-utils/**'
+      # The suite's own definition, so a change to the Kestra version it targets
+      # (or to the shared composites it calls) is exercised by this workflow
+      # rather than merging unvalidated.
+      - '.github/workflows/go-sdk.yml'
+      - '.github/actions/**'
   pull_request:
     branches:
       - main
@@ -17,6 +22,11 @@ on:
       - 'go-sdk/**'
       - 'README.md'
       - 'test-utils/**'
+      # The suite's own definition, so a change to the Kestra version it targets
+      # (or to the shared composites it calls) is exercised by this workflow
+      # rather than merging unvalidated.
+      - '.github/workflows/go-sdk.yml'
+      - '.github/actions/**'
   workflow_dispatch:
     inputs:
       skip-test:

--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -34,6 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+      # The Kestra release the Go SDK is tested against on `main`. Bump it when the
+      # SDK starts targeting a newer Kestra release; see the resolve step below for
+      # why main does not test against `develop` any more.
+      KESTRA_GA_TARGET: v2.0.0
     defaults:
       run:
         working-directory: ./go-sdk
@@ -43,6 +47,28 @@ jobs:
       - name: Compute Kestra version
         id: version
         uses: ./.github/actions/compute-version
+
+      # compute-version answers `develop` whenever no releases/v* branch matched,
+      # i.e. on main and on feature branches targeting it. `develop` is the moving
+      # 2.x bleeding edge, which is the wrong thing to certify the SDK's own 2.0.0
+      # release against: a green run there says nothing about the server users
+      # actually run. Pin those runs to KESTRA_GA_TARGET instead. Release branches
+      # keep resolving to their own version, untouched.
+      #
+      # Drift against the bleeding edge is still watched -- sdk-freshness-check.yml
+      # runs this same suite against `develop` daily and alerts without gating.
+      - name: Resolve the Kestra version under test
+        id: target
+        env:
+          COMPUTED: ${{ steps.version.outputs.kestra_version }}
+        run: |
+          if [ "$COMPUTED" = "develop" ]; then
+            resolved="$KESTRA_GA_TARGET"
+          else
+            resolved="$COMPUTED"
+          fi
+          echo "Testing against Kestra $resolved (compute-version said '$COMPUTED')"
+          echo "kestra_version=$resolved" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@v5
 
@@ -75,16 +101,14 @@ jobs:
         id: license
         uses: ./.github/actions/set-license-file
         with:
-          kestra_version: ${{ steps.version.outputs.kestra_version }}
+          kestra_version: ${{ steps.target.outputs.kestra_version }}
           license_file: ${{ secrets.KESTRA_EE_UNIT_TEST_LICENSE_FILE }}
           license_legacy_file: ${{ secrets.KESTRA_EE_UNIT_TEST_LICENSE_LEGACY_FILE }}
 
       - name: Build local SDK and test it in an example project
         if: inputs.skip-test != 'true'
         env:
-          # Target Kestra 2.0: 'develop' is the 2.0-ee line. Release branches (releases/v*)
-          # still resolve to their own version via compute-version.
-          KESTRA_VERSION: ${{ steps.version.outputs.kestra_version }}
+          KESTRA_VERSION: ${{ steps.target.outputs.kestra_version }}
         run: |
           echo "${{ steps.license.outputs.license }}" | base64 -d > ../test-utils/docker-setup/application-secrets.yml
           sh run-tests.sh $KESTRA_VERSION

--- a/kestra-ee.yml
+++ b/kestra-ee.yml
@@ -4,7 +4,7 @@ info:
   description: |-
     All API operations, except for Instance-owner-only endpoints, require a tenant identifier in the HTTP path.<br/>
     Endpoints designated as Instance-owner-only are not tenant-scoped.
-  version: 2.1.0-SNAPSHOT
+  version: 2.0.0
 tags:
 - name: Flows
   description: Flows api
@@ -29857,7 +29857,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IAMServiceAccountController.ApiUpdateServiceAccountRequest'
+              $ref: '#/components/schemas/IAMServiceAccountController.ApiServiceAccountRequest'
         required: true
       responses:
         '404':
@@ -38174,7 +38174,6 @@ components:
           items:
             type: string
         email:
-          minLength: 1
           type: string
     IAMInvitationController.ApiInvitationDetail:
       type: object
@@ -38525,23 +38524,6 @@ components:
         username:
           type: string
       description: A User Service Account.
-    IAMServiceAccountController.ApiUpdateServiceAccountRequest:
-      required:
-      - name
-      type: object
-      properties:
-        groups:
-          type: array
-          items:
-            $ref: '#/components/schemas/IAMServiceAccountController.ApiGroup'
-        name:
-          pattern: ^(?=.{1,63}$)[a-z0-9]+(?:-[a-z0-9]+)*$
-          type: string
-        description:
-          type: string
-        instanceOwner:
-          type: boolean
-      description: 'Update payload for a service account. It carries no `username`: the login is chosen at creation and is immutable, so exposing it here would let a caller send a value that is silently dropped.'
     IAMTenantAccessController.ApiAuthentication:
       type: object
       properties:
@@ -40677,11 +40659,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PebbleFunction.Argument'
-        deprecated:
-          type: boolean
-        replacement:
-          type: string
-          nullable: true
     PebbleFunction.Argument:
       type: object
       properties:


### PR DESCRIPTION
Prep for cutting `go-sdk/v2.0.0`. Two things were still pointing at `develop` — which, since Kestra 2.0.0 GA was tagged today, now means the **2.1** line.

## The compatibility matrix

`compute-version` answers `develop` for any branch that is not `releases/v*`, so on `main` the Go SDK suite ran against the moving 2.x bleeding edge. That is the wrong server to certify `go-sdk` v2.0.0 against — a green run on develop says nothing about the Kestra 2.0.0 GA release users actually run.

Those runs are now pinned to `KESTRA_GA_TARGET` (`v2.0.0`), declared once at the job level so the next Kestra release is a one-line bump. `releases/v*` branches keep resolving to their own version through `compute-version`, untouched, and drift against the bleeding edge is still watched by the daily, non-gating `sdk-freshness-check.yml`.

Scoped to the Go SDK deliberately: `compute-version` is shared with the Java, Python and JavaScript workflows, which are not releasing 2.0.0 here.

Also added the workflow file and `.github/actions/**` to its own `paths` filters — they listed only `go-sdk/**`, `README.md` and `test-utils/**`, so a change to which Kestra version the suite targets would have merged without the suite ever running.

## The OpenAPI spec

The committed `kestra-ee.yml` said `2.1.0-SNAPSHOT`: it described a version no user can run.

The spec is not a released artifact — kestra-ee generates it from the EE gradle build and kestrabot pushes it here — so there is no `v2.0.0`-tagged file to take. It was reconstructed from the EE distribution instead: `META-INF/swagger/kestra-ee.yml` inside the image's `/app/kestra` executable, `info.version` rewritten to `2.0.0`, then run through kestra-ee's own `tag-enterprise-only-openapi-routes.mjs` against the GA OSS spec so the `x-kestra: {edition: ee}` markers are reproduced exactly as the bot would (399 routes tagged).

### Why rc15 is a sound stand-in

No `v2.0.0` EE image is published yet (the GA Docker publish has not run for OSS or EE — Docker Hub's newest `kestra/kestra` tag is still `v2.0.0-rc15`), so the closest published build was used. Three independent lines of evidence that its API surface *is* the GA surface:

1. The OSS spec bundled in the same rc15 image is **byte-identical** to the one in the `v2.0.0` GA release jar, apart from `info.version`.
2. The three kestra-ee commits between `v2.0.0-rc15` and `v2.0.0` touch only `core-ee` service internals (`BackupService`, apps `Outputs`) plus the `gradle.properties` version bump — no controller, DTO or route.
3. The resulting diff is 491 paths in and 491 out, with no route added or removed.

### What the diff removes

Develop-only 2.1 work, which is the point:

- `IAMServiceAccountController.ApiUpdateServiceAccountRequest` — the 2.1 service-account basic-auth split
- an `email` `minLength`
- `PebbleFunction`'s `deprecated` / `replacement` fields

The Go SDK is hand-written and already matches GA here — its `UpdateServiceAccount` builder sends `ApiServiceAccountRequest`, the GA schema, not the 2.1 split — so no SDK source change accompanies this.

## Reviewer notes

- **This pin will be overwritten.** kestrabot regenerates `kestra-ee.yml` from kestra-ee `develop` on every push there, so `main`'s spec will drift back to 2.1 on the next bot run. Worth deciding whether the 2.0 line wants a `releases/v2.0.x` branch (kestra-ee already has one, and `v2.0.0` sits exactly on it) — `compute-version` resolves such a branch to `v2.0.0` with no code change, and the bot leaves it alone.
- **The JS pipeline will run**, since `javascript-sdk.yml` triggers on `kestra-ee.yml`. It regenerates from this spec and then e2e-tests against a `develop` (2.1) server. Nothing in the JS SDK or its tests references the removed 2.1 schemas, so this is expected to pass, but it is the one job worth watching.
- Once this is green and merged, `go-sdk/v2.0.0` can be tagged.

### ⚠️ Signature change

None. No hand-written SDK source is touched.