### PR TITLE
fix(java): serialize QueryFilter params in the server's PHP-style nested form

### DIFF
--- a/java/java-sdk/src/main/java/io/kestra/sdk/internal/BaseApi.java
+++ b/java/java-sdk/src/main/java/io/kestra/sdk/internal/BaseApi.java
@@ -2,6 +2,8 @@ package io.kestra.sdk.internal;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import io.kestra.sdk.model.QueryFilter;
+
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ParseException;
@@ -75,7 +77,53 @@ public abstract class BaseApi {
     if (filters == null || filters.isEmpty()) {
       return Collections.emptyList();
     }
-    return apiClient.parameterToPairs("csv", "filters", filters);
+    // The server binds filters in PHP-style nested form: filters[<field>][<operation>] or
+    // filters[<field>][<operation>][<key>] for map-like values such as labels (see Kestra's
+    // QueryFilterFormatBinder). Serializing the filter objects as a CSV query value silently
+    // drops them server-side - the binder only looks at "filters["-prefixed parameter names -
+    // which makes every filtered endpoint operate on the full, unfiltered result set.
+    List<Pair> params = new ArrayList<>();
+    for (Object filter : filters) {
+      if (!(filter instanceof QueryFilter queryFilter)) {
+        continue;
+      }
+      if (queryFilter.getField() == null || queryFilter.getOperation() == null) {
+        continue;
+      }
+      String field = toFilterFieldName(queryFilter.getField().getValue());
+      String operation = queryFilter.getOperation().getValue();
+      Object value = queryFilter.getValue();
+      if (value instanceof Map<?, ?> mapValue) {
+        // Map-like values (e.g. labels) expand to filters[<field>][<op>][<key>]=<value>
+        for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
+          params.add(new Pair(
+              "filters[" + field + "][" + operation + "][" + entry.getKey() + "]",
+              apiClient.escapeString(apiClient.parameterToString(entry.getValue()))));
+        }
+      } else {
+        params.add(new Pair(
+            "filters[" + field + "][" + operation + "]",
+            apiClient.escapeString(apiClient.parameterToString(value))));
+      }
+    }
+    return params;
+  }
+
+  /**
+   * Maps a QueryFilter field to the parameter name the server expects: SCREAMING_CASE enum
+   * values become camelCase (NAMESPACE to namespace, FLOW_ID to flowId), and QUERY shortens to
+   * "q", matching the values of Kestra's QueryFilter.Field.
+   */
+  private static String toFilterFieldName(String fieldValue) {
+    String[] parts = fieldValue.toLowerCase(java.util.Locale.ROOT).split("_");
+    StringBuilder sb = new StringBuilder(parts[0]);
+    for (int i = 1; i < parts.length; i++) {
+      if (!parts[i].isEmpty()) {
+        sb.append(Character.toUpperCase(parts[i].charAt(0))).append(parts[i].substring(1));
+      }
+    }
+    String camel = sb.toString();
+    return "query".equals(camel) ? "q" : camel;
   }
 
   protected List<Pair> csvParams(String name, @jakarta.annotation.Nullable List<String> values) {

--- a/java/java-sdk/src/test/java/io/kestra/sdk/internal/BaseApiFilterParamsTest.java
+++ b/java/java-sdk/src/test/java/io/kestra/sdk/internal/BaseApiFilterParamsTest.java
@@ -1,0 +1,97 @@
+package io.kestra.sdk.internal;
+
+import io.kestra.sdk.api.FlowsApi;
+import io.kestra.sdk.model.QueryFilter;
+import io.kestra.sdk.model.QueryFilterField;
+import io.kestra.sdk.model.QueryFilterOp;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BaseApiFilterParamsTest {
+
+    private final FlowsApi api = new FlowsApi();
+
+    @Test
+    public void nullAndEmptyFiltersProduceNoParams() {
+        assertTrue(api.filterParams(null).isEmpty());
+        assertTrue(api.filterParams(List.of()).isEmpty());
+    }
+
+    @Test
+    public void namespaceFilterUsesPhpNestedStyle() {
+        List<Pair> params = api.filterParams(List.of(
+            new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value("system")
+        ));
+
+        assertEquals(1, params.size());
+        assertEquals("filters[namespace][EQUALS]", params.get(0).getName());
+        assertEquals("system", params.get(0).getValue());
+    }
+
+    @Test
+    public void screamingCaseFieldsBecomeCamelCase() {
+        List<Pair> params = api.filterParams(List.of(
+            new QueryFilter().field(QueryFilterField.FLOW_ID).operation(QueryFilterOp.CONTAINS).value("order")
+        ));
+
+        assertEquals("filters[flowId][CONTAINS]", params.get(0).getName());
+    }
+
+    @Test
+    public void queryFieldShortensToQ() {
+        List<Pair> params = api.filterParams(List.of(
+            new QueryFilter().field(QueryFilterField.QUERY).operation(QueryFilterOp.EQUALS).value("hello")
+        ));
+
+        assertEquals("filters[q][EQUALS]", params.get(0).getName());
+    }
+
+    @Test
+    public void mapValuesExpandWithNestedKey() {
+        List<Pair> params = api.filterParams(List.of(
+            new QueryFilter().field(QueryFilterField.LABELS).operation(QueryFilterOp.EQUALS).value(Map.of("team", "data"))
+        ));
+
+        assertEquals(1, params.size());
+        assertEquals("filters[labels][EQUALS][team]", params.get(0).getName());
+        assertEquals("data", params.get(0).getValue());
+    }
+
+    @Test
+    public void listValuesJoinAsCsvForInOperations() {
+        List<Pair> params = api.filterParams(List.of(
+            new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.IN).value(List.of("a", "b"))
+        ));
+
+        assertEquals("filters[namespace][IN]", params.get(0).getName());
+        // The comma is escaped on the wire; the server URL-decodes before splitting IN values on ",".
+        assertEquals("a%2Cb", params.get(0).getValue());
+    }
+
+    @Test
+    public void valuesAreEscapedOnce() {
+        List<Pair> params = api.filterParams(List.of(
+            new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value("a b")
+        ));
+
+        assertEquals("filters[namespace][EQUALS]", params.get(0).getName());
+        // Escaped exactly once at pair creation; invokeAPI does not escape values again.
+        assertTrue(params.get(0).getValue().equals("a+b") || params.get(0).getValue().equals("a%20b"));
+    }
+
+    @Test
+    public void noParamUsesTheDroppedCsvShape() {
+        List<Pair> params = api.filterParams(List.of(
+            new QueryFilter().field(QueryFilterField.NAMESPACE).operation(QueryFilterOp.EQUALS).value("system")
+        ));
+
+        for (Pair param : params) {
+            assertTrue("filter params must use the filters[...] nested shape", param.getName().startsWith("filters["));
+        }
+    }
+}


### PR DESCRIPTION
BaseApi.filterParams passed List<QueryFilter> through parameterToPairs("csv", "filters", ...), producing filters=<QueryFilter.toString()>. Kestra's QueryFilterFormatBinder only reads filters[<field>][<operation>] (and filters[<field>][<operation>][<key>] for map values) and silently skips any other shape, so every filtered endpoint in the Java SDK silently ran unfiltered - e.g. FlowsApi.exportFlowsByQuery returned all flows in the tenant regardless of the namespace filter. Downstream, plugin-git's SyncFlows (delete: true) would then treat flows in unrelated namespaces as deletion candidates.

This change serializes filters the way the server binds them, mirroring the Go SDK's ParseQueryFilters: SCREAMING_CASE fields to camelCase (FLOW_ID -> flowId), QUERY -> q, map values (labels) expanded with a nested key, values escaped exactly once at pair creation.

Tests: new BaseApiFilterParamsTest (8 cases) covering the nested shape, field-name mapping, q shortening, labels expansion, IN-list handling, escape-once, null/empty input, and a guard against the old csv shape. ./gradlew test green on JDK 25 (Temurin 25.0.4); the new test class fails to build/pass against unpatched BaseApi.

Follow-up: plugin-git's MockKestraApiServer should reject the non-bracketed "filters=" shape so SyncFlows integration tests catch any regression; happy to send that PR too if you want it (needs the kestra platform test harness to run).

Refs kestra-io/kestra#19181.

> Built by breken, your AI support engineer - breken.ai - this one's on us.